### PR TITLE
[Feat] SDK 태그 추출 로직 개선

### DIFF
--- a/sdk/src/features/TagExtractor.ts
+++ b/sdk/src/features/TagExtractor.ts
@@ -47,33 +47,7 @@ export class TagExtractor implements TagExtractorInterface {
       if (text) tagTexts.add(text);
     });
 
-    // 방법 3: 일반적인 티스토리 태그 영역 셀렉터들 시도
-    const TAG_CONTAINER_SELECTORS = [
-      '.box-tag',         // 기본 스킨
-      '.article-tag',     // article 기반 스킨
-      '.tags',            // 구형 스킨
-      '.tag-list',        // 일부 커스텀 스킨
-      '.entry-tags',      // entry 기반 스킨
-      '[class*="tag"]',   // tag가 포함된 모든 클래스
-    ];
-
-    for (const selector of TAG_CONTAINER_SELECTORS) {
-      const containers = document.querySelectorAll(selector);
-      containers.forEach((container) => {
-        const links = container.querySelectorAll('a');
-        links.forEach((link) => {
-          const text = link.textContent?.trim();
-          if (text) tagTexts.add(text);
-        });
-      });
-    }
-
     const result = Array.from(tagTexts).join(' ');
-    if (result) {
-      console.log('[DevAd SDK] 티스토리 태그 추출 성공:', result);
-    } else {
-      console.log('[DevAd SDK] 티스토리 태그를 찾지 못했습니다.');
-    }
 
     return result;
   }

--- a/sdk/src/features/TagExtractor.ts
+++ b/sdk/src/features/TagExtractor.ts
@@ -47,6 +47,27 @@ export class TagExtractor implements TagExtractorInterface {
       if (text) tagTexts.add(text);
     });
 
+    // 방법 3: 일반적인 티스토리 태그 영역 셀렉터들 시도
+    const TAG_CONTAINER_SELECTORS = [
+      '.box-tag', // 기본 스킨
+      '.article-tag', // article 기반 스킨
+      '.tags', // 구형 스킨
+      '.tag-list', // 일부 커스텀 스킨
+      '.entry-tags', // entry 기반 스킨
+      '[class*="tag"]', // tag가 포함된 모든 클래스
+    ];
+
+    for (const selector of TAG_CONTAINER_SELECTORS) {
+      const containers = document.querySelectorAll(selector);
+      containers.forEach((container) => {
+        const links = container.querySelectorAll('a');
+        links.forEach((link) => {
+          const text = link.textContent?.trim();
+          if (text) tagTexts.add(text);
+        });
+      });
+    }
+
     const result = Array.from(tagTexts).join(' ');
 
     return result;

--- a/sdk/src/features/TagExtractor.ts
+++ b/sdk/src/features/TagExtractor.ts
@@ -31,8 +31,50 @@ export class TagExtractor implements TagExtractorInterface {
   }
 
   private extractTagsText(): string {
-    // 티스토리 .tags .items a 태그들에서 추출
-    const tagLinks = Array.from(document.querySelectorAll('.tags .items a'));
-    return tagLinks.map((el) => el.textContent || '').join(' ');
+    const tagTexts = new Set<string>();
+
+    // 방법 1: rel="tag" 속성을 가진 링크 찾기 (HTML5 표준, 가장 신뢰도 높음)
+    const relTagLinks = Array.from(document.querySelectorAll('a[rel="tag"]'));
+    relTagLinks.forEach((el) => {
+      const text = el.textContent?.trim();
+      if (text) tagTexts.add(text);
+    });
+
+    // 방법 2: /tag/ URL 패턴을 가진 링크 찾기 (티스토리 URL 구조)
+    const allLinks = Array.from(document.querySelectorAll('a[href*="/tag/"]'));
+    allLinks.forEach((el) => {
+      const text = el.textContent?.trim();
+      if (text) tagTexts.add(text);
+    });
+
+    // 방법 3: 일반적인 티스토리 태그 영역 셀렉터들 시도
+    const TAG_CONTAINER_SELECTORS = [
+      '.box-tag',         // 기본 스킨
+      '.article-tag',     // article 기반 스킨
+      '.tags',            // 구형 스킨
+      '.tag-list',        // 일부 커스텀 스킨
+      '.entry-tags',      // entry 기반 스킨
+      '[class*="tag"]',   // tag가 포함된 모든 클래스
+    ];
+
+    for (const selector of TAG_CONTAINER_SELECTORS) {
+      const containers = document.querySelectorAll(selector);
+      containers.forEach((container) => {
+        const links = container.querySelectorAll('a');
+        links.forEach((link) => {
+          const text = link.textContent?.trim();
+          if (text) tagTexts.add(text);
+        });
+      });
+    }
+
+    const result = Array.from(tagTexts).join(' ');
+    if (result) {
+      console.log('[DevAd SDK] 티스토리 태그 추출 성공:', result);
+    } else {
+      console.log('[DevAd SDK] 티스토리 태그를 찾지 못했습니다.');
+    }
+
+    return result;
   }
 }

--- a/sdk/test/test-blog.html
+++ b/sdk/test/test-blog.html
@@ -118,21 +118,14 @@
         </p>
 
         <!-- 티스토리 스타일 태그 영역 -->
-        <div class="tags">
-          <h2>태그</h2>
-          <div class="items">
-            <a href="/tag/React" rel="tag">React</a>
-            <a href="/tag/TypeScript" rel="tag">TypeScript</a>
-          </div>
-        </div>
       </div>
     </div>
 
     <!-- DevAd SDK 로드 -->
     <!-- 로컬: http://localhost:3000/sdk.js -->
-    <!-- 배포: https://boostad-sdk.kr.object.ncloudstorage.com/sdk/sdk.js -->
+    <!-- 배포: https://kr.object.ncloudstorage.com/boostad-sdk-dev/sdk/sdk.js -->
     <script
-      src="http://localhost:3000/sdk.js"
+      src="https://kr.object.ncloudstorage.com/boostad-sdk-dev/sdk/sdk.js"
       data-blog-key="test-blog"
       async
     ></script>

--- a/sdk/test/test-blog.html
+++ b/sdk/test/test-blog.html
@@ -78,6 +78,41 @@
       .tags .items a:hover {
         background: #d0d0d0;
       }
+      /* 티스토리 스타일 태그 영역 */
+      .article-footer {
+        margin-top: 40px;
+        padding-top: 20px;
+        border-top: 1px solid #e0e0e0;
+      }
+      .article-tag {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+      .article-tag h3 {
+        font-size: 14px;
+        color: #999;
+        margin: 0;
+      }
+      .box-tag {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+      .box-tag a {
+        display: inline-block;
+        padding: 6px 12px;
+        background: #f5f5f5;
+        color: #666;
+        text-decoration: none;
+        border-radius: 4px;
+        font-size: 13px;
+        transition: all 0.2s;
+      }
+      .box-tag a:hover {
+        background: #667eea;
+        color: white;
+      }
     </style>
   </head>
   <body>
@@ -116,8 +151,18 @@
           NestJS와 TypeScript를 함께 사용하면 엔터프라이즈급 백엔드
           애플리케이션을 효율적으로 개발할 수 있습니다.
         </p>
+      </div>
 
-        <!-- 티스토리 스타일 태그 영역 -->
+      <!-- 티스토리 스타일 태그 영역 (article-footer > article-tag > box-tag) -->
+      <div class="article-footer">
+        <!-- article-tag -->
+        <div class="article-tag">
+          <h3 class="title-footer">Tag</h3>
+          <div class="box-tag">
+            <a href="/tag/typescript" rel="tag">TypeScript</a>
+            <a href="/tag/react" rel="tag">React</a>
+          </div>
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION
## 🔗 관련 이슈

- close: #86 

## ✅ 작업 내용

### 1) 태그 추출 로직 개선

구현 파일:

- `sdk/src/features/TagExtractor.ts` - `extractTagsText()` 메서드

변경 배경:

- 기존: .tag 클래스 다음 값만 반영
- 문제점: 다양한 티스토리 포스트 스킨이 존재하기에 범용적인 환경에서태그를 정확하게 추출하지 못함.
- 해결: 여러 단계를 두어 매칭 정확도 향상.

추출 전략 (3단계 폴백):

1단계 - HTML5 표준 방식:

- `a[rel="tag"]` 셀렉터 사용 (가장 신뢰도 높음)
- HTML5 표준을 따르는 블로그 플랫폼 대응

2단계 - 티스토리 URL 패턴:

- `a[href*="/tag/"]` 셀렉터 사용
- 티스토리의 `/tag/태그명` URL 구조 활용

3단계 - 태그 컨테이너 탐색:

- `.box-tag`, `.article-tag`, `.tags`, `.tag-list`, `.entry-tags`, `[class*="tag"]` 순차 탐색
- 다양한 티스토리 스킨 호환성 확보
- 컨테이너 내부 모든 링크에서 텍스트 추출

중복 제거:

- `Set` 자료구조 사용으로 동일 태그 중복 방지
- 대소문자 구분 없이 추출 (trim 처리)

## 🧪 테스트 방법

### 1. 변경된 `sdk/test/test-blog.html` 에서도 확인 가능.

하지만 배포 이후에 실제 tistory에서도 잘 동작하나 확인하는 것이 중요할 것 같음.