### PR TITLE
[Fix] 빌드하는 도커 이미지 변경

### DIFF
--- a/backend/dockerfile
+++ b/backend/dockerfile
@@ -1,15 +1,15 @@
-FROM node:24-alpine AS deps
+FROM node:24-slim AS deps
 WORKDIR /app
 COPY backend/package*.json ./
 RUN npm ci
 
-FROM node:24-alpine AS build
+FROM node:24-slim AS build
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY backend ./
 RUN npm run build && npm prune --omit=dev
 
-FROM node:24-alpine AS runner
+FROM node:24-slim AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 COPY --from=build /app/node_modules ./node_modules


### PR DESCRIPTION
<!-- PR 제목 예시 : [Feat] 로그인 기능 구현 -->
<!-- PR 제목은 위 형식을 참고하여 작성해주세요. -->
<!-- 필요 없는 내용은 지우고 작성해주세요 -->

## 🔗 관련 이슈

- close: #58 

---

## ✅ 작업 내용

- musl을 사용하는 alpine 이미지를 glibc을 사용하는 slim 이미지로 변경


## 📸 스크린샷 / 데모 (옵션)

<!-- UI 변경사항이나 새로운 기능의 동작을 시각적으로 보여주세요. -->

비고

---

## 🧪 테스트 방법 (옵션)

<!-- 리뷰어가 기능을 테스트할 수 있도록 구체적인 테스트 방법을 설명해주세요. -->

비고

---

## 💬 To Reviewers

<!-- 리뷰어에게 전달하고 싶은 내용이나 특별히 확인이 필요한 부분을 작성해주세요. -->

- #58 
 
다음 이슈에 자세히 적어놨습니다. 여기에 요약정리를 하자면

 transformer에서 제공하는 머신러닝 모델을 돌리기 위해서는 `libonnxruntime.so.1.14.0`라이브러릴 사용해서 ONNX 포맷으로 변환시켜야되는데

현재 `libonnxruntime.so.1.14.0`는 glibc에서 제공하는 `ld-linux-x86-64.so.2`를 동적 링크해서 구동을 합니다.

그러나 alpine버전 이미지에서는 musl기반으로 동적 링커 라이브러인 `ld-linux-x86-64.so.2`을 제공하지 않아서 alpine이미지 보다는 크지만 기본 이미지보다는 크기가 작고 glibc을 사용하는 slim버전으로 이미지를 변경했습니다.
