### PR TITLE
[Feat] CORS 전체 허용에 따른 내부 검증 로직 구현

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,6 +13,7 @@
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.0.1",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/throttler": "^6.5.0",
         "@xenova/transformers": "^2.17.2",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.3",
@@ -2368,6 +2369,17 @@
         "@nestjs/platform-express": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/throttler": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/throttler/-/throttler-6.5.0.tgz",
+      "integrity": "sha512-9j0ZRfH0QE1qyrj9JjIRDz5gQLPqq9yVC2nHsrosDVAfI5HHw08/aUAWx9DZLSdQf4HDkmhTTEGLrRFHENvchQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "reflect-metadata": "^0.1.13 || ^0.2.0"
       }
     },
     "node_modules/@noble/hashes": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -24,6 +24,7 @@
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/throttler": "^6.5.0",
     "@xenova/transformers": "^2.17.2",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.3",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,5 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
+import { APP_GUARD } from '@nestjs/core';
 import { RTBModule } from './rtb/rtb.module';
 import { BidLogModule } from './bid-log/bid-log.module';
 import { SdkModule } from './sdk/sdk.module';
@@ -12,6 +14,12 @@ import { UserModule } from './user/user.module';
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
+    ThrottlerModule.forRoot([
+      {
+        ttl: 60000, // 60초
+        limit: 100, // IP당 100회
+      },
+    ]),
     RTBModule,
     BidLogModule,
     SdkModule,
@@ -22,6 +30,11 @@ import { UserModule } from './user/user.module';
     UserModule,
   ],
   controllers: [],
-  providers: [],
+  providers: [
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerGuard,
+    },
+  ],
 })
 export class AppModule {}

--- a/backend/src/common/guards/blog-key-validation.guard.ts
+++ b/backend/src/common/guards/blog-key-validation.guard.ts
@@ -1,0 +1,49 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  BadRequestException,
+  Logger,
+} from '@nestjs/common';
+import { getBlogByKey } from '../utils/blog.utils';
+
+@Injectable()
+export class BlogKeyValidationGuard implements CanActivate {
+  private readonly logger = new Logger(BlogKeyValidationGuard.name);
+
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const { blogKey } = request.body;
+
+    // blogKey 누락 체크
+    if (!blogKey) {
+      this.logger.warn('blogKey 누락된 요청 시도', {
+        ip: request.ip,
+        url: request.url,
+      });
+      throw new BadRequestException('blogKey가 필요합니다.');
+    }
+
+    // blogKey 검증
+    const blog = getBlogByKey(blogKey);
+
+    if (!blog) {
+      this.logger.warn('미등록 blogKey 요청 차단', {
+        blogKey,
+        ip: request.ip,
+        url: request.url,
+        timestamp: new Date().toISOString(),
+      });
+      throw new ForbiddenException(
+        '등록되지 않은 blogKey입니다. 관리자에게 문의하세요.'
+      );
+    }
+
+    // 요청 객체에 blog 정보 첨부 (후속 로직에서 사용 가능)
+    request.blog = blog;
+
+    this.logger.log(`blogKey 검증 성공: ${blogKey} (${blog.name})`);
+    return true;
+  }
+}

--- a/backend/src/common/guards/blog-key-validation.guard.ts
+++ b/backend/src/common/guards/blog-key-validation.guard.ts
@@ -6,15 +6,21 @@ import {
   BadRequestException,
   Logger,
 } from '@nestjs/common';
+import { Request } from 'express';
 import { getBlogByKey } from '../utils/blog.utils';
+import type { MockBlog } from '../constants';
+
+interface RequestWithBlog extends Request {
+  blog?: MockBlog;
+}
 
 @Injectable()
 export class BlogKeyValidationGuard implements CanActivate {
   private readonly logger = new Logger(BlogKeyValidationGuard.name);
 
   canActivate(context: ExecutionContext): boolean {
-    const request = context.switchToHttp().getRequest();
-    const { blogKey } = request.body;
+    const request = context.switchToHttp().getRequest<RequestWithBlog>();
+    const { blogKey } = request.body as { blogKey?: string };
 
     // blogKey 누락 체크
     if (!blogKey) {

--- a/backend/src/rtb/rtb.controller.ts
+++ b/backend/src/rtb/rtb.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body } from '@nestjs/common';
+import { Controller, Post, Body, UseGuards } from '@nestjs/common';
 import { RTBService } from './rtb.service';
 import { plainToInstance } from 'class-transformer';
 
@@ -7,8 +7,10 @@ import { RTBResponseDto } from './dto/rtb-response.dto';
 import type { DecisionContext } from './types/decision.types';
 
 import { Logger } from '@nestjs/common';
+import { BlogKeyValidationGuard } from '../common/guards/blog-key-validation.guard';
 
 @Controller('sdk')
+@UseGuards(BlogKeyValidationGuard)
 export class RTBController {
   private readonly logger = new Logger(RTBController.name);
 

--- a/backend/src/rtb/rtb.service.ts
+++ b/backend/src/rtb/rtb.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { Matcher } from './matchers/matcher.interface';
 import { Scorer } from './scorers/scorer.interface';
 import { CampaignSelector } from './selectors/selector.interface';
@@ -29,13 +29,8 @@ export class RTBService {
     try {
       const auctionId = randomUUID();
 
-      // 0. blogKey → blogId 변환
-      const blogId = getBlogIdByKey(context.blogKey);
-      if (blogId === null) {
-        throw new NotFoundException(
-          `블로그 키 '${context.blogKey}'에 해당하는 블로그를 찾을 수 없습니다.`
-        );
-      }
+      // 0. blogKey → blogId 변환 (Guard에서 이미 검증됨)
+      const blogId = getBlogIdByKey(context.blogKey)!;
 
       // 1. 후보 필터링
       let candidates: Candidate[] =


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 이슈 번호가 있다면 여기에 작성 -->
- close: #83 

---

## ✅ 작업 내용

### 1) blogKey 검증 Guard 구현

구현 파일:
- `backend/src/common/guards/blog-key-validation.guard.ts` (신규)
- `backend/src/rtb/rtb.controller.ts`
- `backend/src/rtb/rtb.service.ts`

`Before: SDK 요청 → Controller → Service (검증) → 비즈니스 로직
After:  SDK 요청 → Guard (검증) → Controller → Service → 비즈니스 로직`

**보안 응답 코드**:

- `400 Bad Request`: blogKey 누락
- `403 Forbidden`: 미등록 blogKey

-> CORS를 *로 설정하기에 외부 블로그에서 http 통신을 할때 검사 로직이 필요한데 이를 service에서 진행하는 것은 적합하지 않다고 판단하여 blogKey 검증 로직을 Guard 패턴으로 빼 컨트롤러 전에 검사하도록함!

---

### 2) Rate Limiting 구현

구현 파일:

- `backend/src/app.module.ts`
- `backend/package.json`

변경 배경:

- 기존: Rate Limiting 없음
- 문제점:
    - 악의적 사용자가 무제한 API 호출 가능
    - DDoS, 무차별 대입 공격 취약
    - 서버 리소스 고갈 위험
- 해결: NestJS 공식 Throttler 모듈 도입

구현 내용:

**ThrottlerModule 설정**:

`ThrottlerModule.forRoot([
  {
    ttl: 60000,  // Time To Live: 60초
    limit: 100,  // 제한: IP당 100회
  },
])`

**전역 Guard 적용**:

`providers: [
  {
    provide: APP_GUARD,
    useClass: ThrottlerGuard,  // 모든 엔드포인트에 자동 적용
  },
]`

**제한 정책**:

- 동일 IP에서 60초 동안 100회 이상 요청 시 차단
- `429 Too Many Requests` 응답 반환

---

### 3) Service 레이어 리팩토링

구현 파일:

- `backend/src/rtb/rtb.service.ts` 

중복 검증 제거를 통해 Service-> 비즈니스 로직. Guard -> 인증/인가 담당으로 설계

---

## 🧪 테스트 방법

### 1. 