### PR TITLE
[Feat] 스크롤 깊이 문제 해결 및 모크 데이터 수정

### DIFF
--- a/backend/src/data/campaign.mock.ts
+++ b/backend/src/data/campaign.mock.ts
@@ -382,7 +382,7 @@ export const CAMPAIGNS_MOCK: Campaign[] = [
   },
   {
     id: 'ae08c7ab-586e-42d5-83a4-990ee736d11c',
-    user_id: 6,
+    user_id: 1,
     title: '[Frontend] 프리미엄 리액트 심화',
     content:
       '시니어 레벨로 도약하기 위한 리액트 심화 과정. 성능 최적화, 서버 사이드 렌더링(SSR), 상태 관리 패턴.',

--- a/backend/src/mock/erd-fixture.json
+++ b/backend/src/mock/erd-fixture.json
@@ -471,7 +471,7 @@
     },
     {
       "id": "ae08c7ab-586e-42d5-83a4-990ee736d11c",
-      "user_id": 6,
+      "user_id": 1,
       "title": "[Frontend] 프리미엄 리액트 심화",
       "content": "MVP 캠페인 프리미엄 리액트 심화 설명",
       "image": "https://cdn.example.com/campaigns/16.png",

--- a/sdk/src/features/BehaviorTracker.ts
+++ b/sdk/src/features/BehaviorTracker.ts
@@ -69,7 +69,10 @@ export class BehaviorTracker implements BehaviorTrackerInterface {
     const prevDepth = this.metrics.scrollDepth;
     const denominator = scrollHeight - clientHeight;
     const scrollPercent = denominator > 0 ? (scrollTop / denominator) * 100 : 0;
-    this.metrics.scrollDepth = Math.min(100, Math.max(0, scrollPercent));
+    const clampedScrollPercent = Math.min(100, Math.max(0, scrollPercent));
+
+    // 최대 스크롤 깊이만 기록 (위로 올려도 점수 유지)
+    this.metrics.scrollDepth = Math.max(this.metrics.scrollDepth, clampedScrollPercent);
 
     // 스크롤 임계값 통과 시 로그
     if (prevDepth < 50 && this.metrics.scrollDepth >= 50) {


### PR DESCRIPTION
## 🔗 관련 이슈

- close: #

---

## ✅ 작업 내용

- scrollDepth를 매번 업데이트하기 때문에 스크롤을 위로 올리면 점수가 낮아지기에 최대값만 유지하도록 수정

- 캠페인의 mockdata를 userId가 1인 부분에 대해서 데모때 주요하게 보여주기 때문에 변경
