### PR TITLE
[Feat] 코드 블록 복사 감지 구현

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,6 +13,7 @@
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.0.1",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/throttler": "^6.5.0",
         "@xenova/transformers": "^2.17.2",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.3",
@@ -2368,6 +2369,17 @@
         "@nestjs/platform-express": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/throttler": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/throttler/-/throttler-6.5.0.tgz",
+      "integrity": "sha512-9j0ZRfH0QE1qyrj9JjIRDz5gQLPqq9yVC2nHsrosDVAfI5HHw08/aUAWx9DZLSdQf4HDkmhTTEGLrRFHENvchQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "reflect-metadata": "^0.1.13 || ^0.2.0"
       }
     },
     "node_modules/@noble/hashes": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -24,6 +24,7 @@
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/throttler": "^6.5.0",
     "@xenova/transformers": "^2.17.2",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.3",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,5 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
+import { APP_GUARD } from '@nestjs/core';
 import { RTBModule } from './rtb/rtb.module';
 import { BidLogModule } from './bid-log/bid-log.module';
 import { SdkModule } from './sdk/sdk.module';
@@ -12,6 +14,12 @@ import { UserModule } from './user/user.module';
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
+    ThrottlerModule.forRoot([
+      {
+        ttl: 60000, // 60초
+        limit: 100, // IP당 100회
+      },
+    ]),
     RTBModule,
     BidLogModule,
     SdkModule,
@@ -22,6 +30,11 @@ import { UserModule } from './user/user.module';
     UserModule,
   ],
   controllers: [],
-  providers: [],
+  providers: [
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerGuard,
+    },
+  ],
 })
 export class AppModule {}

--- a/backend/src/common/guards/blog-key-validation.guard.ts
+++ b/backend/src/common/guards/blog-key-validation.guard.ts
@@ -1,0 +1,49 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  BadRequestException,
+  Logger,
+} from '@nestjs/common';
+import { getBlogByKey } from '../utils/blog.utils';
+
+@Injectable()
+export class BlogKeyValidationGuard implements CanActivate {
+  private readonly logger = new Logger(BlogKeyValidationGuard.name);
+
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const { blogKey } = request.body;
+
+    // blogKey 누락 체크
+    if (!blogKey) {
+      this.logger.warn('blogKey 누락된 요청 시도', {
+        ip: request.ip,
+        url: request.url,
+      });
+      throw new BadRequestException('blogKey가 필요합니다.');
+    }
+
+    // blogKey 검증
+    const blog = getBlogByKey(blogKey);
+
+    if (!blog) {
+      this.logger.warn('미등록 blogKey 요청 차단', {
+        blogKey,
+        ip: request.ip,
+        url: request.url,
+        timestamp: new Date().toISOString(),
+      });
+      throw new ForbiddenException(
+        '등록되지 않은 blogKey입니다. 관리자에게 문의하세요.'
+      );
+    }
+
+    // 요청 객체에 blog 정보 첨부 (후속 로직에서 사용 가능)
+    request.blog = blog;
+
+    this.logger.log(`blogKey 검증 성공: ${blogKey} (${blog.name})`);
+    return true;
+  }
+}

--- a/backend/src/common/guards/blog-key-validation.guard.ts
+++ b/backend/src/common/guards/blog-key-validation.guard.ts
@@ -6,15 +6,21 @@ import {
   BadRequestException,
   Logger,
 } from '@nestjs/common';
+import { Request } from 'express';
 import { getBlogByKey } from '../utils/blog.utils';
+import type { MockBlog } from '../constants';
+
+interface RequestWithBlog extends Request {
+  blog?: MockBlog;
+}
 
 @Injectable()
 export class BlogKeyValidationGuard implements CanActivate {
   private readonly logger = new Logger(BlogKeyValidationGuard.name);
 
   canActivate(context: ExecutionContext): boolean {
-    const request = context.switchToHttp().getRequest();
-    const { blogKey } = request.body;
+    const request = context.switchToHttp().getRequest<RequestWithBlog>();
+    const { blogKey } = request.body as { blogKey?: string };
 
     // blogKey 누락 체크
     if (!blogKey) {

--- a/backend/src/rtb/rtb.controller.ts
+++ b/backend/src/rtb/rtb.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body } from '@nestjs/common';
+import { Controller, Post, Body, UseGuards } from '@nestjs/common';
 import { RTBService } from './rtb.service';
 import { plainToInstance } from 'class-transformer';
 
@@ -7,8 +7,10 @@ import { RTBResponseDto } from './dto/rtb-response.dto';
 import type { DecisionContext } from './types/decision.types';
 
 import { Logger } from '@nestjs/common';
+import { BlogKeyValidationGuard } from '../common/guards/blog-key-validation.guard';
 
 @Controller('sdk')
+@UseGuards(BlogKeyValidationGuard)
 export class RTBController {
   private readonly logger = new Logger(RTBController.name);
 

--- a/backend/src/rtb/rtb.service.ts
+++ b/backend/src/rtb/rtb.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { Matcher } from './matchers/matcher.interface';
 import { Scorer } from './scorers/scorer.interface';
 import { CampaignSelector } from './selectors/selector.interface';
@@ -29,13 +29,8 @@ export class RTBService {
     try {
       const auctionId = randomUUID();
 
-      // 0. blogKey → blogId 변환
-      const blogId = getBlogIdByKey(context.blogKey);
-      if (blogId === null) {
-        throw new NotFoundException(
-          `블로그 키 '${context.blogKey}'에 해당하는 블로그를 찾을 수 없습니다.`
-        );
-      }
+      // 0. blogKey → blogId 변환 (Guard에서 이미 검증됨)
+      const blogId = getBlogIdByKey(context.blogKey)!;
 
       // 1. 후보 필터링
       let candidates: Candidate[] =

--- a/sdk/src/features/BannerAdRenderer.ts
+++ b/sdk/src/features/BannerAdRenderer.ts
@@ -31,7 +31,7 @@ export class BannerAdRenderer implements AdRenderer {
       // 광고 URL 저장 (클릭 시 사용)
       this.currentAdUrl = campaign.url;
 
-      const link = container.querySelector('.devad-link');
+      const link = container.querySelector('.boostad-link');
       link?.addEventListener('click', (e) => {
         e.preventDefault();
         this.handleAdClick();
@@ -74,19 +74,19 @@ export class BannerAdRenderer implements AdRenderer {
       if (response.ok) {
         const data: ViewLogResponse = await response.json();
         this.currentViewId = data.data.viewId;
-        console.log('[DevAd SDK] ViewLog 기록 성공:', data.data.viewId);
+        console.log('[BoostAD SDK] ViewLog 기록 성공:', data.data.viewId);
       } else {
-        console.warn('[DevAd SDK] ViewLog 기록 실패:', response.status);
+        console.warn('[BoostAD SDK] ViewLog 기록 실패:', response.status);
       }
     } catch (error) {
-      console.error('[DevAd SDK] ViewLog API 호출 실패:', error);
+      console.error('[BoostAD SDK] ViewLog API 호출 실패:', error);
     }
   }
 
   private async handleAdClick(): Promise<void> {
     if (this.currentViewId === null) {
       console.warn(
-        '[DevAd SDK] ViewLog가 아직 기록되지 않았습니다. ClickLog를 기록하지 않습니다.'
+        '[BoostAD SDK] ViewLog가 아직 기록되지 않았습니다. ClickLog를 기록하지 않습니다.'
       );
       return;
     }
@@ -107,9 +107,9 @@ export class BannerAdRenderer implements AdRenderer {
 
       if (response.ok) {
         const data: ClickLogResponse = await response.json();
-        console.log('[DevAd SDK] ClickLog 기록 성공:', data.data.clickId);
+        console.log('[BoostAD SDK] ClickLog 기록 성공:', data.data.clickId);
       } else {
-        console.warn('[DevAd SDK] ClickLog 기록 실패:', response.status);
+        console.warn('[BoostAD SDK] ClickLog 기록 실패:', response.status);
       }
 
       // 클릭 로그 성공/실패 여부와 관계없이 광고 페이지 열기
@@ -117,7 +117,7 @@ export class BannerAdRenderer implements AdRenderer {
         window.open(this.currentAdUrl, '_blank');
       }
     } catch (error) {
-      console.error('[DevAd SDK] ClickLog API 호출 실패:', error);
+      console.error('[BoostAD SDK] ClickLog API 호출 실패:', error);
       // API 실패 시에도 광고 페이지는 열기
       if (this.currentAdUrl) {
         window.open(this.currentAdUrl, '_blank');
@@ -156,7 +156,7 @@ export class BannerAdRenderer implements AdRenderer {
     const safeImage = this.escapeHtml(campaign.image);
 
     return `
-      <div class="devad-widget" style="
+      <div class="boostad-widget" style="
         border: 1px solid #e0e0e0;
         border-radius: 12px;
         padding: 20px;
@@ -213,7 +213,7 @@ export class BannerAdRenderer implements AdRenderer {
               padding-top: 16px;
               gap: 12px;
             ">
-              <a href="${safeUrl}" class="devad-link" target="_blank" rel="noopener noreferrer" style="
+              <a href="${safeUrl}" class="boostad-link" target="_blank" rel="noopener noreferrer" style="
                 display: inline-block;
                 padding: 12px 24px;
                 background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);

--- a/sdk/src/features/BannerAdRenderer.ts
+++ b/sdk/src/features/BannerAdRenderer.ts
@@ -198,13 +198,21 @@ export class BannerAdRenderer implements AdRenderer {
             ">${safeTitle}</h3>
 
             <p style="
-              margin: 0 0 16px;
+              margin: 0 0 24px;
               color: #666;
               font-size: 15px;
               line-height: 1.6;
+              flex-grow: 1;
             ">${safeContent}</p>
 
-            <div style="display: flex; justify-content: space-between; align-items: center; margin-top: auto;">
+            <div style="
+              display: flex;
+              justify-content: space-between;
+              align-items: center;
+              margin-top: auto;
+              padding-top: 16px;
+              gap: 12px;
+            ">
               <a href="${safeUrl}" class="devad-link" target="_blank" rel="noopener noreferrer" style="
                 display: inline-block;
                 padding: 12px 24px;
@@ -216,11 +224,12 @@ export class BannerAdRenderer implements AdRenderer {
                 font-weight: 600;
                 transition: opacity 0.2s;
                 cursor: pointer;
+                white-space: nowrap;
               " onmouseover="this.style.opacity='0.9';" onmouseout="this.style.opacity='1';">
                 자세히 보기 →
               </a>
 
-              <span style="font-size: 11px; color: #aaa;">
+              <span style="font-size: 11px; color: #aaa; white-space: nowrap;">
                 by <strong>BoostAD</strong>
               </span>
             </div>

--- a/sdk/src/features/BehaviorTracker.ts
+++ b/sdk/src/features/BehaviorTracker.ts
@@ -6,6 +6,7 @@ export class BehaviorTracker implements BehaviorTrackerInterface {
     scrollDepth: 0,
     timeOnPage: 0,
     copyEvents: 0,
+    codeBlockCopies: 0,
     score: 0,
   };
 

--- a/sdk/src/features/BehaviorTracker.ts
+++ b/sdk/src/features/BehaviorTracker.ts
@@ -89,10 +89,21 @@ export class BehaviorTracker implements BehaviorTrackerInterface {
   };
 
   private handleCopy = (): void => {
-    this.metrics.copyEvents++;
-    console.log(
-      `[DevAd SDK] 복사 이벤트 감지 (${this.metrics.copyEvents}회) → +${this.metrics.copyEvents * 5}점`
-    );
+    const selection = window.getSelection();
+    const isCodeBlock = this.isSelectionInCodeBlock(selection);
+
+    if (isCodeBlock) {
+      this.metrics.codeBlockCopies++;
+      console.log(
+        `[DevAd SDK] 코드 블록 복사 감지 (${this.metrics.codeBlockCopies}회) → +${this.metrics.codeBlockCopies * 15}점`
+      );
+    } else {
+      this.metrics.copyEvents++;
+      console.log(
+        `[DevAd SDK] 일반 복사 이벤트 감지 (${this.metrics.copyEvents}회) → +${this.metrics.copyEvents * 5}점`
+      );
+    }
+
     this.checkThreshold();
   };
 

--- a/sdk/src/features/BehaviorTracker.ts
+++ b/sdk/src/features/BehaviorTracker.ts
@@ -32,7 +32,7 @@ export class BehaviorTracker implements BehaviorTrackerInterface {
       this.checkThreshold();
     }, 1000);
 
-    console.log('[DevAd SDK] 행동 추적 시작');
+    console.log('[BoostAD SDK] 행동 추적 시작');
   }
 
   stop(): void {
@@ -46,7 +46,7 @@ export class BehaviorTracker implements BehaviorTrackerInterface {
       this.timerInterval = null;
     }
 
-    console.log('[DevAd SDK] 행동 추적 중지');
+    console.log('[BoostAD SDK] 행동 추적 중지');
   }
 
   getCurrentScore(): number {
@@ -80,9 +80,9 @@ export class BehaviorTracker implements BehaviorTrackerInterface {
 
     // 스크롤 임계값 통과 시 로그
     if (prevDepth < 50 && this.metrics.scrollDepth >= 50) {
-      console.log('[DevAd SDK] 스크롤 50% 달성 → +20점');
+      console.log('[BoostAD SDK] 스크롤 50% 달성 → +20점');
     } else if (prevDepth < 80 && this.metrics.scrollDepth >= 80) {
-      console.log('[DevAd SDK] 스크롤 80% 달성 → +30점 (총합)');
+      console.log('[BoostAD SDK] 스크롤 80% 달성 → +30점 (총합)');
     }
 
     this.checkThreshold();
@@ -95,12 +95,12 @@ export class BehaviorTracker implements BehaviorTrackerInterface {
     if (isCodeBlock) {
       this.metrics.codeBlockCopies++;
       console.log(
-        `[DevAd SDK] 코드 블록 복사 감지 (${this.metrics.codeBlockCopies}회) → +${this.metrics.codeBlockCopies * 15}점`
+        `[BoostAD SDK] 코드 블록 복사 감지 (${this.metrics.codeBlockCopies}회) → +${this.metrics.codeBlockCopies * 15}점`
       );
     } else {
       this.metrics.copyEvents++;
       console.log(
-        `[DevAd SDK] 일반 복사 이벤트 감지 (${this.metrics.copyEvents}회) → +${this.metrics.copyEvents * 5}점`
+        `[BoostAD SDK] 일반 복사 이벤트 감지 (${this.metrics.copyEvents}회) → +${this.metrics.copyEvents * 5}점`
       );
     }
 
@@ -172,7 +172,7 @@ export class BehaviorTracker implements BehaviorTrackerInterface {
     if (!this.thresholdReached && this.metrics.score >= 70) {
       this.thresholdReached = true;
       console.log(
-        '[DevAd SDK] 70점 도달! 5초 후 2차 광고 요청... (현재:',
+        '[BoostAD SDK] 70점 도달! 5초 후 2차 광고 요청... (현재:',
         this.metrics.score,
         '점)'
       );
@@ -180,7 +180,7 @@ export class BehaviorTracker implements BehaviorTrackerInterface {
       // 5초 후 콜백 실행 (전부 70점으로만 몰리지 않도록 하기 위해서)
       setTimeout(() => {
         console.log(
-          '[DevAd SDK] 2차 광고 요청 실행 (최종 점수:',
+          '[BoostAD SDK] 2차 광고 요청 실행 (최종 점수:',
           this.metrics.score,
           '점)'
         );

--- a/sdk/src/features/BoostAdSDK.ts
+++ b/sdk/src/features/BoostAdSDK.ts
@@ -6,8 +6,8 @@ import type {
   Tag,
 } from '@/shared/types';
 
-// DevAd SDK 메인 클래스 (전략 패턴)
-export class DevAdSDK {
+// BoostAD SDK 메인 클래스 (전략 패턴)
+export class BoostAdSDK {
   private hasRequestedSecondAd = false;
   private readonly CONTENT_SELECTORS = [
     '.article-view',
@@ -29,12 +29,12 @@ export class DevAdSDK {
 
   async init(): Promise<void> {
     const tags = this.tagExtractor.extract();
-    console.log('[DevAd SDK] 추출된 태그:', tags);
+    console.log('[BoostAD SDK] 추출된 태그:', tags);
 
     const postUrl = window.location.href;
 
     // 1차 광고: 본문 상단에 삽입
-    const firstAdContainer = this.createAdContainer('devad-first-ad');
+    const firstAdContainer = this.createAdContainer('boostad-first-ad');
     const insertionPoint = this.findContentTop();
 
     if (insertionPoint) {
@@ -142,20 +142,20 @@ export class DevAdSDK {
     const isHighIntent = this.behaviorTracker.isHighIntent();
 
     console.log(
-      '[DevAd SDK] 2차 광고 요청 - Score:',
+      '[BoostAD SDK] 2차 광고 요청 - Score:',
       score,
       'HighIntent:',
       isHighIntent
     );
 
     // 1차 광고 제거
-    const firstAdContainer = document.getElementById('devad-first-ad');
+    const firstAdContainer = document.getElementById('boostad-first-ad');
     if (firstAdContainer) {
       firstAdContainer.remove();
     }
 
     // 2차 광고 컨테이너 생성 및 현재 스크롤 위치에 삽입
-    const secondAdContainer = this.createAdContainer('devad-second-ad');
+    const secondAdContainer = this.createAdContainer('boostad-second-ad');
     const insertionPoint = this.findScrollBasedInsertionPoint();
 
     if (insertionPoint) {

--- a/sdk/src/features/DecisionAPIClient.ts
+++ b/sdk/src/features/DecisionAPIClient.ts
@@ -39,7 +39,7 @@ export class DecisionAPIClient implements APIClient {
 
       return await response.json();
     } catch (error) {
-      console.error('[DevAd SDK] API 호출 실패:', error);
+      console.error('[BoostAD SDK] API 호출 실패:', error);
       // API 실패 시 빈 응답 반환 (광고 없음 상태)
       return {
         status: 'error',

--- a/sdk/src/features/TagExtractor.ts
+++ b/sdk/src/features/TagExtractor.ts
@@ -18,7 +18,7 @@ export class TagExtractor implements TagExtractorInterface {
       allText.includes(tag.name.toLowerCase())
     );
 
-    console.log('[DevAd SDK] 추출된 태그:', extractedTags);
+    console.log('[BoostAD SDK] 추출된 태그:', extractedTags);
 
     return extractedTags;
   }

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -5,7 +5,7 @@ import { TagExtractor } from './features/TagExtractor';
 import { DecisionAPIClient } from './features/DecisionAPIClient';
 import { BannerAdRenderer } from './features/BannerAdRenderer';
 import { BehaviorTracker } from './features/BehaviorTracker';
-import { DevAdSDK } from './features/DevAdSDK';
+import { BoostAdSDK } from './features/BoostAdSDK';
 
 (function () {
   'use strict';
@@ -15,7 +15,7 @@ import { DevAdSDK } from './features/DevAdSDK';
   const apiClient = new DecisionAPIClient(config);
   const adRenderer = new BannerAdRenderer(config);
   const behaviorTracker = new BehaviorTracker();
-  const sdk = new DevAdSDK(
+  const sdk = new BoostAdSDK(
     tagExtractor,
     apiClient,
     adRenderer,

--- a/sdk/test/test-blog.html
+++ b/sdk/test/test-blog.html
@@ -113,6 +113,43 @@
         background: #667eea;
         color: white;
       }
+      /* 티스토리 코드 블록 스타일 */
+      pre[id^='code_'] {
+        background: #282c34;
+        border-radius: 8px;
+        padding: 20px;
+        margin: 20px 0;
+        overflow-x: auto;
+        font-family: 'Courier New', monospace;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      pre[id^='code_'] code.hljs {
+        background: transparent;
+        color: #abb2bf;
+        display: block;
+        padding: 0;
+      }
+      .hljs-keyword {
+        color: #c678dd;
+        font-weight: bold;
+      }
+      .hljs-string {
+        color: #98c379;
+      }
+      .hljs-function {
+        color: #61afef;
+      }
+      .hljs-comment {
+        color: #5c6370;
+        font-style: italic;
+      }
+      .hljs-number {
+        color: #d19a66;
+      }
+      .hljs-title {
+        color: #e5c07b;
+      }
     </style>
   </head>
   <body>
@@ -170,6 +207,34 @@
           <code>@Post()</code> 등의 데코레이터를 통해 라우팅을 명시적으로 정의할
           수 있어, 코드만 보고도 API 구조를 쉽게 파악할 수 있습니다.
         </p>
+
+        <p>간단한 컨트롤러 예제를 살펴보겠습니다:</p>
+
+        <!-- 티스토리 스타일 코드 블록 #1 (Kotlin 예제) -->
+        <pre
+          id="code_1687849651218"
+          class="kotlin"
+          data-ke-language="kotlin"
+          data-ke-type="codeblock"
+        ><code class="hljs"><span class="hljs-keyword">fun</span> <span class="hljs-function">main</span>() {
+    <span class="hljs-keyword">val</span> message = <span class="hljs-string">"Hello, Kotlin!"</span>
+    println(message)
+
+    <span class="hljs-comment">// 코드블럭 사용</span>
+    <span class="hljs-keyword">val</span> numbers = listOf(<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>)
+}</code></pre>
+
+        <!-- 티스토리 스타일 코드 블록 #2 (HTML 예제) -->
+        <pre
+          id="code_1697901963751"
+          class="html"
+          style="background-color: #1f1f1f; color: #353638; text-align: left"
+          data-ke-type="codeblock"
+          data-ke-language="html"
+        ><code class="hljs">&lt;<span class="hljs-keyword">div</span>&gt;
+    &lt;<span class="hljs-keyword">h1</span>&gt;<span class="hljs-string">Title</span>&lt;/<span class="hljs-keyword">h1</span>&gt;
+    &lt;<span class="hljs-keyword">p</span>&gt;<span class="hljs-string">Content</span>&lt;/<span class="hljs-keyword">p</span>&gt;
+&lt;/<span class="hljs-keyword">div</span>&gt;</code></pre>
 
         <h2>미들웨어와 가드</h2>
         <p>
@@ -246,7 +311,6 @@
       data-blog-key="test-blog"
       async
     ></script>
-
     <!-- SDK는 자동으로 초기화되므로 별도 체크 불필요 -->
   </body>
 </html>


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 이슈 번호가 있다면 여기에 작성 -->
- close: #85 

---

## ✅ 작업 내용

### 1) 코드 블록 복사 감지 기능 구현

구현 파일:
- `sdk/src/features/BehaviorTracker.ts`

변경 배경:
- 기존: 모든 복사 이벤트를 동일하게 처리 (5점/회)
- 문제점:
  - 기술 블로그에서 코드 복사는 매우 강한 관심 신호
  - 일반 텍스트 복사와 코드 복사를 구분하지 못함
  - 고의도 사용자 판별 정확도 저하
- 해결: 코드 블록 내 복사를 별도로 감지하여 높은 가중치 부여

구현 내용:

**새로운 메트릭 추가**:
- `codeBlockCopies`: 코드 블록 복사 횟수 추적
- 기존 `copyEvents`와 별도 관리

**코드 블록 감지 로직** (`isSelectionInCodeBlock` 메서드):
- DOM 트리를 순회하며 복사된 텍스트의 부모 요소 확인
- `<pre>`, `<code>` 태그 감지
- 티스토리, 벨로그 등 주요 블로그 플랫폼의 코드 블록 클래스 감지
  - `hljs` (Highlight.js)
  - `language-*` (언어별 구문 강조)
  - `code`, `highlight` 클래스

**복사 이벤트 핸들러 개선** (`handleCopy` 메서드):
- `window.getSelection()`으로 선택 영역 획득
- `isSelectionInCodeBlock()`로 코드 블록 여부 판단
- 코드 블록 복사: `codeBlockCopies` 증가 → 15점/회
- 일반 텍스트 복사: `copyEvents` 증가 → 5점/회

**점수 계산 공식 업데이트** (`calculateScore` 메서드):
- 일반 복사: `copyEvents × 5점`
- 코드 블록 복사: `codeBlockCopies × 15점` (3배 가중치)
- 총점 = 스크롤(최대 30점) + 체류시간(최대 40점) + 일반복사 + 코드복사

---

### 2) 테스트 환경 개선

구현 파일:
- `sdk/test/test-blog.html`

변경 사항:
- 티스토리 실제 코드 블록 구조 추가

-> 코드 블록 감지 로직 검증을 위해 추가.

## 🧪 테스트 방법

### 1. 실제 티스토리에서 테스트.

### 2. test-blog(로컬) 에서 테스트.

<img width="798" height="157" alt="image" src="https://github.com/user-attachments/assets/9acc55c7-d38a-4046-b9ee-12a23318e48b" />


---

## 💬 To Reviewers

### 주요 리뷰 포인트
1. 가중치 적절성: 코드 복사 15점 vs 일반 복사 5점의 비율이 적절한지 검토 부탁드립니다! 복사도 중요한 행동이지만 코드 복사가 실제로 방문자가 제대로 학습 또는 도움을 얻고 있다는 직접적인 증거라고 생각하여 15점이라는 높은 점수를 부여하였습니다.
2. 코드 블록 감지 범위: 현재 `<pre>`, `<code>`, `hljs`, `language-*` 등을 감지하는데, 추가로 필요한 패턴이 있는지 의견 부탁드립니다.