### PR TITLE
[Feat] https 설정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: .
       dockerfile: nginx/Dockerfile
     ports:
-      - "80:80"
+      - '80:80'
     depends_on:
       - backend
     restart: unless-stopped
@@ -17,10 +17,10 @@ services:
       dockerfile: backend/dockerfile
       target: runner
     environment:
-      PORT: "3000"
+      PORT: '3000'
       # 배포 시 Object Storage(정적 호스팅) 도메인으로 교체
-      CORS_ORIGIN: ${CORS_ORIGIN:-http://localhost:5173}
-      NODE_ENV: "production"
+      CORS_ORIGIN: 'https://www.boostad.site,https://boostad.site,*'
+      NODE_ENV: 'production'
     expose:
-      - "3000"
+      - '3000'
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     environment:
       PORT: '3000'
       # 배포 시 Object Storage(정적 호스팅) 도메인으로 교체
-      CORS_ORIGIN: 'https://www.boostad.site,https://boostad.site,*'
+      CORS_ORIGIN: '${CORS_ORIGIN:-http://localhost:5173}'
       NODE_ENV: 'production'
     expose:
       - '3000'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     environment:
       PORT: '3000'
       # 배포 시 Object Storage(정적 호스팅) 도메인으로 교체
-      CORS_ORIGIN: '${CORS_ORIGIN:-http://localhost:5173}'
+      CORS_ORIGIN: ${CORS_ORIGIN:-http://localhost:5173}
       NODE_ENV: 'production'
     expose:
       - '3000'

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -10,7 +10,26 @@ map $http_upgrade $connection_upgrade {
 
 server {
   listen 80;
+  server_name api.boostad.site;
   server_tokens off;
+
+  # CloudFlare의 실제 클라이언트 IP 가져오기
+  set_real_ip_from 173.245.48.0/20;
+  set_real_ip_from 103.21.244.0/22;
+  set_real_ip_from 103.22.200.0/22;
+  set_real_ip_from 103.31.4.0/22;
+  set_real_ip_from 141.101.64.0/18;
+  set_real_ip_from 108.162.192.0/18;
+  set_real_ip_from 190.93.240.0/20;
+  set_real_ip_from 188.114.96.0/20;
+  set_real_ip_from 197.234.240.0/22;
+  set_real_ip_from 198.41.128.0/17;
+  set_real_ip_from 162.158.0.0/15;
+  set_real_ip_from 104.16.0.0/13;
+  set_real_ip_from 104.24.0.0/14;
+  set_real_ip_from 172.64.0.0/13;
+  set_real_ip_from 131.0.72.0/22;
+  real_ip_header CF-Connecting-IP;
 
   # 간단한 헬스체크 엔드포인트
   location = /healthz {
@@ -23,7 +42,7 @@ server {
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Proto https;
 
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $connection_upgrade;
@@ -45,7 +64,7 @@ server {
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Proto https;
 
     # WebSocket / SSE 대비
     proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
## ✅ 작업 내용

### 1) CloudFlare 도메인 및 DNS 설정

- 도메인 구매: `boostad.site` (가비아, 연 3,000원)
- CloudFlare 네임서버로 변경
- DNS 레코드 설정:
    - `www.boostad.site` → CloudFlare Workers (프론트)
    - `api.boostad.site` → NCP 서버 (백엔드, Proxy ON)

---

### 2) CloudFlare Workers 구현 (프론트엔드 HTTPS)

**구현 파일**:

- CloudFlare Workers 대시보드에서 직접 생성

**주요 기능**:

- Object Storage 요청 시 Host 헤더 변경
- `www.boostad.site` → `boostad-frontend-dev.s3-website.kr.object.ncloudstorage.com`

**Workers 코드**:

`export default {
  async fetch(request, env, ctx) {
    const url = new URL(request.url);
    url.hostname = "boostad-frontend-dev.s3-website.kr.object.ncloudstorage.com";
    url.protocol = "http:";
    url.port = "80";
    return fetch(url.toString(), request);
  }
};`

**Route 설정**: `www.boostad.site/*`, `boostad.site/*`

---

### 3) Nginx 설정 수정 (백엔드 HTTPS)

**구현 파일**:

- `nginx/default.conf`

**설명**:

- `server_name`: CloudFlare Proxy를 위한 도메인 명시
- `set_real_ip_from`: CloudFlare IP 범위에서 오는 요청의 실제 클라이언트 IP 추출
- `X-Forwarded-Proto https`: NestJS가 HTTPS로 인식하도록 설정

---

### 4) CORS 설정 수정

github repository variables에서 수정 가능.

### 5) 구조

```
사용자
  ↓
https://www.boostad.site
  ↓
CloudFlare (HTTPS)
  ↓
CloudFlare Workers (Host 헤더 변경)
  ↓
http://boostad-frontend-dev.s3-website.kr.object.ncloudstorage.com
  ↓
NCP Object Storage
```

## 📸 스크린샷 / 데모 (옵션)

<!-- UI 변경사항이나 새로운 기능의 동작을 시각적으로 보여주세요. -->

---

## 🧪 테스트 방법 (옵션)

<!-- 리뷰어가 기능을 테스트할 수 있도록 구체적인 테스트 방법을 설명해주세요. -->

1. [https://www.boostad.site](https://www.boostad.site) 접속
2.

---

## 💬 To Reviewers

<!-- 리뷰어에게 전달하고 싶은 내용이나 특별히 확인이 필요한 부분을 작성해주세요. -->
