### PR TITLE
[Refactor] 데이터형 라우터 적용

### DIFF
--- a/frontend/src/1_app/providers/RouterProvider.tsx
+++ b/frontend/src/1_app/providers/RouterProvider.tsx
@@ -1,19 +1,24 @@
 import { lazy, Suspense } from 'react';
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import {
+  // BrowserRouter,
+  // Routes,
+  // Route,
+  // Navigate,
+  createBrowserRouter,
+} from 'react-router-dom';
 import { DashboardLayout, OnboardingLayout } from '@app/layouts';
 import { AdvertiserDashboardPage } from '@pages/advertiserDashboard';
 import { AdvertiserCampaignsPage } from '@pages/advertiserCampaigns';
 import { AdvertiserBudgetPage } from '@pages/advertiserBudget';
 import { NotFoundPage } from '@pages/notFound';
-import { RegisterPage } from '@/2_pages/auth/ui/RegisterPage';
-import { LoginPage } from '@/2_pages/auth/ui/LoginPage';
+import { RegisterPage } from '@pages/auth/ui/RegisterPage';
+import { LoginPage } from '@pages/auth/ui/LoginPage';
 import { PublisherDashboardPage } from '@pages/publisherDashboard';
 import { PublisherEarningsPage } from '@pages/publisherEarnings';
 import { PublisherSettingsPage } from '@pages/publisherSettings';
 import { OnboardingSdkGuidePageSkeleton } from '@pages/onboardingSdkGuide';
 import { CampaignCreatePage } from '@pages/campaginCreate';
-import { BlogAdmissionPage } from '@/2_pages/onboardingBlogAdmission/ui/BlogAdmissionPage';
-// import { RoleSelectPage } from '@/2_pages/onboardingRoleSelect/ui/_RoleSelectPage';
+import { BlogAdmissionPage } from '@pages/onboardingBlogAdmission/ui/BlogAdmissionPage';
 
 const OnboardingSdkGuidePage = lazy(() =>
   import('@pages/onboardingSdkGuide').then((m) => ({
@@ -21,58 +26,135 @@ const OnboardingSdkGuidePage = lazy(() =>
   }))
 );
 
-export function RouterProvider() {
-  return (
-    <BrowserRouter>
-      <Routes>
-        <Route
-          path="/"
-          element={<Navigate to="/publisher/dashboard" replace />}
-        />
+export const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <OnboardingLayout />,
+    children: [
+      { index: true, element: <LoginPage /> }, // 추후에 메인페이지 넣으면 될듯합니다.
+      {
+        path: 'auth/login',
+        element: <LoginPage />,
+      },
+      {
+        path: 'auth/register',
+        element: <RegisterPage />,
+      },
+      {
+        path: 'publisher/onboarding/sdk-guide',
+        element: (
+          <Suspense fallback={<OnboardingSdkGuidePageSkeleton />}>
+            <OnboardingSdkGuidePage />
+          </Suspense>
+        ),
+      },
+      {
+        path: 'publisher/onboarding/blog-admission',
+        element: <BlogAdmissionPage />,
+      },
+      {
+        path: 'advertiser/campaign-create',
+        element: <CampaignCreatePage />,
+      },
+    ],
+  },
+  {
+    path: '/publisher',
+    element: <DashboardLayout />,
+    children: [
+      {
+        path: 'dashboard',
+        element: <PublisherDashboardPage />,
+      },
+      {
+        path: 'earnings',
+        element: <PublisherEarningsPage />,
+      },
+      {
+        path: 'settings',
+        element: <PublisherSettingsPage />,
+      },
+    ],
+  },
+  {
+    path: '/advertiser',
+    element: <DashboardLayout />,
+    children: [
+      {
+        path: 'dashboard',
+        element: <AdvertiserDashboardPage />,
+      },
+      {
+        path: 'campaigns',
+        element: <AdvertiserCampaignsPage />,
+      },
+      {
+        path: 'budget',
+        element: <AdvertiserBudgetPage />,
+      },
+    ],
+  },
+  {
+    path: '*',
+    element: <NotFoundPage />,
+  },
+]);
 
-        <Route element={<OnboardingLayout />}>
-          <Route
-            path="/publisher/onboarding/sdk-guide"
-            element={
-              <Suspense fallback={<OnboardingSdkGuidePageSkeleton />}>
-                <OnboardingSdkGuidePage />
-              </Suspense>
-            }
-          />
-          <Route path="/auth/register" element={<RegisterPage />} />
-          <Route path="/auth/login" element={<LoginPage />} />
-          <Route path="/publisher/onboarding/blog-admission" element={<BlogAdmissionPage/>} />
-          <Route
-            path="/advertiser/campaign-create"
-            element={<CampaignCreatePage />}
-          />
-        </Route>
+// export function RouterProvider() {
+//   return (
+//     <BrowserRouter>
+//       <Routes>
+//         <Route
+//           path="/"
+//           element={<Navigate to="/publisher/dashboard" replace />}
+//         />
 
-        <Route element={<DashboardLayout />}>
-          <Route
-            path="/advertiser/dashboard"
-            element={<AdvertiserDashboardPage />}
-          />
-          <Route
-            path="/advertiser/campaigns"
-            element={<AdvertiserCampaignsPage />}
-          />
-          <Route path="/advertiser/budget" element={<AdvertiserBudgetPage />} />
-          <Route
-            path="/publisher/dashboard"
-            element={<PublisherDashboardPage />}
-          />
-          <Route
-            path="/publisher/earnings"
-            element={<PublisherEarningsPage />}
-          />
-          <Route
-            path="/publisher/settings"
-            element={<PublisherSettingsPage />}
-          />
-        </Route>
-        <Route path="*" element={<NotFoundPage />} />
-      </Routes>
-    </BrowserRouter>
-  );
-}
+//         <Route element={<OnboardingLayout />}>
+//           <Route
+//             path="/publisher/onboarding/sdk-guide"
+//             element={
+//               <Suspense fallback={<OnboardingSdkGuidePageSkeleton />}>
+//                 <OnboardingSdkGuidePage />
+//               </Suspense>
+//             }
+//           />
+//           <Route path="/auth/register" element={<RegisterPage />} />
+//           <Route path="/auth/login" element={<LoginPage />} />
+//           <Route
+//             path="/publisher/onboarding/blog-admission"
+//             element={<BlogAdmissionPage />}
+//           />
+//           <Route
+//             path="/advertiser/campaign-create"
+//             element={<CampaignCreatePage />}
+//           />
+//         </Route>
+
+//         <Route element={<DashboardLayout />}>
+//           <Route
+//             path="/advertiser/dashboard"
+//             element={<AdvertiserDashboardPage />}
+//           />
+//           <Route
+//             path="/advertiser/campaigns"
+//             element={<AdvertiserCampaignsPage />}
+//           />
+//           <Route path="/advertiser/budget" element={<AdvertiserBudgetPage />} />
+//           <Route
+//             path="/publisher/dashboard"
+//             element={<PublisherDashboardPage />}
+//           />
+//           <Route
+//             path="/publisher/earnings"
+//             element={<PublisherEarningsPage />}
+//           />
+//           <Route
+//             path="/publisher/settings"
+//             element={<PublisherSettingsPage />}
+//           />
+//         </Route>
+//         <Route path="*" element={<NotFoundPage />} />
+//       </Routes>
+//     </BrowserRouter>
+//   );
+// }

--- a/frontend/src/1_app/providers/index.ts
+++ b/frontend/src/1_app/providers/index.ts
@@ -1,2 +1,2 @@
-export { RouterProvider } from './RouterProvider';
+export { router } from './RouterProvider';
 export { ToastProvider } from './ToastProvider';

--- a/frontend/src/4_shared/ui/Header/OnboardingHeader.tsx
+++ b/frontend/src/4_shared/ui/Header/OnboardingHeader.tsx
@@ -1,9 +1,14 @@
 import { Icon } from '@shared/ui/Icon';
+import { useNavigate } from 'react-router-dom';
 
 export function OnboardingHeader() {
+  const navigate = useNavigate();
   return (
     <header className="flex items-center w-full h-16 bg-white border-b border-gray-200 px-6 text-2xl font-bold text-gray-900 whitespace-nowrap">
-      <div className="flex flex-row h-16 items-center gap-3 border-b border-gray-200 text-gray-900 text-lg font-bold">
+      <div
+        onClick={()=>{navigate('/')}}
+        className="flex flex-row h-16 items-center gap-3 border-b border-gray-200 text-gray-900 text-lg font-bold cursor-pointer"
+      >
         <Icon.Logo className="w-8 h-8 text-blue-500" />
         BoostAD
       </div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,11 @@
-import { RouterProvider, ToastProvider } from '@app/providers';
+import { ToastProvider } from '@app/providers';
+import { RouterProvider } from 'react-router-dom';
+import { router } from '@app/providers';
 
 export default function App() {
   return (
     <ToastProvider>
-      <RouterProvider />
+      <RouterProvider router={router} />
     </ToastProvider>
   );
 }


### PR DESCRIPTION
<!-- PR 제목 예시 : [Feat] 로그인 기능 구현 -->
<!-- PR 제목은 위 형식을 참고하여 작성해주세요. -->
<!-- 필요 없는 내용은 지우고 작성해주세요 -->

## 🔗 관련 이슈

- close: #

---

## ✅ 작업 내용

### 📌 주요 검토 파일

- `frontend/src/1_app/providers/RouterProvider.tsx`
  - `BrowserRouter`/`Routes` 기반 라우팅에서 `createBrowserRouter`(Data Router)로 전환
  - 라우트 트리 정의 후 `router` export
  - `/` 진입 시 `index` 라우트로 로그인 페이지 렌더
  - `*` NotFound 라우트 추가
- `frontend/src/App.tsx`
  - `react-router-dom`의 `<RouterProvider router={router} />`로 앱 라우터 주입 방식 변경
- `frontend/src/1_app/providers/index.ts`
  - `RouterProvider` export 제거, `router` export로 변경
- `frontend/src/4_shared/ui/Header/OnboardingHeader.tsx`
  - 로고 클릭 시 `/`로 이동하도록 `useNavigate` 추가
  - 클릭 가능 UX를 위해 `cursor-pointer` 적용

### 1. Data Router 적용

- `createBrowserRouter`를 사용해 라우트 구성을 “라우트 객체” 형태로 정의하도록 변경했습니다.
- 추후 `loader`/`action`/`redirect` 기반 인증 가드(비로그인 접근 차단) 등 확장이 쉬운 형태로 맞췄습니다.

### 2. 라우트 구성 정리

- `OnboardingLayout` 하위 라우트
  - `/`(index) → `LoginPage`
  - `/auth/login`, `/auth/register`
  - `/publisher/onboarding/sdk-guide`
  - `/publisher/onboarding/blog-admission`
  - `/advertiser/campaign-create`
- `DashboardLayout` 하위 라우트
  - `/publisher/dashboard`, `/publisher/earnings`, `/publisher/settings`
  - `/advertiser/dashboard`, `/advertiser/campaigns`, `/advertiser/budget`

## 📸 스크린샷 / 데모 (옵션)

-

---

## 🧪 테스트 방법 (옵션)

1. `cd web27-boostcamp/frontend`
2. `npm install`
3. `npm run dev`
4. 브라우저에서 `/` 접속 → 로그인 페이지 렌더 확인
5. `/publisher/dashboard`, `/advertiser/dashboard` 접속 확인
6. `/publisher/onboarding/sdk-guide`, `/publisher/onboarding/blog-admission` 접속 확인
7. 존재하지 않는 경로 접속 → NotFound 렌더 확인

---

## 💬 To Reviewers

- Data Router 전환만 우선 적용했고, 인증 가드(`loader` + `redirect`)는 후속 PR에서 `/publisher`, `/advertiser` 라우트에 붙이는 형태가 자연스러울 것 같습니다.
- 루트경로는 로그인 페이지로 이어지도록했고, 편의를 위해 온보딩레이아웃의 로고를 누르면 루트경로로 이어지도록해놨습니다.
- 추후에 루트 경로는 메인페이지 만들고 붙이면 될 것 같습니다.
- 현재 `frontend/src/1_app/providers/RouterProvider.tsx`에 이전 라우팅 코드가 주석으로 남아있어, 머지 후 제거/정리가 필요하면 말씀해주세요.
