### PR TITLE
[Feat] 광고주 대시보드 키워드 성과 카드 구현(Mock)

### DIFF
--- a/frontend/src/1_app/providers/RouterProvider.tsx
+++ b/frontend/src/1_app/providers/RouterProvider.tsx
@@ -25,7 +25,7 @@ export function RouterProvider() {
       <Routes>
         <Route
           path="/"
-          element={<Navigate to="/publisher/dashboard" replace />}
+          element={<Navigate to="/advertiser/dashboard" replace />}
         />
 
         <Route element={<OnboardingLayout />}>
@@ -67,7 +67,7 @@ export function RouterProvider() {
           />
         </Route>
         <Route path="/auth/register" element={<RegisterPage />} />
-        <Route path="/auth/login" element={<LoginPage/>} />
+        <Route path="/auth/login" element={<LoginPage />} />
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
     </BrowserRouter>

--- a/frontend/src/2_pages/advertiserDashboard/ui/AdvertiserDashboardPage.tsx
+++ b/frontend/src/2_pages/advertiserDashboard/ui/AdvertiserDashboardPage.tsx
@@ -1,5 +1,6 @@
 import { AccountSummaryCardList } from '@features/accountSummary';
 import { CampaignStatsTable } from '@features/campaignStats';
+import { KeywordStatsCard } from '@features/keywordStats';
 import { RealtimeBidsTable } from '@features/realtimeBids';
 
 export function AdvertiserDashboardPage() {
@@ -7,7 +8,14 @@ export function AdvertiserDashboardPage() {
     <div className="flex flex-col gap-4 px-8 py-8 bg-gray-100">
       <AccountSummaryCardList />
       <CampaignStatsTable />
-      <RealtimeBidsTable />
+      <div className="flex flex-row gap-4">
+        <div className="flex-[2.5]">
+          <RealtimeBidsTable />
+        </div>
+        <div className="flex-1">
+          <KeywordStatsCard />
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/3_features/campaignStats/ui/BudgetProgressBar.tsx
+++ b/frontend/src/3_features/campaignStats/ui/BudgetProgressBar.tsx
@@ -10,8 +10,8 @@ export function BudgetProgressBar({ percentage }: BudgetProgressBarProps) {
   };
 
   return (
-    <div className="flex items-center gap-2">
-      <div className="w-32 h-2 bg-gray-200 rounded-full overflow-hidden">
+    <div className="flex items-center gap-2 whitespace-nowrap">
+      <div className="w-32 h-2 bg-gray-200 rounded-full overflow-hidden shrink-0">
         <div
           className={`h-full rounded-full bg-${getColor()}`}
           style={{ width: `${Math.min(percentage, 100)}%` }}

--- a/frontend/src/3_features/campaignStats/ui/CampaignStatsTableHeader.tsx
+++ b/frontend/src/3_features/campaignStats/ui/CampaignStatsTableHeader.tsx
@@ -2,20 +2,30 @@ export function CampaignStatsTableHeader() {
   return (
     <thead className="bg-gray-50 text-sm">
       <tr>
-        <th className="px-5 py-3 text-left font-medium text-gray-600">
+        <th className="px-5 py-3 text-left font-medium text-gray-600 whitespace-nowrap">
           캠페인 명
         </th>
-        <th className="px-5 py-3 text-left font-medium text-gray-600">상태</th>
-        <th className="px-5 py-3 text-left font-medium text-gray-600">노출</th>
-        <th className="px-5 py-3 text-left font-medium text-gray-600">클릭</th>
-        <th className="px-5 py-3 text-left font-medium text-gray-600">CTR</th>
-        <th className="px-5 py-3 text-left font-medium text-gray-600">
+        <th className="px-5 py-3 text-left font-medium text-gray-600 whitespace-nowrap">
+          상태
+        </th>
+        <th className="px-5 py-3 text-left font-medium text-gray-600 whitespace-nowrap">
+          노출
+        </th>
+        <th className="px-5 py-3 text-left font-medium text-gray-600 whitespace-nowrap">
+          클릭
+        </th>
+        <th className="px-5 py-3 text-left font-medium text-gray-600 whitespace-nowrap">
+          CTR
+        </th>
+        <th className="px-5 py-3 text-left font-medium text-gray-600 whitespace-nowrap">
           하루 예산 소진율
         </th>
-        <th className="px-5 py-3 text-left font-medium text-gray-600">
+        <th className="px-5 py-3 text-left font-medium text-gray-600 whitespace-nowrap">
           전체 예산 소진율
         </th>
-        <th className="px-5 py-3 text-left font-medium text-gray-600">전략</th>
+        <th className="px-5 py-3 text-left font-medium text-gray-600 whitespace-nowrap">
+          전략
+        </th>
       </tr>
     </thead>
   );

--- a/frontend/src/3_features/campaignStats/ui/CampaignStatsTableRow.tsx
+++ b/frontend/src/3_features/campaignStats/ui/CampaignStatsTableRow.tsx
@@ -49,15 +49,23 @@ export function CampaignStatsTableRow({
       <td className="px-5 py-4 text-gray-900 font-semibold">
         {campaign.title}
       </td>
-      <td className="px-5 py-4">{getStatusBadge()}</td>
-      <td className="px-5 py-4 text-gray-900">{campaign.impressions}</td>
-      <td className="px-5 py-4 text-gray-900">{campaign.clicks}</td>
-      <td className="px-5 py-4 text-gray-900">{campaign.ctr.toFixed(2)}%</td>
-      <td className="px-5 py-4">
+      <td className="px-5 py-4 whitespace-nowrap">{getStatusBadge()}</td>
+      <td className="px-5 py-4 text-gray-900 whitespace-nowrap">
+        {campaign.impressions}
+      </td>
+      <td className="px-5 py-4 text-gray-900 whitespace-nowrap">
+        {campaign.clicks}
+      </td>
+      <td className="px-5 py-4 text-gray-900 whitespace-nowrap">
+        {campaign.ctr.toFixed(2)}%
+      </td>
+      <td className="px-5 py-4 whitespace-nowrap">
         <BudgetProgressBar percentage={campaign.dailySpentPercent} />
       </td>
-      <td className="px-5 py-4 text-gray-900">{campaign.totalSpentPercent}%</td>
-      <td className="px-5 py-4 text-gray-900 text-sm">
+      <td className="px-5 py-4 text-gray-900 whitespace-nowrap">
+        {campaign.totalSpentPercent}%
+      </td>
+      <td className="px-5 py-4 text-gray-900 text-sm whitespace-nowrap">
         {campaign.isHighIntent ? '고의도 학습자' : '모든 학습자'}
       </td>
     </tr>

--- a/frontend/src/3_features/campaignStats/ui/CampaignStatsTableRow.tsx
+++ b/frontend/src/3_features/campaignStats/ui/CampaignStatsTableRow.tsx
@@ -45,7 +45,7 @@ export function CampaignStatsTableRow({
   };
 
   return (
-    <tr className="text-base border-b border-gray-100">
+    <tr className="text-sm border-b border-gray-100">
       <td className="px-5 py-4 text-gray-900 font-semibold">
         {campaign.title}
       </td>
@@ -57,8 +57,8 @@ export function CampaignStatsTableRow({
         <BudgetProgressBar percentage={campaign.dailySpentPercent} />
       </td>
       <td className="px-5 py-4 text-gray-900">{campaign.totalSpentPercent}%</td>
-      <td className="px-5 py-4 text-gray-600 text-sm">
-        {campaign.isHighIntent ? '고의도 학습자 대상' : '모든 학습자 대상'}
+      <td className="px-5 py-4 text-gray-900 text-sm">
+        {campaign.isHighIntent ? '고의도 학습자' : '모든 학습자'}
       </td>
     </tr>
   );

--- a/frontend/src/3_features/keywordStats/index.ts
+++ b/frontend/src/3_features/keywordStats/index.ts
@@ -1,0 +1,4 @@
+export { KeywordStatsCard } from './ui/KeywordStatsCard';
+export { useKeywordStats } from './lib/useKeywordStats';
+export { LOW_CTR_THRESHOLD } from './lib/constants';
+export type { KeywordStats, SortKey, KeywordStatsResponse } from './lib/types';

--- a/frontend/src/3_features/keywordStats/index.ts
+++ b/frontend/src/3_features/keywordStats/index.ts
@@ -1,4 +1,4 @@
 export { KeywordStatsCard } from './ui/KeywordStatsCard';
 export { useKeywordStats } from './lib/useKeywordStats';
 export { LOW_CTR_THRESHOLD } from './lib/constants';
-export type { KeywordStats, SortKey, KeywordStatsResponse } from './lib/types';
+export type { KeywordStats, SortBy, KeywordStatsResponse } from './lib/types';

--- a/frontend/src/3_features/keywordStats/lib/constants.ts
+++ b/frontend/src/3_features/keywordStats/lib/constants.ts
@@ -1,0 +1,1 @@
+export const LOW_CTR_THRESHOLD = 10;

--- a/frontend/src/3_features/keywordStats/lib/types.ts
+++ b/frontend/src/3_features/keywordStats/lib/types.ts
@@ -1,11 +1,15 @@
 export interface KeywordStats {
   id: number;
   name: string;
-  avgImpressions: number;
-  avgClicks: number;
+  totalImpressions: number;
+  totalClicks: number;
   avgCtr: number;
 }
 
-export type SortKey = 'avgClicks' | 'avgImpressions' | 'avgCtr';
+export type SortBy = 'avgCtr' | 'totalImpressions' | 'totalClicks';
 
-export type KeywordStatsResponse = KeywordStats[];
+export interface KeywordStatsResponse {
+  total: number;
+  hasMore: boolean;
+  keywords: KeywordStats[];
+}

--- a/frontend/src/3_features/keywordStats/lib/types.ts
+++ b/frontend/src/3_features/keywordStats/lib/types.ts
@@ -1,0 +1,11 @@
+export interface KeywordStats {
+  id: number;
+  name: string;
+  avgImpressions: number;
+  avgClicks: number;
+  avgCtr: number;
+}
+
+export type SortKey = 'avgClicks' | 'avgImpressions' | 'avgCtr';
+
+export type KeywordStatsResponse = KeywordStats[];

--- a/frontend/src/3_features/keywordStats/lib/useKeywordStats.ts
+++ b/frontend/src/3_features/keywordStats/lib/useKeywordStats.ts
@@ -1,0 +1,40 @@
+import { useState, useEffect } from 'react';
+import { apiClient } from '@shared/lib/api';
+import type { KeywordStatsResponse, KeywordStats } from './types';
+
+interface UseKeywordStatsReturn {
+  keywords: KeywordStats[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+export function useKeywordStats(): UseKeywordStatsReturn {
+  const [keywords, setKeywords] = useState<KeywordStats[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchKeywords = async () => {
+      try {
+        setIsLoading(true);
+        setError(null);
+
+        const response = await apiClient<KeywordStatsResponse>(
+          '/api/advertiser/keywords/stats'
+        );
+
+        setKeywords(response);
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : '알 수 없는 오류가 발생했습니다';
+        setError(message);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchKeywords();
+  }, []);
+
+  return { keywords, isLoading, error };
+}

--- a/frontend/src/3_features/keywordStats/lib/useKeywordStats.ts
+++ b/frontend/src/3_features/keywordStats/lib/useKeywordStats.ts
@@ -1,29 +1,46 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { apiClient } from '@shared/lib/api';
-import type { KeywordStatsResponse, KeywordStats } from './types';
+import type { KeywordStatsResponse, KeywordStats, SortBy } from './types';
+
+const LIMIT = 6;
+
+interface UseKeywordStatsParams {
+  sortBy: SortBy;
+}
 
 interface UseKeywordStatsReturn {
   keywords: KeywordStats[];
   isLoading: boolean;
+  isLoadingMore: boolean;
   error: string | null;
+  hasMore: boolean;
+  loadMore: () => void;
 }
 
-export function useKeywordStats(): UseKeywordStatsReturn {
+export function useKeywordStats({
+  sortBy,
+}: UseKeywordStatsParams): UseKeywordStatsReturn {
   const [keywords, setKeywords] = useState<KeywordStats[]>([]);
+  const [page, setPage] = useState(1);
   const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(true);
 
+  // 초기 로딩되거나 정렬 변경 시에 실행
   useEffect(() => {
     const fetchKeywords = async () => {
       try {
         setIsLoading(true);
         setError(null);
+        setPage(1);
 
         const response = await apiClient<KeywordStatsResponse>(
-          '/api/advertiser/keywords/stats'
+          `/api/advertiser/keywords/stats?sortBy=${sortBy}&order=desc&limit=${LIMIT}&offset=0`
         );
 
-        setKeywords(response);
+        setKeywords(response.keywords);
+        setHasMore(response.hasMore);
       } catch (err) {
         const message =
           err instanceof Error ? err.message : '알 수 없는 오류가 발생했습니다';
@@ -34,7 +51,32 @@ export function useKeywordStats(): UseKeywordStatsReturn {
     };
 
     fetchKeywords();
-  }, []);
+  }, [sortBy]);
 
-  return { keywords, isLoading, error };
+  // 스크롤이 카드 끝에 도달해 정보를 더 불러올 때 실행
+  const loadMore = useCallback(async () => {
+    if (isLoadingMore || !hasMore) return;
+
+    try {
+      setIsLoadingMore(true);
+      const nextPage = page + 1;
+      const offset = page * LIMIT;
+
+      const response = await apiClient<KeywordStatsResponse>(
+        `/api/advertiser/keywords/stats?sortBy=${sortBy}&order=desc&limit=${LIMIT}&offset=${offset}`
+      );
+
+      setKeywords((prev) => [...prev, ...response.keywords]);
+      setPage(nextPage);
+      setHasMore(response.hasMore);
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : '알 수 없는 오류가 발생했습니다';
+      setError(message);
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }, [sortBy, page, isLoadingMore, hasMore]);
+
+  return { keywords, isLoading, isLoadingMore, error, hasMore, loadMore };
 }

--- a/frontend/src/3_features/keywordStats/ui/KeywordStatsCard.tsx
+++ b/frontend/src/3_features/keywordStats/ui/KeywordStatsCard.tsx
@@ -1,0 +1,68 @@
+import { useState, useMemo } from 'react';
+import type { KeywordStats, SortKey } from '../lib/types';
+import { KeywordStatsHeader } from './KeywordStatsHeader';
+import { KeywordStatsItem } from './KeywordStatsItem';
+
+// Mock 데이터 (API 연동 시 삭제)
+const mockKeywords: KeywordStats[] = [
+  { id: 1, name: 'Python', avgImpressions: 521, avgClicks: 98, avgCtr: 18.5 },
+  { id: 2, name: 'Django', avgImpressions: 411, avgClicks: 60, avgCtr: 14.6 },
+  { id: 3, name: 'React', avgImpressions: 380, avgClicks: 45, avgCtr: 11.8 },
+  { id: 4, name: 'AWS', avgImpressions: 320, avgClicks: 21, avgCtr: 6.5 },
+  { id: 5, name: 'Node.js', avgImpressions: 290, avgClicks: 35, avgCtr: 12.1 },
+  {
+    id: 6,
+    name: 'TypeScript',
+    avgImpressions: 250,
+    avgClicks: 18,
+    avgCtr: 7.2,
+  },
+];
+
+export function KeywordStatsCard() {
+  // TODO: API 연동 시 useKeywordStats 사용할 것!
+  // const { keywords, isLoading, error } = useKeywordStats();
+  const keywords = mockKeywords;
+  const isLoading = false;
+  const error = null;
+
+  const [sortKey, setSortKey] = useState<SortKey>('avgCtr');
+
+  const sortedKeywords = useMemo(() => {
+    return [...keywords].sort((a, b) => b[sortKey] - a[sortKey]);
+  }, [keywords, sortKey]);
+
+  if (isLoading) {
+    return (
+      <div className="text-gray-600 flex flex-col bg-white border border-gray-200 rounded-xl shadow">
+        <KeywordStatsHeader sortKey={sortKey} onSortChange={setSortKey} />
+        <div className="p-10 text-center text-gray-500">로딩 중...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="text-gray-600 flex flex-col bg-white border border-gray-200 rounded-xl shadow">
+        <KeywordStatsHeader sortKey={sortKey} onSortChange={setSortKey} />
+        <div className="p-10 text-center text-red-500">{error}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="text-gray-600 flex flex-col bg-white border border-gray-200 rounded-xl shadow">
+      <KeywordStatsHeader sortKey={sortKey} onSortChange={setSortKey} />
+
+      <div className="p-4 flex flex-col gap-2 max-h-72 overflow-y-auto">
+        {sortedKeywords.map((keyword, index) => (
+          <KeywordStatsItem
+            key={keyword.id}
+            keyword={keyword}
+            rank={index + 1}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/3_features/keywordStats/ui/KeywordStatsCard.tsx
+++ b/frontend/src/3_features/keywordStats/ui/KeywordStatsCard.tsx
@@ -1,67 +1,218 @@
-import { useState, useMemo } from 'react';
-import type { KeywordStats, SortKey } from '../lib/types';
+import { useState, useRef, useCallback } from 'react';
+import type { KeywordStats, SortBy } from '../lib/types';
+// import { useKeywordStats } from '../lib/useKeywordStats';
 import { KeywordStatsHeader } from './KeywordStatsHeader';
 import { KeywordStatsItem } from './KeywordStatsItem';
 
 // Mock 데이터 (API 연동 시 삭제)
-const mockKeywords: KeywordStats[] = [
-  { id: 1, name: 'Python', avgImpressions: 521, avgClicks: 98, avgCtr: 18.5 },
-  { id: 2, name: 'Django', avgImpressions: 411, avgClicks: 60, avgCtr: 14.6 },
-  { id: 3, name: 'React', avgImpressions: 380, avgClicks: 45, avgCtr: 11.8 },
-  { id: 4, name: 'AWS', avgImpressions: 320, avgClicks: 21, avgCtr: 6.5 },
-  { id: 5, name: 'Node.js', avgImpressions: 290, avgClicks: 35, avgCtr: 12.1 },
+const allMockKeywords: KeywordStats[] = [
+  {
+    id: 1,
+    name: 'Python',
+    totalImpressions: 521,
+    totalClicks: 98,
+    avgCtr: 18.5,
+  },
+  {
+    id: 2,
+    name: 'Django',
+    totalImpressions: 411,
+    totalClicks: 60,
+    avgCtr: 14.6,
+  },
+  {
+    id: 3,
+    name: 'React',
+    totalImpressions: 380,
+    totalClicks: 45,
+    avgCtr: 11.8,
+  },
+  { id: 4, name: 'AWS', totalImpressions: 320, totalClicks: 21, avgCtr: 6.5 },
+  {
+    id: 5,
+    name: 'Node.js',
+    totalImpressions: 290,
+    totalClicks: 35,
+    avgCtr: 12.1,
+  },
   {
     id: 6,
     name: 'TypeScript',
-    avgImpressions: 250,
-    avgClicks: 18,
+    totalImpressions: 250,
+    totalClicks: 18,
     avgCtr: 7.2,
+  },
+  {
+    id: 7,
+    name: 'JavaScript',
+    totalImpressions: 480,
+    totalClicks: 72,
+    avgCtr: 15.0,
+  },
+  { id: 8, name: 'Go', totalImpressions: 200, totalClicks: 28, avgCtr: 14.0 },
+  { id: 9, name: 'Rust', totalImpressions: 150, totalClicks: 12, avgCtr: 8.0 },
+  {
+    id: 10,
+    name: 'Java',
+    totalImpressions: 350,
+    totalClicks: 42,
+    avgCtr: 12.0,
+  },
+  {
+    id: 11,
+    name: 'Kotlin',
+    totalImpressions: 180,
+    totalClicks: 15,
+    avgCtr: 8.3,
+  },
+  {
+    id: 12,
+    name: 'Swift',
+    totalImpressions: 220,
+    totalClicks: 30,
+    avgCtr: 13.6,
+  },
+  {
+    id: 13,
+    name: 'Flutter',
+    totalImpressions: 170,
+    totalClicks: 14,
+    avgCtr: 8.2,
+  },
+  {
+    id: 14,
+    name: 'Docker',
+    totalImpressions: 300,
+    totalClicks: 38,
+    avgCtr: 12.7,
+  },
+  {
+    id: 15,
+    name: 'Kubernetes',
+    totalImpressions: 140,
+    totalClicks: 10,
+    avgCtr: 7.1,
+  },
+  {
+    id: 16,
+    name: 'GraphQL',
+    totalImpressions: 160,
+    totalClicks: 13,
+    avgCtr: 8.1,
+  },
+  {
+    id: 17,
+    name: 'MongoDB',
+    totalImpressions: 190,
+    totalClicks: 22,
+    avgCtr: 11.6,
+  },
+  {
+    id: 18,
+    name: 'PostgreSQL',
+    totalImpressions: 210,
+    totalClicks: 25,
+    avgCtr: 11.9,
   },
 ];
 
+const LIMIT = 6;
+
+// Mock: 정렬 후 페이지네이션을 위한 코드 (API 연동 시 삭제)
+function getMockKeywords(sortBy: SortBy, offset: number, limit: number) {
+  const sorted = [...allMockKeywords].sort((a, b) => b[sortBy] - a[sortBy]);
+  return sorted.slice(offset, offset + limit);
+}
+
 export function KeywordStatsCard() {
+  const [sortBy, setSortBy] = useState<SortBy>('avgCtr');
+  const [keywords, setKeywords] = useState<KeywordStats[]>(() =>
+    getMockKeywords('avgCtr', 0, LIMIT)
+  );
+  const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
   // TODO: API 연동 시 useKeywordStats 사용할 것!
-  // const { keywords, isLoading, error } = useKeywordStats();
-  const keywords = mockKeywords;
-  const isLoading = false;
-  const error = null;
+  // const { keywords, isLoading, isLoadingMore, error, hasMore, loadMore } = useKeywordStats({ sortBy });
 
-  const [sortKey, setSortKey] = useState<SortKey>('avgCtr');
+  const handleSortChange = useCallback((newSortBy: SortBy) => {
+    setSortBy(newSortBy);
+    setIsLoading(true);
 
-  const sortedKeywords = useMemo(() => {
-    return [...keywords].sort((a, b) => b[sortKey] - a[sortKey]);
-  }, [keywords, sortKey]);
+    // Mock: 정렬 변경을  위한 코드 (API 연동 시 삭제)
+    setTimeout(() => {
+      setKeywords(getMockKeywords(newSortBy, 0, LIMIT));
+      setHasMore(allMockKeywords.length > LIMIT);
+      setIsLoading(false);
+    }, 300);
+  }, []);
+
+  const handleScroll = useCallback(() => {
+    if (!scrollRef.current || isLoadingMore || !hasMore) return;
+
+    const { scrollTop, scrollHeight, clientHeight } = scrollRef.current;
+    const isNearBottom = scrollTop + clientHeight >= scrollHeight - 10;
+
+    if (isNearBottom) {
+      setIsLoadingMore(true);
+
+      // Mock: 추가 로딩을 위한 코드 (API 연동 시 삭제)
+      setTimeout(() => {
+        const currentLength = keywords.length;
+        const newKeywords = getMockKeywords(sortBy, currentLength, LIMIT);
+
+        if (newKeywords.length > 0) {
+          setKeywords((prev) => [...prev, ...newKeywords]);
+          setHasMore(
+            currentLength + newKeywords.length < allMockKeywords.length
+          );
+        } else {
+          setHasMore(false);
+        }
+        setIsLoadingMore(false);
+      }, 500);
+    }
+  }, [isLoadingMore, hasMore, keywords.length, sortBy]);
 
   if (isLoading) {
     return (
       <div className="text-gray-600 flex flex-col bg-white border border-gray-200 rounded-xl shadow">
-        <KeywordStatsHeader sortKey={sortKey} onSortChange={setSortKey} />
+        <KeywordStatsHeader sortBy={sortBy} onSortChange={handleSortChange} />
         <div className="p-10 text-center text-gray-500">로딩 중...</div>
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="text-gray-600 flex flex-col bg-white border border-gray-200 rounded-xl shadow">
-        <KeywordStatsHeader sortKey={sortKey} onSortChange={setSortKey} />
-        <div className="p-10 text-center text-red-500">{error}</div>
       </div>
     );
   }
 
   return (
     <div className="text-gray-600 flex flex-col bg-white border border-gray-200 rounded-xl shadow">
-      <KeywordStatsHeader sortKey={sortKey} onSortChange={setSortKey} />
+      <KeywordStatsHeader sortBy={sortBy} onSortChange={handleSortChange} />
 
-      <div className="p-4 flex flex-col gap-2 max-h-72 overflow-y-auto">
-        {sortedKeywords.map((keyword, index) => (
+      <div
+        ref={scrollRef}
+        onScroll={handleScroll}
+        className="p-4 flex flex-col gap-2 max-h-72 overflow-y-auto"
+      >
+        {keywords.map((keyword, index) => (
           <KeywordStatsItem
             key={keyword.id}
             keyword={keyword}
             rank={index + 1}
           />
         ))}
+
+        {isLoadingMore && (
+          <div className="py-2 text-center text-sm text-gray-500">
+            로딩 중...
+          </div>
+        )}
+
+        {!hasMore && keywords.length > 0 && (
+          <div className="py-2 text-center text-xs text-gray-400">
+            모든 키워드를 불러왔습니다
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/3_features/keywordStats/ui/KeywordStatsHeader.tsx
+++ b/frontend/src/3_features/keywordStats/ui/KeywordStatsHeader.tsx
@@ -1,0 +1,72 @@
+import { useState, useRef, useEffect } from 'react';
+import type { SortKey } from '../lib/types';
+import { Icon } from '@shared/ui/Icon';
+
+interface KeywordStatsHeaderProps {
+  sortKey: SortKey;
+  onSortChange: (key: SortKey) => void;
+}
+
+const SORT_OPTIONS: { key: SortKey; label: string }[] = [
+  { key: 'avgCtr', label: 'CTR순' },
+  { key: 'avgClicks', label: '클릭수순' },
+  { key: 'avgImpressions', label: '노출수순' },
+];
+
+export function KeywordStatsHeader({
+  sortKey,
+  onSortChange,
+}: KeywordStatsHeaderProps) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // 메뉴 외부 클릭 시 닫는 로직
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setIsMenuOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const handleSortSelect = (key: SortKey) => {
+    onSortChange(key);
+    setIsMenuOpen(false);
+  };
+
+  return (
+    <div className="p-5 flex flex-row justify-between items-center border-b border-gray-100">
+      <h2 className="text-gray-900 text-xl font-bold">키워드 성과</h2>
+
+      <div className="relative" ref={menuRef}>
+        <button
+          onClick={() => setIsMenuOpen(!isMenuOpen)}
+          className="p-1 hover:bg-gray-100 rounded-lg"
+        >
+          <Icon.More className="w-5 h-5 text-gray-500" />
+        </button>
+
+        {isMenuOpen && (
+          <div className="absolute right-0 top-full mt-1 bg-white border border-gray-200 rounded-lg shadow-lg z-10 min-w-30">
+            {SORT_OPTIONS.map((option) => (
+              <button
+                key={option.key}
+                onClick={() => handleSortSelect(option.key)}
+                className={`w-full px-4 py-2 text-left text-sm hover:bg-gray-50 first:rounded-t-lg last:rounded-b-lg ${
+                  sortKey === option.key
+                    ? 'text-blue-500 font-semibold'
+                    : 'text-gray-700'
+                }`}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/3_features/keywordStats/ui/KeywordStatsHeader.tsx
+++ b/frontend/src/3_features/keywordStats/ui/KeywordStatsHeader.tsx
@@ -1,20 +1,20 @@
 import { useState, useRef, useEffect } from 'react';
-import type { SortKey } from '../lib/types';
+import type { SortBy } from '../lib/types';
 import { Icon } from '@shared/ui/Icon';
 
 interface KeywordStatsHeaderProps {
-  sortKey: SortKey;
-  onSortChange: (key: SortKey) => void;
+  sortBy: SortBy;
+  onSortChange: (key: SortBy) => void;
 }
 
-const SORT_OPTIONS: { key: SortKey; label: string }[] = [
+const SORT_OPTIONS: { key: SortBy; label: string }[] = [
   { key: 'avgCtr', label: 'CTR순' },
-  { key: 'avgClicks', label: '클릭수순' },
-  { key: 'avgImpressions', label: '노출수순' },
+  { key: 'totalClicks', label: '클릭수순' },
+  { key: 'totalImpressions', label: '노출수순' },
 ];
 
 export function KeywordStatsHeader({
-  sortKey,
+  sortBy,
   onSortChange,
 }: KeywordStatsHeaderProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -32,7 +32,7 @@ export function KeywordStatsHeader({
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
-  const handleSortSelect = (key: SortKey) => {
+  const handleSortSelect = (key: SortBy) => {
     onSortChange(key);
     setIsMenuOpen(false);
   };
@@ -56,7 +56,7 @@ export function KeywordStatsHeader({
                 key={option.key}
                 onClick={() => handleSortSelect(option.key)}
                 className={`w-full px-4 py-2 text-left text-sm hover:bg-gray-50 first:rounded-t-lg last:rounded-b-lg ${
-                  sortKey === option.key
+                  sortBy === option.key
                     ? 'text-blue-500 font-semibold'
                     : 'text-gray-700'
                 }`}

--- a/frontend/src/3_features/keywordStats/ui/KeywordStatsItem.tsx
+++ b/frontend/src/3_features/keywordStats/ui/KeywordStatsItem.tsx
@@ -37,10 +37,10 @@ export function KeywordStatsItem({ keyword, rank }: KeywordStatsItemProps) {
             <span className="text-gray-900">{keyword.avgCtr.toFixed(1)}%</span>
           </span>
           <span className="text-gray-500">
-            노출 <span className="text-gray-900">{keyword.avgImpressions}</span>
+            노출 <span className="text-gray-900">{keyword.totalImpressions}</span>
           </span>
           <span className="text-gray-500">
-            클릭 <span className="text-gray-900">{keyword.avgClicks}</span>
+            클릭 <span className="text-gray-900">{keyword.totalClicks}</span>
           </span>
         </div>
       </div>

--- a/frontend/src/3_features/keywordStats/ui/KeywordStatsItem.tsx
+++ b/frontend/src/3_features/keywordStats/ui/KeywordStatsItem.tsx
@@ -1,0 +1,51 @@
+import type { KeywordStats } from '../lib/types';
+import { LOW_CTR_THRESHOLD } from '../lib/constants';
+import { Icon } from '@shared/ui/Icon';
+
+interface KeywordStatsItemProps {
+  keyword: KeywordStats;
+  rank: number;
+}
+
+export function KeywordStatsItem({ keyword, rank }: KeywordStatsItemProps) {
+  const isLowCtr = keyword.avgCtr < LOW_CTR_THRESHOLD;
+
+  return (
+    <div
+      className={`flex flex-row items-center justify-between px-4 py-3 rounded-lg border ${
+        isLowCtr ? 'bg-red-100 border-red-300' : 'bg-gray-50 border-gray-200'
+      }`}
+    >
+      <div className="flex flex-col gap-1">
+        <div className="flex flex-row items-center gap-1.5">
+          <span className="text-sm font-semibold text-gray-900">
+            {keyword.name}
+          </span>
+          <Icon.Circle
+            className={`w-2 h-2 ${isLowCtr ? 'text-red-700' : 'text-green-500'}`}
+          />
+          {isLowCtr && (
+            <span className="px-1.5 py-0.5 bg-white border border-red-500 rounded text-xs font-semibold text-red-700">
+              제거권장
+            </span>
+          )}
+        </div>
+
+        <div className="flex flex-row items-center gap-2 text-xs">
+          <span className="text-gray-500">
+            CTR{' '}
+            <span className="text-gray-900">{keyword.avgCtr.toFixed(1)}%</span>
+          </span>
+          <span className="text-gray-500">
+            노출 <span className="text-gray-900">{keyword.avgImpressions}</span>
+          </span>
+          <span className="text-gray-500">
+            클릭 <span className="text-gray-900">{keyword.avgClicks}</span>
+          </span>
+        </div>
+      </div>
+
+      <span className="text-sm font-bold text-gray-900">{rank}위</span>
+    </div>
+  );
+}

--- a/frontend/src/3_features/realtimeBids/ui/RealtimeBidsTableHeader.tsx
+++ b/frontend/src/3_features/realtimeBids/ui/RealtimeBidsTableHeader.tsx
@@ -2,23 +2,27 @@ export function RealtimeBidsTableHeader() {
   return (
     <thead className="bg-gray-50 text-sm">
       <tr>
-        <th className="px-5 py-3 text-left font-medium text-gray-600">시간</th>
-        <th className="px-5 py-3 text-left font-medium text-gray-600">
+        <th className="px-5 py-3 text-left font-medium text-gray-600 whitespace-nowrap">
+          시간
+        </th>
+        <th className="px-5 py-3 text-left font-medium text-gray-600 whitespace-nowrap">
           캠페인
         </th>
-        <th className="px-5 py-3 text-left font-medium text-gray-600">
+        <th className="px-5 py-3 text-left font-medium text-gray-600 whitespace-nowrap">
           블로그
         </th>
-        <th className="px-5 py-3 text-left font-medium text-gray-600">
+        <th className="px-5 py-3 text-left font-medium text-gray-600 whitespace-nowrap">
           나의 입찰
         </th>
-        <th className="px-5 py-3 text-left font-medium text-gray-600">
+        <th className="px-5 py-3 text-left font-medium text-gray-600 whitespace-nowrap">
           낙찰가
         </th>
-        <th className="px-5 py-3 text-left font-medium text-gray-600">
+        <th className="px-5 py-3 text-left font-medium text-gray-600 whitespace-nowrap">
           결정 결과 / INSIGHT
         </th>
-        <th className="px-5 py-3 text-left font-medium text-gray-600">결과</th>
+        <th className="px-5 py-3 text-left font-medium text-gray-600 whitespace-nowrap">
+          결과
+        </th>
       </tr>
     </thead>
   );

--- a/frontend/src/3_features/realtimeBids/ui/RealtimeBidsTableRow.tsx
+++ b/frontend/src/3_features/realtimeBids/ui/RealtimeBidsTableRow.tsx
@@ -23,11 +23,13 @@ export function RealtimeBidsTableRow({ bid }: RealtimeBidsTableRowProps) {
     <tr
       className={`text-sm border-b border-gray-100 ${bid.isWon ? 'bg-green-100/30' : ''}`}
     >
-      <td className="px-5 py-4 text-gray-900">{formatTime(bid.timestamp)}</td>
+      <td className="px-5 py-4 text-gray-900 whitespace-nowrap">
+        {formatTime(bid.timestamp)}
+      </td>
       <td className="px-5 py-4 text-gray-900 font-semibold">
         {bid.campaignTitle}
       </td>
-      <td className="px-5 py-4">
+      <td className="px-5 py-4 whitespace-nowrap">
         {bid.blogDomain ? (
           <a
             href={`https://${bid.blogDomain}`}
@@ -42,23 +44,23 @@ export function RealtimeBidsTableRow({ bid }: RealtimeBidsTableRowProps) {
         )}
       </td>
       <td
-        className={`px-5 py-4 ${bid.isWon ? 'text-green-500' : 'text-gray-600'}`}
+        className={`px-5 py-4 whitespace-nowrap ${bid.isWon ? 'text-green-500' : 'text-gray-600'}`}
       >
         {formatAmount(bid.bidAmount)}
       </td>
       <td
-        className={`px-5 py-4 font-semibold ${bid.isWon ? 'text-green-500' : 'text-gray-900'}`}
+        className={`px-5 py-4 font-semibold whitespace-nowrap ${bid.isWon ? 'text-green-500' : 'text-gray-900'}`}
       >
         {formatAmount(bid.winAmount)}
       </td>
-      <td className="px-5 py-4">
+      <td className="px-5 py-4 whitespace-nowrap">
         <div className="text-gray-900 text-sm">
           {bid.isHighIntent
             ? `고의도 학습자 - ${bid.behaviorScore}점 학습자`
             : '모든 학습자'}
         </div>
       </td>
-      <td className="px-5 py-4">
+      <td className="px-5 py-4 whitespace-nowrap">
         {bid.isWon ? (
           <div className="flex flex-row items-center gap-1 px-1.5 py-0.5 bg-green-100 border border-green-300 rounded-lg text-xs font-semibold text-green-500 w-fit">
             <Icon.Circle className="w-3 h-3 text-green-500" />

--- a/frontend/src/3_features/realtimeBids/ui/RealtimeBidsTableRow.tsx
+++ b/frontend/src/3_features/realtimeBids/ui/RealtimeBidsTableRow.tsx
@@ -21,9 +21,9 @@ export function RealtimeBidsTableRow({ bid }: RealtimeBidsTableRowProps) {
 
   return (
     <tr
-      className={`text-base border-b border-gray-100 ${bid.isWon ? 'bg-green-100/30' : ''}`}
+      className={`text-sm border-b border-gray-100 ${bid.isWon ? 'bg-green-100/30' : ''}`}
     >
-      <td className="px-5 py-4 text-gray-600">{formatTime(bid.timestamp)}</td>
+      <td className="px-5 py-4 text-gray-900">{formatTime(bid.timestamp)}</td>
       <td className="px-5 py-4 text-gray-900 font-semibold">
         {bid.campaignTitle}
       </td>
@@ -52,10 +52,10 @@ export function RealtimeBidsTableRow({ bid }: RealtimeBidsTableRowProps) {
         {formatAmount(bid.winAmount)}
       </td>
       <td className="px-5 py-4">
-        <div className="text-gray-600 text-sm">
+        <div className="text-gray-900 text-sm">
           {bid.isHighIntent
-            ? `고의도 학습자 대상 - ${bid.behaviorScore}점 학습자`
-            : '모든 학습자 대상'}
+            ? `고의도 학습자 - ${bid.behaviorScore}점 학습자`
+            : '모든 학습자'}
         </div>
       </td>
       <td className="px-5 py-4">

--- a/frontend/src/4_shared/ui/Sidebar/Sidebar.tsx
+++ b/frontend/src/4_shared/ui/Sidebar/Sidebar.tsx
@@ -58,17 +58,15 @@ export function Sidebar() {
 
   return (
     <aside
-      className="flex flex-col w-64 shrink-0 bg-white border-r border-gray-200"
+      className="flex flex-col w-52 shrink-0 bg-white border-r border-gray-200"
       role="navigation"
       aria-label="Main navigation"
     >
-      {/* 로고 영역 */}
       <header className="flex flex-row h-16 items-center gap-3 py-4 px-6 border-b border-gray-200 text-gray-900 text-lg font-bold">
         <Icon.Logo className="w-8 h-8 text-blue-500" />
         BoostAD
       </header>
 
-      {/* 네비게이션 메뉴 */}
       <nav className="p-4">
         <ul className="flex flex-col gap-1">
           {menuItems.map((item) => {


### PR DESCRIPTION
<!-- PR 제목 예시 : [Feat] 로그인 기능 구현 -->
<!-- PR 제목은 위 형식을 참고하여 작성해주세요. -->
<!-- 필요 없는 내용은 지우고 작성해주세요 -->

## 🔗 관련 이슈

- close: #44 

---

## ✅ 작업 내용
이번 PR에서는 광고주 대시보드에 키워드 성과 카드 UI를 추가하고,
기존 대시보드 전반의 레이아웃을 개선했습니다.

### 📌 검토 파일
**주요 검토 파일:**
* `frontend/src/3_features/keywordStats/*`
  * 키워드 성과 통계 관련 타입, 상수, 커스텀 훅, UI 컴포넌트 전반 (무한 스크롤 및 정렬 포함)
* `frontend/src/2_pages/advertiserDashboard/ui/AdvertiserDashboardPage.tsx`
  * 대시보드 내 키워드 성과 카드 배치 및 레이아웃 수정
* `frontend/src/4_shared/ui/Sidebar/Sidebar.tsx`
  * 사이드바 너비 축소 및 스타일 수정

**참고용:**
* `frontend/src/3_features/campaignStats/ui/*`
  * 테이블 가독성 개선 및 프로그레스 바 스타일 수정
* `frontend/src/3_features/realtimeBids/ui/*`
  * 테이블 데이터 줄바꿈 방지 및 텍스트 크기 조정

## 1️⃣ 키워드 성과(KeywordStats) 기능 구현
### 변경 사항
* **타입 및 상수 정의**: `KeywordStats`, `SortBy` 타입을 정의하고, 
제거권장 기준인 `LOW_CTR_THRESHOLD(10%)`를 상수로 분리했습니다.
* **커스텀 훅(`useKeywordStats`)**:
  * API 명세(totalImpressions, totalClicks 등)에 맞춰 구현했습니다.
  * 무한 스크롤(Pagination)로 데이터를 더 불러오는 형식이며, 정렬 조건(`SortBy`) 변경 시 데이터를 새로 불러옵니다.

* **UI 컴포넌트**:
* `KeywordStatsCard`: 카드 컨테이너 및 무한 스크롤 가상 구현(현재 Mock 데이터 사용).
* `KeywordStatsHeader`: 정렬기능(CTR/클릭수/노출수) 제공.
* `KeywordStatsItem`: 키워드별 지표수치 정보를 담는 컴포넌트. 
특히 **CTR 10% 미만 키워드**는 빨간 배경과 '제거권장' 태그를 노출하도록 구현.

## 2️⃣ 대시보드 레이아웃 및 스타일 최적화
### 변경 배경
다양한 지표를 한 화면에 효율적으로 보여주기 위해 콘텐츠 영역을 넓히고 사이드 바영역을 조금 줄였습니다.

### 변경 사항
* **사이드바**: 너비를 `w-64`에서 `w-52`로 축소.
* **대시보드 구성**: `실시간 입찰(RealtimeBids)`과 `키워드 성과(KeywordStats)`를 가로(`flex-row`)로 배치하여 공간 활용도를 높였습니다.
* **라우팅 설정**: 작업 편의를 위해 임시로 기본 경로(`/`) 접속 시 광고주 대시보드로 리다이렉트되도록 수정.

## 3️⃣ 테이블 가독성 및 가로 깨짐 방지
### 주요 UI 포인트
* **줄바꿈 방지(`whitespace-nowrap`) 적용**: `RealtimeBids` 및 `CampaignStats` 테이블의 헤더와 로우에 적용하여 텍스트가 겹치거나 잘리는 현상이 있어서 추가햇습니다.
* **컴포넌트 보호**: `BudgetProgressBar`에 `shrink-0`을 적용하여 좁은 화면에서도 형태가 유지되도록 했습니다.

## 📸 스크린샷 / 데모 (옵션)

<!-- UI 변경사항이나 새로운 기능의 동작을 시각적으로 보여주세요. -->

---

## 🧪 테스트 방법 (옵션)

<!-- 리뷰어가 기능을 테스트할 수 있도록 구체적인 테스트 방법을 설명해주세요. -->


1. `/advertiser/dashboard` 접속 확인
2. **키워드 성과 카드** 테스트:
* 우측 상단 더보기 버튼 클릭 시 정렬 메뉴 노출 확인
* 스크롤 시 무한 스크롤 동작 확인 (Mock 데이터)
* CTR 10% 미만 키워드가 빨간색으로 강조되는지 확인

---

## 💬 To Reviewers
* 현재 `KeywordStatsCard` 내에서 API 연동 부분은 주석 처리되어 있으며, 테스트를 위해 Mock 데이터를 사용하고 있습니다. 로직 검토 부탁드립니다...!

### 🔄 추후 작업 필요
* 실제 광고주 키워드 성과 API 연동
* 무한 스크롤 시 API 연동도 확인
