### PR TITLE
[Feat] 실제 블로그 목록에 광고 삽입 문제 해결 및 수동 모드 지원

### DIFF
--- a/sdk/src/features/BannerAdRenderer.ts
+++ b/sdk/src/features/BannerAdRenderer.ts
@@ -1,19 +1,17 @@
 import type {
   AdRenderer,
   Campaign,
-  SDKConfig,
   ViewLogRequest,
   ViewLogResponse,
   ClickLogRequest,
   ClickLogResponse,
 } from '@/shared/types';
+import { API_BASE_URL } from '@/shared/config/constants';
 
 // 배너 광고 렌더러
 export class BannerAdRenderer implements AdRenderer {
   private currentViewId: number | null = null;
   private currentAdUrl: string | null = null;
-
-  constructor(private readonly config: SDKConfig) {}
 
   render(
     campaign: Campaign | null,
@@ -65,7 +63,7 @@ export class BannerAdRenderer implements AdRenderer {
         positionRatio: null, // 일단 null로 전송
       };
 
-      const response = await fetch(`${this.config.apiBase}/sdk/campaign-view`, {
+      const response = await fetch(`${API_BASE_URL}/sdk/campaign-view`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(requestBody),
@@ -97,7 +95,7 @@ export class BannerAdRenderer implements AdRenderer {
       };
 
       const response = await fetch(
-        `${this.config.apiBase}/sdk/campaign-click`,
+        `${API_BASE_URL}/sdk/campaign-click`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },

--- a/sdk/src/features/BoostAdSDK.ts
+++ b/sdk/src/features/BoostAdSDK.ts
@@ -119,10 +119,7 @@ export class BoostAdSDK {
     tags: Tag[],
     postUrl: string
   ): Promise<void> {
-    if (this.hasRequestedSecondAd) {
-      return;
-    }
-
+    if (this.hasRequestedSecondAd) return;
     this.hasRequestedSecondAd = true;
 
     const score = this.behaviorTracker.getCurrentScore();
@@ -136,16 +133,11 @@ export class BoostAdSDK {
     );
 
     // 1차 광고 제거
-    const firstAdContainer = document.getElementById('boostad-first-ad');
-    if (firstAdContainer) {
-      firstAdContainer.remove();
-    }
+    document.getElementById('boostad-first-ad')?.remove();
 
-    // 2차 광고 컨테이너 생성 및 현재 스크롤 위치에 삽입
+    // 2차 광고: 현재 스크롤 위치에 삽입
     const secondAdContainer = this.createAdContainer('boostad-second-ad');
     const insertionPoint = this.findScrollBasedInsertionPoint();
-
-    console.log('[BoostAD SDK] 2차 광고 삽입 위치:', insertionPoint);
 
     if (insertionPoint) {
       insertionPoint.after(secondAdContainer);
@@ -161,9 +153,7 @@ export class BoostAdSDK {
   }
 
   private isPostPage(): boolean {
-    // 대표 도메인(메인 페이지)이면 광고 표시 안 함
-    // 예: https://chazy.tistory.com/ → false
-    // 예: https://chazy.tistory.com/123 → true
+    // 메인 페이지(/)가 아니면 포스트 페이지로 간주
     const pathname = window.location.pathname;
     return pathname !== '/' && pathname !== '';
   }
@@ -173,23 +163,19 @@ export class BoostAdSDK {
       const contentArea = document.querySelector(selector);
       if (contentArea) {
         const firstElement = contentArea.querySelector('p, h2');
-        if (firstElement) {
-          return firstElement;
-        }
+        if (firstElement) return firstElement;
       }
     }
-
     return null;
   }
 
   private findScrollBasedInsertionPoint(): Element | null {
+    // 본문 영역 찾기
     let contentArea: Element | null = null;
     for (const selector of this.CONTENT_SELECTORS) {
       contentArea = document.querySelector(selector);
       if (contentArea) break;
     }
-
-    console.log('[BoostAD SDK] 본문 영역 찾기:', contentArea);
 
     if (!contentArea) {
       console.warn('[BoostAD SDK] 본문 영역을 찾을 수 없습니다');
@@ -197,8 +183,6 @@ export class BoostAdSDK {
     }
 
     const paragraphs = contentArea.querySelectorAll('p');
-    console.log('[BoostAD SDK] <p> 태그 개수:', paragraphs.length);
-
     if (paragraphs.length === 0) {
       console.warn('[BoostAD SDK] <p> 태그를 찾을 수 없습니다');
       return null;
@@ -211,12 +195,12 @@ export class BoostAdSDK {
     const contentRect = contentArea.getBoundingClientRect();
     const contentBottom = contentRect.bottom + scrollY;
 
-    // 스크롤이 본문을 넘어섰다면 본문의 마지막 <p> 태그 반환
+    // 스크롤이 본문 끝을 넘어섰다면 마지막 <p> 반환
     if (targetY > contentBottom) {
       return paragraphs[paragraphs.length - 1];
     }
 
-    // 본문 내에서 스크롤 위치에 가장 가까운 <p> 태그 찾기
+    // 본문 내에서 스크롤 위치에 가장 가까운 <p> 찾기
     let closestParagraph: Element | null = null;
     let minDistance = Infinity;
 
@@ -292,8 +276,7 @@ export class BoostAdSDK {
     // 모든 광고존의 광고를 2차 광고로 교체
     zones.forEach(async (zone) => {
       const container = zone as HTMLElement;
-      container.innerHTML = ''; // 기존 광고 제거
-
+      container.innerHTML = '';
       await this.fetchAndRenderAd(
         container,
         tags,

--- a/sdk/src/features/BoostAdSDK.ts
+++ b/sdk/src/features/BoostAdSDK.ts
@@ -31,6 +31,14 @@ export class BoostAdSDK {
   ) {}
 
   async init(): Promise<void> {
+    // 개별 포스트 페이지인지 확인
+    if (!this.isPostPage()) {
+      console.log(
+        '[BoostAD SDK] 포스트 페이지가 아니므로 광고를 표시하지 않습니다.'
+      );
+      return;
+    }
+
     const tags = this.tagExtractor.extract();
     console.log('[BoostAD SDK] 추출된 태그:', tags);
 
@@ -69,6 +77,12 @@ export class BoostAdSDK {
       this.requestSecondAd(tags, postUrl);
     });
     this.behaviorTracker.start();
+  }
+
+  private isPostPage(): boolean {
+    // 대표 도메인(메인 페이지)이면 광고 표시 안 함
+    const pathname = window.location.pathname;
+    return pathname !== '/' && pathname !== '';
   }
 
   private createAdContainer(id: string): HTMLElement {

--- a/sdk/src/features/DecisionAPIClient.ts
+++ b/sdk/src/features/DecisionAPIClient.ts
@@ -5,6 +5,7 @@ import type {
   SDKConfig,
   Tag,
 } from '@/shared/types';
+import { API_BASE_URL } from '@/shared/config/constants';
 
 // Decision API 클라이언트 (광고 가져오기)
 export class DecisionAPIClient implements APIClient {
@@ -25,7 +26,7 @@ export class DecisionAPIClient implements APIClient {
     };
 
     try {
-      const response = await fetch(`${this.config.apiBase}/sdk/decision`, {
+      const response = await fetch(`${API_BASE_URL}/sdk/decision`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -13,13 +13,18 @@ import { BoostAdSDK } from './features/BoostAdSDK';
   const config = getSDKConfig();
   const tagExtractor = new TagExtractor(TAGS);
   const apiClient = new DecisionAPIClient(config);
-  const adRenderer = new BannerAdRenderer(config);
+  const adRenderer = new BannerAdRenderer();
   const behaviorTracker = new BehaviorTracker();
   const sdk = new BoostAdSDK(
     tagExtractor,
     apiClient,
     adRenderer,
-    behaviorTracker
+    behaviorTracker,
+    config.auto // 자동/수동 모드 플래그
+  );
+
+  console.log(
+    `[BoostAD SDK] ${config.auto ? '자동' : '수동'} 모드로 초기화됩니다.`
   );
 
   // DOM 로드 완료 후 SDK 자동 초기화

--- a/sdk/src/shared/config/constants.ts
+++ b/sdk/src/shared/config/constants.ts
@@ -1,8 +1,6 @@
 import type { Tag } from '../types';
 
-export const SDK_VERSION = '0.1.0-prototype';
-
-export const DEFAULT_API_BASE_URL = `${import.meta.env.VITE_API_URL || 'http://localhost:3000'}/api`;
+export const API_BASE_URL = `${import.meta.env.VITE_API_URL || 'http://localhost:3000'}/api`;
 
 export const TAGS: Tag[] = [
   // Programming Languages

--- a/sdk/src/shared/config/sdk-config.ts
+++ b/sdk/src/shared/config/sdk-config.ts
@@ -1,13 +1,15 @@
 import type { SDKConfig } from '../types';
-import { DEFAULT_API_BASE_URL } from './constants';
 
 // 스크립트 태그의 data-* 속성에서 설정값 읽기
-// 사용: <script src="sdk.js" data-blog-key="my-blog" data-api-base="..."></script>
+// 사용 예시:
+// - 자동 모드: <script src="sdk.js" data-blog-key="my-blog"></script>
+// - 수동 모드: <script src="sdk.js" data-blog-key="my-blog" data-auto="false"></script>
 export function getSDKConfig(): SDKConfig {
   const script = document.currentScript as HTMLScriptElement | null;
+  const autoValue = script?.dataset.auto;
 
   return {
     blogKey: script?.dataset.blogKey || 'unknown',
-    apiBase: script?.dataset.apiBase || DEFAULT_API_BASE_URL,
+    auto: autoValue === undefined || autoValue === 'true', // 기본값: true (자동 모드)
   };
 }

--- a/sdk/src/shared/types/index.ts
+++ b/sdk/src/shared/types/index.ts
@@ -1,7 +1,7 @@
 // SDK 설정 타입 (스크립트 태그의 data-* 속성)
 export interface SDKConfig {
   blogKey: string;
-  apiBase: string;
+  auto: boolean; // true: 자동 모드 (블로그), false: 수동 모드 (광고존 직접 지정)
 }
 
 // 태그 타입


### PR DESCRIPTION
## 🔗 관련 이슈

- close: #123 

---

## ✅ 작업 내용

### 1) 블로그 메인 페이지 광고 노출 문제 해결

구현 파일:

- `sdk/src/features/BoostAdSDK.ts`

변경 배경:

- 기존: Tistory 전체 스킨에 SDK 삽입 시 모든 페이지에 광고 표시
- 문제점:
    - 블로그 메인 페이지(글 목록)에도 광고가 노출됨
    - 사용자 경험 저하 및 의도하지 않은 광고 노출
- 해결: URL 패턴 기반으로 개별 포스트 페이지만 광고 표시

구현 내용:

**포스트 페이지 감지 로직** (`isPostPage` 메서드):

- `window.location.pathname`이 `/`가 아닌 경우만 포스트로 간주
- 메인 페이지(`https://blog.tistory.com/`)에서는 광고 미표시
- 개별 포스트(`https://blog.tistory.com/123`)에서만 광고 표시

---

### 2) 수동 광고 삽입 모드 추가 (웹서비스 지원)

구현 파일:

- `sdk/src/features/BoostAdSDK.ts`
- `sdk/src/shared/types/index.ts`
- `sdk/src/shared/config/sdk-config.ts`
- `sdk/src/index.ts`

변경 배경:

- 기존: 블로그 전용 자동 삽입 방식만 지원
- 문제점:
    - 일반 웹서비스에서 사용 불가
    - 광고 위치를 직접 제어할 수 없음
- 해결: `data-auto` 플래그로 자동/수동 모드 선택 가능

구현 내용:

**SDK 설정 확장**:

- `SDKConfig`에 `auto: boolean` 필드 추가
- `data-auto` 속성으로 모드 제어 (기본값: `true`)

**자동 모드 (블로그용)**:

`<script src="~~sdk.js" data-blog-key="my-blog"></script>`

- 포스트 페이지 자동 감지
- 본문 상단에 1차 광고 자동 삽입
- 70점 도달 시 스크롤 위치에 2차 광고 삽입
- 메인 페이지에서는 광고 미표시

**수동 모드 (웹서비스용)**:

`<script src="~~sdk.js" data-blog-key="my-blog" data-auto="false"></script>
<div data-boostad-zone></div>`

- `data-boostad-zone` 속성이 있는 요소에 광고 삽입
- 페이지 타입 제한 없음 (어디서나 작동)
- 70점 도달 시 같은 위치에서 광고 교체

**모드별 처리 로직 분리**:

- `initAutoMode()`: 자동 모드 진입점
- `initManualMode()`: 수동 모드 진입점
- `requestSecondAdAutoMode()`: 자동 모드 2차 광고 로직
- `requestSecondAdManualMode()`: 수동 모드 2차 광고 로직

---

### 3) SDK 코드 구조 개선

구현 파일:

- `sdk/src/features/BoostAdSDK.ts`
- `sdk/src/features/BannerAdRenderer.ts`
- `sdk/src/features/DecisionAPIClient.ts`
- `sdk/src/shared/config/constants.ts`

변경 내용:

**불필요한 설정 제거**:

- `apiBase` 제거 → `API_BASE_URL` 상수로 통일
- `SDK_VERSION` 상수 제거
- `BannerAdRenderer`에서 `config` 의존성 제거

---

## 🎯 자동/수동 모드 플로우

### 자동 모드 (블로그)

```
1. SDK 초기화
   ↓
2. 포스트 페이지 확인 (isPostPage)
   ↓ (메인 페이지면 종료)
3. 태그 추출 (h1, h2, Tistory 태그)
   ↓
4. 1차 광고: 본문 상단 자동 삽입 (findContentTop)
   ↓
5. 행동 추적 시작
   ↓
6. 70점 도달 시 → 1차 광고 제거
   ↓
7. 2차 광고: 현재 스크롤 위치에 삽입 (findScrollBasedInsertionPoint)
```

### 수동 모드 (웹서비스)

```
1. SDK 초기화
   ↓
2. data-boostad-zone 요소 검색
   ↓ (없으면 종료)
3. 태그 추출 (h1, h2 또는 메타태그)
   ↓
4. 1차 광고: 각 광고존에 삽입
   ↓
5. 행동 추적 시작
   ↓
6. 70점 도달 시 → 모든 광고존의 광고 내용 교체
   ↓
7. 2차 광고: 같은 위치에 렌더링
```