### PR TITLE
[Feat] 광고주 대시보드 캠페인별 보기 기능 추가(Mock)

### DIFF
--- a/frontend/src/2_pages/advertiserDashboard/ui/AdvertiserDashboardPage.tsx
+++ b/frontend/src/2_pages/advertiserDashboard/ui/AdvertiserDashboardPage.tsx
@@ -1,10 +1,10 @@
-import { StatsCardList } from '@features/dashboardStats/ui/StatsCardList';
+import { AccountSummaryCardList } from '@features/accountSummary';
 import { RealtimeBidsTable } from '@features/realtimeBids';
 
 export function AdvertiserDashboardPage() {
   return (
     <div className="flex flex-col gap-4 px-8 py-8 bg-gray-100">
-      <StatsCardList />
+      <AccountSummaryCardList />
       <RealtimeBidsTable />
     </div>
   );

--- a/frontend/src/2_pages/advertiserDashboard/ui/AdvertiserDashboardPage.tsx
+++ b/frontend/src/2_pages/advertiserDashboard/ui/AdvertiserDashboardPage.tsx
@@ -1,10 +1,12 @@
 import { AccountSummaryCardList } from '@features/accountSummary';
+import { CampaignStatsTable } from '@features/campaignStats';
 import { RealtimeBidsTable } from '@features/realtimeBids';
 
 export function AdvertiserDashboardPage() {
   return (
     <div className="flex flex-col gap-4 px-8 py-8 bg-gray-100">
       <AccountSummaryCardList />
+      <CampaignStatsTable />
       <RealtimeBidsTable />
     </div>
   );

--- a/frontend/src/2_pages/campaginCreate/ui/CampaignCreatePage.tsx
+++ b/frontend/src/2_pages/campaginCreate/ui/CampaignCreatePage.tsx
@@ -3,11 +3,11 @@ import {
   Step1Content,
   Step2Content,
   Step3Content,
-  useCampaignForm,
+  useCampaignFormStore,
 } from '@features/campaignCreation';
 
 export function CampaignCreatePage() {
-  const { currentStep } = useCampaignForm();
+  const { currentStep } = useCampaignFormStore();
 
   const handleSubmit = () => {
     // TODO: 실제 광고 생성 API 호출 및 페이지 이동 로직 구현 필요!

--- a/frontend/src/3_features/accountSummary/index.ts
+++ b/frontend/src/3_features/accountSummary/index.ts
@@ -1,0 +1,2 @@
+export { AccountSummaryCard } from './ui/AccountSummaryCard';
+export { AccountSummaryCardList } from './ui/AccountSummaryCardList';

--- a/frontend/src/3_features/accountSummary/lib/useAccountSummary.ts
+++ b/frontend/src/3_features/accountSummary/lib/useAccountSummary.ts
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { apiClient } from '@shared/lib/api';
 
 // 서버에서 받는 응답 형태
-interface DashboardStatsResponse {
+interface AccountSummaryResponse {
   performance: {
     totalClicks: number; // 총 클릭 수
     clicksChange: number; // 클릭 수 변화량
@@ -23,16 +23,16 @@ interface DashboardStatsResponse {
     }>;
   };
 }
-interface UseStatsReturn {
-  data: DashboardStatsResponse['performance'] | null;
+interface UseAccountSummaryReturn {
+  data: AccountSummaryResponse['performance'] | null;
   isLoading: boolean;
   error: string | null;
 }
 
 // 이 훅이 반환하는 것들
-export function useStats(): UseStatsReturn {
+export function useAccountSummary(): UseAccountSummaryReturn {
   const [data, setData] = useState<
-    DashboardStatsResponse['performance'] | null
+    AccountSummaryResponse['performance'] | null
   >(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -43,7 +43,7 @@ export function useStats(): UseStatsReturn {
         setIsLoading(true);
         setError(null);
 
-        const response = await apiClient<DashboardStatsResponse>(
+        const response = await apiClient<AccountSummaryResponse>(
           '/api/advertiser/dashboard/stats'
         );
 

--- a/frontend/src/3_features/accountSummary/ui/AccountSummaryCard.tsx
+++ b/frontend/src/3_features/accountSummary/ui/AccountSummaryCard.tsx
@@ -1,13 +1,13 @@
 import { Icon } from '@shared/ui/Icon';
 
-interface StatsCardProps {
+interface AccountSummaryCardProps {
   title: string;
   value: string | number;
   change?: string;
   icon?: React.ReactNode;
 }
 
-export function StatsCard({ title, value, change, icon }: StatsCardProps) {
+export function AccountSummaryCard({ title, value, change, icon }: AccountSummaryCardProps) {
   return (
     <div className="flex-1 min-w-65 p-5 bg-white border border-gray-200 rounded-xl shadow">
       <div className="flex flex-row items-center justify-between text-gray-600">

--- a/frontend/src/3_features/accountSummary/ui/AccountSummaryCardList.tsx
+++ b/frontend/src/3_features/accountSummary/ui/AccountSummaryCardList.tsx
@@ -1,33 +1,33 @@
-import { StatsCard } from './StatsCard';
+import { AccountSummaryCard } from './AccountSummaryCard';
 import { Icon } from '@shared/ui/Icon';
-import { useStats } from '../lib/useStats';
+import { useAccountSummary } from '../lib/useAccountSummary';
 
-export function StatsCardList() {
-  const { data, isLoading, error } = useStats();
+export function AccountSummaryCardList() {
+  const { data, isLoading, error } = useAccountSummary();
 
   // 에러가 있거나 로딩 중이거나 데이터가 없으면 0 값 표시
   if (error || isLoading || !data) {
     return (
       <div className="flex flex-row gap-4 min-w-fit">
-        <StatsCard
+        <AccountSummaryCard
           title="전체 광고 클릭 수"
           value="0"
           change="+0"
           icon={<Icon.Click className="w-8 h-8" />}
         />
-        <StatsCard
+        <AccountSummaryCard
           title="전체 광고 노출 수"
           value="0"
           change="+0"
           icon={<Icon.Eye className="w-8 h-8" />}
         />
-        <StatsCard
+        <AccountSummaryCard
           title="평균 노출당 클릭률 (CTR)"
           value="0.0%"
           change="0.00%"
           icon={<Icon.Percent className="w-8 h-8" />}
         />
-        <StatsCard
+        <AccountSummaryCard
           title="총 사용"
           value="0원"
           icon={<Icon.Dollar className="w-8 h-8" />}
@@ -38,7 +38,7 @@ export function StatsCardList() {
 
   return (
     <div className="flex flex-row gap-4 min-w-fit">
-      <StatsCard
+      <AccountSummaryCard
         title="전체 캠페인 클릭 수"
         value={data.totalClicks.toLocaleString()}
         change={
@@ -48,7 +48,7 @@ export function StatsCardList() {
         }
         icon={<Icon.Click className="w-8 h-8" />}
       />
-      <StatsCard
+      <AccountSummaryCard
         title="전체 캠페인 노출 수"
         value={data.totalImpressions.toLocaleString()}
         change={
@@ -58,7 +58,7 @@ export function StatsCardList() {
         }
         icon={<Icon.Eye className="w-8 h-8" />}
       />
-      <StatsCard
+      <AccountSummaryCard
         title="평균 노출당 클릭률 (CTR)"
         value={`${data.averageCtr}%`}
         change={
@@ -68,7 +68,7 @@ export function StatsCardList() {
         }
         icon={<Icon.Percent className="w-8 h-8" />}
       />
-      <StatsCard
+      <AccountSummaryCard
         title="총 사용"
         value={`${data.totalSpent.toLocaleString()}원`}
         icon={<Icon.Dollar className="w-8 h-8" />}

--- a/frontend/src/3_features/campaignCreation/index.ts
+++ b/frontend/src/3_features/campaignCreation/index.ts
@@ -14,7 +14,7 @@ export {
   MAX_SELECTED_TAGS,
   DEFAULT_ENGAGEMENT_SCORE,
 } from './lib/constants';
-export { useCampaignForm } from './lib/useCampaignForm';
+export { useCampaignFormStore } from './lib/campaignFormStore';
 export { StepIndicator } from './ui/StepIndicator';
 export { FormNavigation } from './ui/FormNavigation';
 export { CampaignCreationForm } from './ui/CampaignCreationForm';

--- a/frontend/src/3_features/campaignCreation/lib/campaignFormStore.ts
+++ b/frontend/src/3_features/campaignCreation/lib/campaignFormStore.ts
@@ -35,7 +35,7 @@ const initialFormData: CampaignFormData = {
   },
 };
 
-export const useCampaignForm = create<CampaignFormState>((set) => ({
+export const useCampaignFormStore = create<CampaignFormState>((set) => ({
   currentStep: 1,
   formData: initialFormData,
   errors: {},

--- a/frontend/src/3_features/campaignCreation/ui/CampaignCreationForm.tsx
+++ b/frontend/src/3_features/campaignCreation/ui/CampaignCreationForm.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { Modal } from '@shared/ui/Modal';
-import { useCampaignForm } from '../lib/useCampaignForm';
+import { useCampaignFormStore } from '../lib/campaignFormStore';
 import { StepIndicator } from './StepIndicator';
 import { FormNavigation } from './FormNavigation';
 
@@ -13,7 +13,7 @@ export function CampaignCreationForm({
   children,
   onSubmit,
 }: CampaignCreationFormProps) {
-  const { currentStep, setStep } = useCampaignForm();
+  const { currentStep, setStep } = useCampaignFormStore();
 
   const handlePrev = () => {
     if (currentStep === 2) {

--- a/frontend/src/3_features/campaignCreation/ui/Step1Content.tsx
+++ b/frontend/src/3_features/campaignCreation/ui/Step1Content.tsx
@@ -3,11 +3,11 @@ import { ContentHeader } from './ContentHeader';
 import { ImageUpload } from './ImageUpload';
 import { KeywordSelector } from './KeywordSelector';
 import { AdvancedSettings } from './AdvancedSettings';
-import { useCampaignForm } from '../lib/useCampaignForm';
+import { useCampaignFormStore } from '../lib/campaignFormStore';
 import type { Tag } from '../lib/types';
 
 export function Step1Content() {
-  const { formData, updateCampaignContent } = useCampaignForm();
+  const { formData, updateCampaignContent } = useCampaignFormStore();
   const { title, content, url, tags, isHighIntent, imageFile } =
     formData.campaignContent;
 

--- a/frontend/src/3_features/campaignCreation/ui/Step2Content.tsx
+++ b/frontend/src/3_features/campaignCreation/ui/Step2Content.tsx
@@ -1,12 +1,12 @@
 import { ContentHeader } from './ContentHeader';
 import { CurrencyField } from './CurrencyField';
-import { useCampaignForm } from '../lib/useCampaignForm';
+import { useCampaignFormStore } from '../lib/campaignFormStore';
 
 const MIN_DAILY_BUDGET = 3000;
 
 export function Step2Content() {
   const { formData, updateBudgetSettings, errors, setErrors } =
-    useCampaignForm();
+    useCampaignFormStore();
   const { dailyBudget, totalBudget, maxCpc } = formData.budgetSettings;
 
   const handleDailyBudgetChange = (value: number) => {

--- a/frontend/src/3_features/campaignCreation/ui/Step3Content.tsx
+++ b/frontend/src/3_features/campaignCreation/ui/Step3Content.tsx
@@ -2,12 +2,12 @@ import { useMemo } from 'react';
 import { ContentHeader } from './ContentHeader';
 import { ConfirmCard } from './ConfirmCard';
 import { ConfirmItem } from './ConfirmItem';
-import { useCampaignForm } from '../lib/useCampaignForm';
+import { useCampaignFormStore } from '../lib/campaignFormStore';
 import { formatWithComma } from '@shared/lib/format';
 import { DEFAULT_ENGAGEMENT_SCORE } from '../lib/constants';
 
 export function Step3Content() {
-  const { formData, setStep } = useCampaignForm();
+  const { formData, setStep } = useCampaignFormStore();
   const { title, content, url, tags, isHighIntent, imageFile } =
     formData.campaignContent;
   const { dailyBudget, totalBudget, maxCpc } = formData.budgetSettings;

--- a/frontend/src/3_features/campaignStats/index.ts
+++ b/frontend/src/3_features/campaignStats/index.ts
@@ -1,0 +1,3 @@
+export { CampaignStatsTable } from './ui/CampaignStatsTable';
+export { BudgetProgressBar } from './ui/BudgetProgressBar';
+export type { CampaignStats, CampaignStatus, CampaignStatsResponse } from './lib/types';

--- a/frontend/src/3_features/campaignStats/lib/types.ts
+++ b/frontend/src/3_features/campaignStats/lib/types.ts
@@ -1,0 +1,15 @@
+export type CampaignStatus = 'PENDING' | 'ACTIVE' | 'PAUSED' | 'ENDED';
+
+export interface CampaignStats {
+  id: string;
+  title: string;
+  status: CampaignStatus;
+  impressions: number;
+  clicks: number;
+  ctr: number;
+  dailySpentPercent: number;
+  totalSpentPercent: number;
+  isHighIntent: boolean;
+}
+
+export type CampaignStatsResponse = CampaignStats[];

--- a/frontend/src/3_features/campaignStats/lib/useCampaignStats.ts
+++ b/frontend/src/3_features/campaignStats/lib/useCampaignStats.ts
@@ -1,0 +1,52 @@
+import { useState, useEffect } from 'react';
+import { apiClient } from '@shared/lib/api';
+import type { CampaignStatsResponse, CampaignStats } from './types';
+
+interface UseCampaignStatsParams {
+  limit?: number;
+  offset?: number;
+}
+
+interface UseCampaignStatsReturn {
+  total: number;
+  hasMore: boolean;
+  campaigns: CampaignStats[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+export function useCampaignStats(params: UseCampaignStatsParams = {}): UseCampaignStatsReturn {
+  const { limit = 3, offset = 0 } = params;
+  const [campaigns, setCampaigns] = useState<CampaignStats[]>([]);
+  const [total, setTotal] = useState(0);
+  const [hasMore, setHasMore] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchCampaigns = async () => {
+      try {
+        setIsLoading(true);
+        setError(null);
+
+        const response = await apiClient<CampaignStatsResponse>(
+          `/api/advertiser/campaigns?limit=${limit}&offset=${offset}`
+        );
+
+        setCampaigns(response);
+        setTotal(0);
+        setHasMore(false);
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : '알 수 없는 오류가 발생했습니다';
+        setError(message);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchCampaigns();
+  }, [limit, offset]);
+
+  return { campaigns, total, hasMore, isLoading, error };
+}

--- a/frontend/src/3_features/campaignStats/ui/BudgetProgressBar.tsx
+++ b/frontend/src/3_features/campaignStats/ui/BudgetProgressBar.tsx
@@ -1,0 +1,25 @@
+interface BudgetProgressBarProps {
+  percentage: number;
+}
+
+export function BudgetProgressBar({ percentage }: BudgetProgressBarProps) {
+  const getColor = () => {
+    if (percentage >= 80) return 'red-700';
+    if (percentage >= 50) return 'yellow-500';
+    return 'blue-500';
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <div className="w-32 h-2 bg-gray-200 rounded-full overflow-hidden">
+        <div
+          className={`h-full rounded-full bg-${getColor()}`}
+          style={{ width: `${Math.min(percentage, 100)}%` }}
+        />
+      </div>
+      <span className={`text-sm font-medium text-${getColor()}`}>
+        {percentage}%
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/3_features/campaignStats/ui/CampaignStatsTable.tsx
+++ b/frontend/src/3_features/campaignStats/ui/CampaignStatsTable.tsx
@@ -1,0 +1,96 @@
+import type { CampaignStats } from '../lib/types';
+import { CampaignStatsTableHeader } from './CampaignStatsTableHeader';
+import { CampaignStatsTableRow } from './CampaignStatsTableRow';
+
+// Mock 데이터 (API 연동 시 삭제)
+const mockCampaigns: CampaignStats[] = [
+  {
+    id: 'campaign-001',
+    title: '캠페인 A next.js 배워보기',
+    status: 'ACTIVE',
+    impressions: 384,
+    clicks: 109,
+    ctr: 28.84,
+    dailySpentPercent: 23,
+    totalSpentPercent: 80.14,
+    isHighIntent: true,
+  },
+  {
+    id: 'campaign-002',
+    title: '캠페인 B nest.js 배워보기',
+    status: 'PAUSED',
+    impressions: 384,
+    clicks: 109,
+    ctr: 28.84,
+    dailySpentPercent: 81,
+    totalSpentPercent: 25.24,
+    isHighIntent: true,
+  },
+  {
+    id: 'campaign-003',
+    title: '캠페인 C Mysql 완전 정복',
+    status: 'ENDED',
+    impressions: 384,
+    clicks: 109,
+    ctr: 28.84,
+    dailySpentPercent: 94,
+    totalSpentPercent: 65.23,
+    isHighIntent: false,
+  },
+];
+
+export function CampaignStatsTable() {
+  // TODO: API 연동 시 useCampaignStats 사용할 것!
+  // const { campaigns, isLoading, error } = useCampaignStats({ limit: 3 });
+  const campaigns = mockCampaigns;
+  const isLoading = false;
+  const error = null;
+
+  if (isLoading) {
+    return (
+      <div className="text-gray-600 flex flex-col bg-white border border-gray-200 rounded-xl shadow">
+        <div className="p-5 flex flex-row justify-between items-center border-b border-gray-100">
+          <h2 className="text-gray-900 text-xl font-bold">캠페인</h2>
+          <a href="#" className="text-base font-bold">
+            전체 캠페인 목록 보기 →
+          </a>
+        </div>
+        <div className="p-10 text-center text-gray-500">로딩 중...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="text-gray-600 flex flex-col bg-white border border-gray-200 rounded-xl shadow">
+        <div className="p-5 flex flex-row justify-between items-center border-b border-gray-100">
+          <h2 className="text-gray-900 text-xl font-bold">캠페인</h2>
+          <a href="#" className="text-base font-bold">
+            전체 캠페인 목록 보기 →
+          </a>
+        </div>
+        <div className="p-10 text-center text-red-500">{error}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="text-gray-600 flex flex-col bg-white border border-gray-200 rounded-xl shadow">
+      <div className="p-5 flex flex-row justify-between items-center border-b border-gray-100">
+        <h2 className="text-gray-900 text-xl font-bold">캠페인</h2>
+        <a href="#" className="text-base font-bold">
+          전체 캠페인 목록 보기 →
+        </a>
+      </div>
+
+      <table>
+        <CampaignStatsTableHeader />
+        <tbody>
+          {campaigns.map((campaign) => (
+            <CampaignStatsTableRow key={campaign.id} campaign={campaign} />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/3_features/campaignStats/ui/CampaignStatsTableHeader.tsx
+++ b/frontend/src/3_features/campaignStats/ui/CampaignStatsTableHeader.tsx
@@ -1,0 +1,22 @@
+export function CampaignStatsTableHeader() {
+  return (
+    <thead className="bg-gray-50 text-sm">
+      <tr>
+        <th className="px-5 py-3 text-left font-medium text-gray-600">
+          캠페인 명
+        </th>
+        <th className="px-5 py-3 text-left font-medium text-gray-600">상태</th>
+        <th className="px-5 py-3 text-left font-medium text-gray-600">노출</th>
+        <th className="px-5 py-3 text-left font-medium text-gray-600">클릭</th>
+        <th className="px-5 py-3 text-left font-medium text-gray-600">CTR</th>
+        <th className="px-5 py-3 text-left font-medium text-gray-600">
+          하루 예산 소진율
+        </th>
+        <th className="px-5 py-3 text-left font-medium text-gray-600">
+          전체 예산 소진율
+        </th>
+        <th className="px-5 py-3 text-left font-medium text-gray-600">전략</th>
+      </tr>
+    </thead>
+  );
+}

--- a/frontend/src/3_features/campaignStats/ui/CampaignStatsTableRow.tsx
+++ b/frontend/src/3_features/campaignStats/ui/CampaignStatsTableRow.tsx
@@ -1,0 +1,65 @@
+import type { CampaignStats } from '../lib/types';
+import { Icon } from '@shared/ui/Icon';
+import { BudgetProgressBar } from './BudgetProgressBar';
+
+interface CampaignStatsTableRowProps {
+  campaign: CampaignStats;
+}
+
+export function CampaignStatsTableRow({
+  campaign,
+}: CampaignStatsTableRowProps) {
+  const getStatusBadge = () => {
+    switch (campaign.status) {
+      case 'ACTIVE':
+        return (
+          <div className="flex flex-row items-center gap-1 px-1.5 py-0.5 bg-green-100 border border-green-300 rounded-lg text-xs font-semibold text-green-500 w-fit">
+            <Icon.Circle className="w-3 h-3 text-green-500" />
+            진행중
+          </div>
+        );
+      case 'PAUSED':
+        return (
+          <div className="flex flex-row items-center gap-1 px-1.5 py-0.5 bg-red-100 border border-red-300 rounded-lg text-xs font-semibold text-red-700 w-fit">
+            <Icon.Circle className="w-3 h-3 text-red-700" />
+            일시정지
+          </div>
+        );
+      case 'PENDING':
+        return (
+          <div className="flex flex-row items-center gap-1 px-1.5 py-0.5 bg-yellow-100 border border-yellow-300 rounded-lg text-xs font-semibold text-yellow-600 w-fit">
+            <Icon.Circle className="w-3 h-3 text-yellow-500" />
+            대기
+          </div>
+        );
+      case 'ENDED':
+        return (
+          <div className="flex flex-row items-center gap-1 px-1.5 py-0.5 bg-gray-100 border border-gray-300 rounded-lg text-xs font-semibold text-gray-500 w-fit">
+            <Icon.Circle className="w-3 h-3 text-gray-500" />
+            종료
+          </div>
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <tr className="text-base border-b border-gray-100">
+      <td className="px-5 py-4 text-gray-900 font-semibold">
+        {campaign.title}
+      </td>
+      <td className="px-5 py-4">{getStatusBadge()}</td>
+      <td className="px-5 py-4 text-gray-900">{campaign.impressions}</td>
+      <td className="px-5 py-4 text-gray-900">{campaign.clicks}</td>
+      <td className="px-5 py-4 text-gray-900">{campaign.ctr.toFixed(2)}%</td>
+      <td className="px-5 py-4">
+        <BudgetProgressBar percentage={campaign.dailySpentPercent} />
+      </td>
+      <td className="px-5 py-4 text-gray-900">{campaign.totalSpentPercent}%</td>
+      <td className="px-5 py-4 text-gray-600 text-sm">
+        {campaign.isHighIntent ? '고의도 학습자 대상' : '모든 학습자 대상'}
+      </td>
+    </tr>
+  );
+}

--- a/frontend/src/3_features/dashboardStats/index.ts
+++ b/frontend/src/3_features/dashboardStats/index.ts
@@ -1,2 +1,0 @@
-export { StatsCard } from './ui/StatsCard';
-export { StatsCardList } from './ui/StatsCardList';


### PR DESCRIPTION
<!-- PR 제목 예시 : [Feat] 로그인 기능 구현 -->
<!-- PR 제목은 위 형식을 참고하여 작성해주세요. -->
<!-- 필요 없는 내용은 지우고 작성해주세요 -->

## 🔗 관련 이슈

- close: #44 

---

## ✅ 작업 내용

### 📌 검토 파일

**주요 검토 파일:**

* `frontend/src/2_pages/advertiserDashboard/ui/AdvertiserDashboardPage.tsx`
  * 광고주 대시보드에 캠페인 테이블 추가
* `frontend/src/3_features/campaignStats/*`
  * 캠페인 통계 테이블, 타입, 훅, UI 컴포넌트 전반

**참고용:**
* `frontend/src/3_features/accountSummary/*`
  * 기존 `dashboardStats` → `accountSummary`로 네이밍 통일
* `frontend/src/3_features/campaignCreation/*`
  * `useCampaignForm` → `useCampaignFormStore` 네이밍 변경

## 1️⃣ features 네이밍 컨벤션 정리
### 변경 배경
기존 `dashboardStats`, `useStats` 등은 범위가 모호해
**광고 계정 요약 정보**라는 의미가 잘 드러나지 않는다고 판단했습니다.

### 변경 사항
* `dashboardStats` → `accountSummary`
* `useStats` → `useAccountSummary`
* `StatsCard` → `AccountSummaryCard`
* `StatsCardList` → `AccountSummaryCardList`
* `useCampaignForm` → `useCampaignFormStore` (Zustand store임을 명확히 표현)

## 2️⃣ 캠페인 통계 타입 및 커스텀 훅 정의
### 타입 정의
#### **types.ts**
```ts
export type CampaignStatus = 'PENDING' | 'ACTIVE' | 'PAUSED' | 'ENDED';

export interface CampaignStats {
  id: string;
  title: string;
  status: CampaignStatus;
  impressions: number;
  clicks: number;
  ctr: number;
  dailySpentPercent: number;
  totalSpentPercent: number;
  isHighIntent: boolean;
}
```
* 캠페인 상태, 지표, 예산 소진율 등 테이블 UI에 필요한 최소 단위로 정의
* API 응답 변경 시 타입 기준으로 UI 영향 범위 파악 가능

### 커스텀 훅
#### **useCampaignStats.ts**
* 캠페인 목록 조회용 훅
* `limit`, `offset` 파라미터 기반 구조
* 현재는 API 미구현이라 우선 mock 데이터 사용 중

## 3️⃣ 캠페인 테이블 UI 컴포넌트 구현
### 구성 요소
* `CampaignStatsTable`
* `CampaignStatsTableHeader`
* `CampaignStatsTableRow`
* `BudgetProgressBar`

### 주요 UI 포인트
#### 상태 배지
* `ACTIVE / PENDING / PAUSED / ENDED` 상태별 색상 분기
* 아이콘 + 텍스트 조합으로 가독성 강화

#### 예산 소진율 프로그레스 바
```tsx
<BudgetProgressBar percentage={campaign.dailySpentPercent} />
```
* 퍼센트에 따라 색상 변경

---

## 4️⃣ 광고주 대시보드에 캠페인별 보기 카드 컴포넌트 추가
#### **AdvertiserDashboardPage.tsx**
```tsx
<AccountSummaryCardList />
<CampaignStatsTable />
<RealtimeBidsTable />
```
* 상단: 계정 요약 카드
* 중단: 캠페인 통계 테이블
* 하단: 실시간 입찰 현황

---

## 📸 스크린샷 / 데모 (옵션)

<!-- UI 변경사항이나 새로운 기능의 동작을 시각적으로 보여주세요. -->
<img width="1291" height="309" alt="캠페인카드" src="https://github.com/user-attachments/assets/141a11b4-a4bb-4456-9bef-4b99ac8d0f19" />

---

## 🧪 테스트 방법 (옵션)

<!-- 리뷰어가 기능을 테스트할 수 있도록 구체적인 테스트 방법을 설명해주세요. -->

. `/advertiser/dashboard` 접속
2. 상단 **계정 요약 카드** 정상 노출 확인
3. **캠페인 테이블**

   * 상태 배지 색상 정상 표시
   * CTR, 노출/클릭 수, 예산 소진율 표시 확인
4. 예산 소진율이 높은 캠페인의 프로그레스 바 색상 변화 확인


---

## 💬 To Reviewers

* 캠페인 테이블은 현재 **mock 데이터**입니다...!
  API 연동은 `useCampaignStats`를 기준으로 후속 작업이 추가로 필요합니다. 그래도 우선 틀은 다 작성해뒀습니다.
* `accountSummary`, `campaignStats` 네이밍 변경으로 import 경로가 수정된 부분이 조금 많아요!
* 예산 소진율 50이하 파랑, 50-80 노랑, 80이상 빨강으로 표시하고 있습니다.

### 🔄 추후 작업 필요
* 캠페인 통계 API 실제 연동
* 캠페인 테이블 pagination / “전체 캠페인 목록” 페이지 연결

