### PR TITLE
[Feat] loader 구현 및 등록

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -89,7 +89,7 @@ export class AuthController {
         redirectUrl =
           result.role === UserRole.PUBLISHER
             ? `${clientUrl}/publisher/entry`
-            : `${clientUrl}/advertiser/dashboard`;
+            : `${clientUrl}/advertiser/dashboard/main`;
       }
     } else {
       redirectUrl = result.isNew

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -86,7 +86,7 @@ export class AuthController {
         }
         redirectUrl =
           result.role === UserRole.PUBLISHER
-            ? `${clientUrl}/publisher/dashboard`
+            ? `${clientUrl}/publisher/entry`
             : `${clientUrl}/advertiser/dashboard`;
       }
     } else {

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   Controller,
   Get,
+  Post,
   Query,
   Res,
 } from '@nestjs/common';
@@ -9,6 +10,7 @@ import { type AuthIntent, OAuthService } from './auth.service';
 import { type Response } from 'express';
 import { Public } from './decorators/public.decorator';
 import { UserRole } from 'src/user/entities/user.entity';
+import { successResponse } from 'src/common/response/success-response';
 
 @Controller('auth')
 export class AuthController {
@@ -96,5 +98,18 @@ export class AuthController {
     }
 
     return res.redirect(redirectUrl);
+  }
+
+  @Post('logout')
+  @Public()
+  logout(@Res({ passthrough: true }) res: Response) {
+    res.clearCookie('access_token', {
+      path: '/',
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+    });
+
+    return successResponse({}, '로그아웃되었습니다.');
   }
 }

--- a/backend/src/blog/blog.controller.ts
+++ b/backend/src/blog/blog.controller.ts
@@ -28,7 +28,7 @@ export class BlogController {
   @Get('me/exists')
   async getMyBlogExists(@Req() req: AuthenticatedRequest) {
     const { userId } = req.user;
-    const exists = await this.blogService.existsBlogByUserId(userId);
+    const exists = await this.blogService.getMyBlogExists(userId);
     return successResponse(
       { exists },
       '블로그 등록 여부가 성공적으로 반환되었습니다.'

--- a/backend/src/blog/blog.controller.ts
+++ b/backend/src/blog/blog.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post, Req } from '@nestjs/common';
+import { Body, Controller, Get, Post, Req } from '@nestjs/common';
 import { CreateBlogDto } from './dto/create-blog.dto';
 import { type AuthenticatedRequest } from 'src/types/authenticated-request';
 import { BlogService } from './blog.service';
@@ -23,5 +23,15 @@ export class BlogController {
     });
 
     return successResponse({ blogKey }, 'blogKey가 성공적으로 반환되었습니다.');
+  }
+
+  @Get('me/exists')
+  async getMyBlogExists(@Req() req: AuthenticatedRequest) {
+    const { userId } = req.user;
+    const exists = await this.blogService.existsBlogByUserId(userId);
+    return successResponse(
+      { exists },
+      '블로그 등록 여부가 성공적으로 반환되었습니다.'
+    );
   }
 }

--- a/backend/src/blog/blog.module.ts
+++ b/backend/src/blog/blog.module.ts
@@ -4,7 +4,7 @@ import { BlogController } from './blog.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { BlogEntity } from './entities/blog.entity';
 import { UserModule } from 'src/user/user.module';
-import { BlogRepository } from './repository/blog.repository';
+import { BlogRepository } from './repository/blog.repository.interface';
 import { TypeOrmBlogRepository } from './repository/typeorm-blog.repository';
 
 @Module({

--- a/backend/src/blog/blog.service.ts
+++ b/backend/src/blog/blog.service.ts
@@ -55,11 +55,10 @@ export class BlogService {
     return blogKey;
   }
 
-  async existsBlogByUserId(userId: number) {
-    if (await this.blogRepository.existsBlogByUserId(userId)) {
-      return true;
+  async getMyBlogExists(userId: number) {
+    if (await this.userRepository.verifyRole(userId, UserRole.ADVERTISER)) {
+      throw new BadRequestException('잘못된 Role의 접근입니다.');
     }
-
-    return false;
+    return await this.blogRepository.existsBlogByUserId(userId);
   }
 }

--- a/backend/src/blog/blog.service.ts
+++ b/backend/src/blog/blog.service.ts
@@ -7,7 +7,7 @@ import {
 import { randomUUID } from 'crypto';
 import { UserRole } from 'src/user/entities/user.entity';
 import { UserRepository } from 'src/user/repository/user.repository';
-import { BlogRepository } from './repository/blog.repository';
+import { BlogRepository } from './repository/blog.repository.interface';
 
 @Injectable()
 export class BlogService {
@@ -53,5 +53,13 @@ export class BlogService {
     }
 
     return blogKey;
+  }
+
+  async existsBlogByUserId(userId: number) {
+    if (await this.blogRepository.existsBlogByUserId(userId)) {
+      return true;
+    }
+
+    return false;
   }
 }

--- a/backend/src/blog/repository/blog.repository.interface.ts
+++ b/backend/src/blog/repository/blog.repository.interface.ts
@@ -7,4 +7,5 @@ export abstract class BlogRepository {
   ): Promise<number>;
 
   abstract existsBlogByDomain(domain: string): Promise<boolean>;
+  abstract existsBlogByUserId(userId: number): Promise<boolean>;
 }

--- a/backend/src/blog/repository/typeorm-blog.repository.ts
+++ b/backend/src/blog/repository/typeorm-blog.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { BlogRepository } from './blog.repository';
+import { BlogRepository } from './blog.repository.interface';
 import { InjectRepository } from '@nestjs/typeorm';
 import { BlogEntity } from '../entities/blog.entity';
 import { Repository } from 'typeorm';
@@ -25,6 +25,16 @@ export class TypeOrmBlogRepository extends BlogRepository {
   async existsBlogByDomain(domain: string): Promise<boolean> {
     const qb = this.blogRepo.createQueryBuilder('b');
     const blog = await qb.where('b.domain = :domain', { domain }).getOne();
+    if (blog) {
+      return true;
+    }
+
+    return false;
+  }
+
+  async existsBlogByUserId(userId: number): Promise<boolean> {
+    const qb = this.blogRepo.createQueryBuilder('b');
+    const blog = await qb.where('b.userId = :id', { id: userId }).getOne();
     if (blog) {
       return true;
     }

--- a/backend/src/user/entities/user.entity.ts
+++ b/backend/src/user/entities/user.entity.ts
@@ -39,6 +39,9 @@ export class UserEntity {
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
 
+  @Column({ name: 'first_login_at', type: 'datetime', nullable: true })
+  firstLoginAt: Date | null;
+
   @DeleteDateColumn({ name: 'deleted_at', nullable: true })
   deletedAt: Date | null;
 

--- a/backend/src/user/repository/typeorm-user.repository.ts
+++ b/backend/src/user/repository/typeorm-user.repository.ts
@@ -43,4 +43,16 @@ export class TypeOrmUserRepository extends UserRepository {
 
     return null;
   }
+
+  async setFirstLoginAtIfNull(userId: number): Promise<boolean> {
+    const qb = this.userRepo.createQueryBuilder('u');
+    const result = await qb
+      .update(UserEntity)
+      .set({ firstLoginAt: () => 'CURRENT_TIMESTAMP' })
+      .where('id = :id', { id: userId })
+      .andWhere('first_login_at IS NULL')
+      .execute();
+
+    return (result.affected ?? 0) > 0;
+  }
 }

--- a/backend/src/user/repository/user.repository.ts
+++ b/backend/src/user/repository/user.repository.ts
@@ -5,4 +5,5 @@ export abstract class UserRepository {
   abstract verifyRole(userId: number, role: UserRole): Promise<boolean>;
   abstract createUser(email: string, role: UserRole): Promise<number>;
   abstract findByEmail(email: string): Promise<number | null>;
+  abstract setFirstLoginAtIfNull(userId: number): Promise<boolean>;
 }

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('user')
+export class UserController {}

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Post, Req } from '@nestjs/common';
 import { type AuthenticatedRequest } from 'src/types/authenticated-request';
 import { UserService } from './user.service';
+import { successResponse } from 'src/common/response/success-response';
 
 @Controller('users')
 export class UserController {
@@ -9,6 +10,10 @@ export class UserController {
   @Post('me/first-login')
   async handleFirstLogin(@Req() req: AuthenticatedRequest) {
     const { userId } = req.user;
-    await this.userService.handleFirstLogin(userId);
+    const isFirstLogin = await this.userService.handleFirstLogin(userId);
+    return successResponse(
+      { isFirstLogin },
+      '첫 로그인 여부가 성공적으로 체크되었습니다.'
+    );
   }
 }

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Req } from '@nestjs/common';
+import { Controller, Get, Post, Req } from '@nestjs/common';
 import { type AuthenticatedRequest } from 'src/types/authenticated-request';
 import { UserService } from './user.service';
 import { successResponse } from 'src/common/response/success-response';
@@ -14,6 +14,15 @@ export class UserController {
     return successResponse(
       { isFirstLogin },
       '첫 로그인 여부가 성공적으로 체크되었습니다.'
+    );
+  }
+
+  @Get('me')
+  getMe(@Req() req: AuthenticatedRequest) {
+    const { userId, role, email } = req.user;
+    return successResponse(
+      { userId, role, email },
+      '로그인된 사용자 정보입니다.'
     );
   }
 }

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -1,4 +1,8 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Post, Req } from '@nestjs/common';
+import { type AuthenticatedRequest } from 'src/types/authenticated-request';
 
-@Controller('user')
-export class UserController {}
+@Controller('users')
+export class UserController {
+  @Post('me/first-login')
+  checkFirstLogin(@Req() req: AuthenticatedRequest) {}
+}

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -1,8 +1,14 @@
 import { Controller, Post, Req } from '@nestjs/common';
 import { type AuthenticatedRequest } from 'src/types/authenticated-request';
+import { UserService } from './user.service';
 
 @Controller('users')
 export class UserController {
+  constructor(private readonly userService: UserService) {}
+
   @Post('me/first-login')
-  checkFirstLogin(@Req() req: AuthenticatedRequest) {}
+  async handleFirstLogin(@Req() req: AuthenticatedRequest) {
+    const { userId } = req.user;
+    await this.userService.handleFirstLogin(userId);
+  }
 }

--- a/backend/src/user/user.module.ts
+++ b/backend/src/user/user.module.ts
@@ -4,11 +4,15 @@ import { TypeOrmUserRepository } from './repository/typeorm-user.repository';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserEntity } from './entities/user.entity';
 import { UserController } from './user.controller';
+import { UserService } from './user.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([UserEntity])],
-  providers: [{ provide: UserRepository, useClass: TypeOrmUserRepository }],
-  exports: [UserRepository],
   controllers: [UserController],
+  providers: [
+    { provide: UserRepository, useClass: TypeOrmUserRepository },
+    UserService,
+  ],
+  exports: [UserRepository],
 })
 export class UserModule {}

--- a/backend/src/user/user.module.ts
+++ b/backend/src/user/user.module.ts
@@ -3,11 +3,12 @@ import { UserRepository } from './repository/user.repository';
 import { TypeOrmUserRepository } from './repository/typeorm-user.repository';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserEntity } from './entities/user.entity';
-// import { JsonUserRepository } from './repository/user/json-user.repository';
+import { UserController } from './user.controller';
 
 @Module({
   imports: [TypeOrmModule.forFeature([UserEntity])],
   providers: [{ provide: UserRepository, useClass: TypeOrmUserRepository }],
   exports: [UserRepository],
+  controllers: [UserController],
 })
 export class UserModule {}

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class UserService {}

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -1,4 +1,13 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { UserEntity } from './entities/user.entity';
+import { Repository } from 'typeorm';
 
 @Injectable()
-export class UserService {}
+export class UserService {
+  constructor(@InjectRepository(UserEntity) private readonly userRepo: Repository<UserEntity>) {}
+
+  async handleFirstLogin(userId: number) {
+    const isFirstLogin = this.userRepo.
+  }
+}

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -1,13 +1,13 @@
 import { Injectable } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { UserEntity } from './entities/user.entity';
-import { Repository } from 'typeorm';
+import { UserRepository } from './repository/user.repository';
 
 @Injectable()
 export class UserService {
-  constructor(@InjectRepository(UserEntity) private readonly userRepo: Repository<UserEntity>) {}
+  constructor(private readonly userRepository: UserRepository) {}
 
-  async handleFirstLogin(userId: number) {
-    const isFirstLogin = this.userRepo.
+  async handleFirstLogin(userId: number): Promise<boolean> {
+    const isFirstLogin =
+      await this.userRepository.setFirstLoginAtIfNull(userId);
+    return isFirstLogin;
   }
 }

--- a/frontend/src/1_app/lib/index.ts
+++ b/frontend/src/1_app/lib/index.ts
@@ -1,1 +1,1 @@
-export { publisherEntryLoader, publisherGateLoader } from './loader';
+export { publisherEntryLoader, publisherBlogRequiredLoader } from './loader';

--- a/frontend/src/1_app/lib/index.ts
+++ b/frontend/src/1_app/lib/index.ts
@@ -1,0 +1,1 @@
+export { publisherEntryLoader, publisherGateLoader } from './loader';

--- a/frontend/src/1_app/lib/index.ts
+++ b/frontend/src/1_app/lib/index.ts
@@ -1,1 +1,7 @@
-export { publisherEntryLoader, publisherBlogRequiredLoader } from './loader';
+export {
+  publisherEntryLoader,
+  publisherBlogRequiredLoader,
+  publisherGateLoader,
+  advertiserGateLoader,
+  guestOnlyLoader,
+} from './loader';

--- a/frontend/src/1_app/lib/loader.ts
+++ b/frontend/src/1_app/lib/loader.ts
@@ -21,14 +21,15 @@ export const publisherEntryLoader = async () => {
       isFirstLogin ? BLOG_ADMISSION_PATH : PUBLISHER_DASHBOARD_PATH
     );
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response?.status === 401) { // 로그인 만료 체크
+    if (axios.isAxiosError(error) && error.response?.status === 401) {
+      // 로그인 만료 체크
       throw redirect(LOGIN_PATH);
     }
     throw error;
   }
 };
 
-export const publisherGateLoader = async () => {
+export const publisherBlogRequiredLoader = async () => {
   try {
     const res = await axios.get(`${API_CONFIG.baseURL}/api/blogs/me/exists`, {
       withCredentials: true,
@@ -41,7 +42,7 @@ export const publisherGateLoader = async () => {
 
     return null;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response?.status === 401) { 
+    if (axios.isAxiosError(error) && error.response?.status === 401) {
       throw redirect(LOGIN_PATH);
     }
     throw error;

--- a/frontend/src/1_app/lib/loader.ts
+++ b/frontend/src/1_app/lib/loader.ts
@@ -1,15 +1,50 @@
 import { API_CONFIG } from '@/4_shared/lib/api';
 import axios from 'axios';
+import { redirect } from 'react-router-dom';
 
-export const handleFirstLogin = async () => {
-  const data = await axios.post(
-    `${API_CONFIG.baseURL}/api/users/me/first-login`,
-    null,
-    {
-      withCredentials: true,
-      headers: { 'Content-Type': 'application/json' },
+const LOGIN_PATH = '/auth/login';
+const BLOG_ADMISSION_PATH = '/publisher/onboarding/blog-admission';
+const PUBLISHER_DASHBOARD_PATH = '/publisher/dashboard/main';
+
+export const publisherEntryLoader = async () => {
+  try {
+    const res = await axios.post(
+      `${API_CONFIG.baseURL}/api/users/me/first-login`,
+      null,
+      {
+        withCredentials: true,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+
+    const { isFirstLogin } = res.data.data;
+    return redirect(
+      isFirstLogin ? BLOG_ADMISSION_PATH : PUBLISHER_DASHBOARD_PATH
+    );
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response?.status === 401) { // 로그인 만료 체크
+      throw redirect(LOGIN_PATH);
     }
-  );
+    throw error;
+  }
+};
 
-  const { isFirstLogin } = data.data;
+export const publisherGateLoader = async () => {
+  try {
+    const res = await axios.get(`${API_CONFIG.baseURL}/api/blogs/me/exists`, {
+      withCredentials: true,
+    });
+
+    const { exists } = res.data.data;
+    if (!exists) {
+      return redirect(BLOG_ADMISSION_PATH);
+    }
+
+    return null;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response?.status === 401) { 
+      throw redirect(LOGIN_PATH);
+    }
+    throw error;
+  }
 };

--- a/frontend/src/1_app/lib/loader.ts
+++ b/frontend/src/1_app/lib/loader.ts
@@ -48,3 +48,9 @@ export const publisherBlogRequiredLoader = async () => {
     throw error;
   }
 };
+
+export const publisherGateLoader = async () => {};
+
+export const advertiserGateLoader = async () => {};
+
+export const guestOnlyLoader = async () => {};

--- a/frontend/src/1_app/lib/loader.ts
+++ b/frontend/src/1_app/lib/loader.ts
@@ -1,0 +1,15 @@
+import { API_CONFIG } from '@/4_shared/lib/api';
+import axios from 'axios';
+
+export const handleFirstLogin = async () => {
+  const data = await axios.post(
+    `${API_CONFIG.baseURL}/api/users/me/first-login`,
+    null,
+    {
+      withCredentials: true,
+      headers: { 'Content-Type': 'application/json' },
+    }
+  );
+
+  const { isFirstLogin } = data.data;
+};

--- a/frontend/src/1_app/lib/loader.ts
+++ b/frontend/src/1_app/lib/loader.ts
@@ -10,10 +10,9 @@ export const publisherEntryLoader = async () => {
   try {
     const res = await axios.post(
       `${API_CONFIG.baseURL}/api/users/me/first-login`,
-      null,
+      {},
       {
         withCredentials: true,
-        headers: { 'Content-Type': 'application/json' },
       }
     );
 

--- a/frontend/src/1_app/providers/RouterProvider.tsx
+++ b/frontend/src/1_app/providers/RouterProvider.tsx
@@ -27,77 +27,83 @@ const OnboardingSdkGuidePage = lazy(() =>
 );
 
 export const router = createBrowserRouter([
+  // 1. 공통 (로그인 등) - 여긴 역할 구분이 없으므로 최상위 유지
   {
     path: '/',
     element: <OnboardingLayout />,
     children: [
-      { index: true, element: <LoginPage /> }, // 추후에 메인페이지 넣으면 될듯합니다.
-      {
-        path: 'auth/login',
-        element: <LoginPage />,
-      },
-      {
-        path: 'auth/register',
-        element: <RegisterPage />,
-      },
-      {
-        path: 'publisher/onboarding/sdk-guide',
-        element: (
-          <Suspense fallback={<OnboardingSdkGuidePageSkeleton />}>
-            <OnboardingSdkGuidePage />
-          </Suspense>
-        ),
-      },
-      {
-        path: 'publisher/onboarding/blog-admission',
-        element: <BlogAdmissionPage />,
-      },
-      {
-        path: 'advertiser/campaign-create',
-        element: <CampaignCreatePage />,
-      },
+      { index: true, element: <LoginPage /> },
+      { path: 'auth/login', element: <LoginPage /> },
+      { path: 'auth/register', element: <RegisterPage /> },
     ],
   },
+
+  // 2. 퍼블리셔 (Publisher) 그룹
   {
-    path: '/publisher',
-    element: <DashboardLayout />,
+    path: '/publisher', // 👈 URL 접두사 역할만 수행 (Layout 없음)
     children: [
+      // 2-1. 퍼블리셔 온보딩 (OnboardingLayout 사용)
+      {
+        path: 'onboarding',
+        element: <OnboardingLayout />, // 👈 여기서 레이아웃 지정
+        children: [
+          {
+            path: 'sdk-guide',
+            element: (
+              <Suspense fallback={<OnboardingSdkGuidePageSkeleton />}>
+                <OnboardingSdkGuidePage />
+              </Suspense>
+            ),
+          },
+          { path: 'blog-admission', element: <BlogAdmissionPage /> },
+        ],
+      },
+
+      // 2-2. 퍼블리셔 대시보드 (DashboardLayout 사용)
       {
         path: 'dashboard',
-        element: <PublisherDashboardPage />,
-      },
-      {
-        path: 'earnings',
-        element: <PublisherEarningsPage />,
-      },
-      {
-        path: 'settings',
-        element: <PublisherSettingsPage />,
+        element: <DashboardLayout />, // 👈 다른 레이아웃 지정
+        children: [
+          { path: 'main', element: <PublisherDashboardPage /> },
+          { path: 'earnings', element: <PublisherEarningsPage /> },
+          { path: 'settings', element: <PublisherSettingsPage /> },
+        ],
       },
     ],
   },
+
+  // 3. 광고주 (Advertiser) 그룹
   {
-    path: '/advertiser',
-    element: <DashboardLayout />,
+    path: '/advertiser', // 👈 URL 접두사 역할
     children: [
+      // 3-1. 광고주 온보딩 (OnboardingLayout 재사용)
+      {
+        path: 'onboarding', // URL: /advertiser/onboarding/...
+        element: <OnboardingLayout />,
+        children: [
+          // 필요하다면 광고주용 온보딩 페이지들 추가
+        ],
+      },
+      // 3-2. 광고주 캠페인 생성 (OnboardingLayout 사용한다고 가정)
+      {
+        path: 'campaign-create',
+        element: <OnboardingLayout />,
+        children: [{ index: true, element: <CampaignCreatePage /> }],
+      },
+      // 3-3. 광고주 대시보드 (DashboardLayout 사용)
       {
         path: 'dashboard',
-        element: <AdvertiserDashboardPage />,
-      },
-      {
-        path: 'campaigns',
-        element: <AdvertiserCampaignsPage />,
-      },
-      {
-        path: 'budget',
-        element: <AdvertiserBudgetPage />,
+        element: <DashboardLayout />,
+        children: [
+          { path: 'main', element: <AdvertiserDashboardPage /> },
+          { path: 'campaigns', element: <AdvertiserCampaignsPage /> },
+          { path: 'budget', element: <AdvertiserBudgetPage /> },
+        ],
       },
     ],
   },
-  {
-    path: '*',
-    element: <NotFoundPage />,
-  },
+
+  { path: '*', element: <NotFoundPage /> },
 ]);
 
 // export function RouterProvider() {

--- a/frontend/src/1_app/providers/RouterProvider.tsx
+++ b/frontend/src/1_app/providers/RouterProvider.tsx
@@ -1,11 +1,5 @@
 import { lazy, Suspense } from 'react';
-import {
-  // BrowserRouter,
-  // Routes,
-  // Route,
-  // Navigate,
-  createBrowserRouter,
-} from 'react-router-dom';
+import { createBrowserRouter } from 'react-router-dom';
 import { DashboardLayout, OnboardingLayout } from '@app/layouts';
 import { AdvertiserDashboardPage } from '@pages/advertiserDashboard';
 import { AdvertiserCampaignsPage } from '@pages/advertiserCampaigns';
@@ -19,7 +13,7 @@ import { PublisherSettingsPage } from '@pages/publisherSettings';
 import { OnboardingSdkGuidePageSkeleton } from '@pages/onboardingSdkGuide';
 import { CampaignCreatePage } from '@pages/campaginCreate';
 import { BlogAdmissionPage } from '@pages/onboardingBlogAdmission/ui/BlogAdmissionPage';
-import { publisherGateLoader } from '../lib';
+import { publisherEntryLoader, publisherGateLoader } from '../lib';
 
 const OnboardingSdkGuidePage = lazy(() =>
   import('@pages/onboardingSdkGuide').then((m) => ({
@@ -43,6 +37,10 @@ export const router = createBrowserRouter([
   {
     path: '/publisher', // 👈 URL 접두사 역할만 수행 (Layout 없음)
     children: [
+      {
+        path: 'entry',
+        loader: publisherEntryLoader,
+      },
       // 2-1. 퍼블리셔 온보딩 (OnboardingLayout 사용)
       {
         path: 'onboarding',

--- a/frontend/src/1_app/providers/RouterProvider.tsx
+++ b/frontend/src/1_app/providers/RouterProvider.tsx
@@ -13,7 +13,13 @@ import { PublisherSettingsPage } from '@pages/publisherSettings';
 import { OnboardingSdkGuidePageSkeleton } from '@pages/onboardingSdkGuide';
 import { CampaignCreatePage } from '@pages/campaginCreate';
 import { BlogAdmissionPage } from '@pages/onboardingBlogAdmission/ui/BlogAdmissionPage';
-import { publisherEntryLoader, publisherBlogRequiredLoader } from '../lib';
+import {
+  publisherEntryLoader,
+  publisherBlogRequiredLoader,
+  guestOnlyLoader,
+  publisherGateLoader,
+  advertiserGateLoader,
+} from '../lib';
 
 const OnboardingSdkGuidePage = lazy(() =>
   import('@pages/onboardingSdkGuide').then((m) => ({
@@ -25,6 +31,7 @@ export const router = createBrowserRouter([
   // 1. 공통 (로그인 등) - 여긴 역할 구분이 없으므로 최상위 유지
   {
     path: '/',
+    loader: guestOnlyLoader,
     element: <OnboardingLayout />,
     children: [
       { index: true, element: <LoginPage /> },
@@ -36,6 +43,7 @@ export const router = createBrowserRouter([
   // 2. 퍼블리셔 (Publisher) 그룹
   {
     path: '/publisher', // 👈 URL 접두사 역할만 수행 (Layout 없음)
+    loader: publisherGateLoader,
     children: [
       {
         path: 'entry',
@@ -75,6 +83,7 @@ export const router = createBrowserRouter([
   // 3. 광고주 (Advertiser) 그룹
   {
     path: '/advertiser', // 👈 URL 접두사 역할
+    loader: advertiserGateLoader,
     children: [
       // 3-1. 광고주 온보딩 (OnboardingLayout 재사용)
       {

--- a/frontend/src/1_app/providers/RouterProvider.tsx
+++ b/frontend/src/1_app/providers/RouterProvider.tsx
@@ -13,7 +13,7 @@ import { PublisherSettingsPage } from '@pages/publisherSettings';
 import { OnboardingSdkGuidePageSkeleton } from '@pages/onboardingSdkGuide';
 import { CampaignCreatePage } from '@pages/campaginCreate';
 import { BlogAdmissionPage } from '@pages/onboardingBlogAdmission/ui/BlogAdmissionPage';
-import { publisherEntryLoader, publisherGateLoader } from '../lib';
+import { publisherEntryLoader, publisherBlogRequiredLoader } from '../lib';
 
 const OnboardingSdkGuidePage = lazy(() =>
   import('@pages/onboardingSdkGuide').then((m) => ({
@@ -61,7 +61,7 @@ export const router = createBrowserRouter([
       // 2-2. 퍼블리셔 대시보드 (DashboardLayout 사용)
       {
         path: 'dashboard',
-        loader: publisherGateLoader,
+        loader: publisherBlogRequiredLoader,
         element: <DashboardLayout />, // 👈 다른 레이아웃 지정
         children: [
           { path: 'main', element: <PublisherDashboardPage /> },

--- a/frontend/src/1_app/providers/RouterProvider.tsx
+++ b/frontend/src/1_app/providers/RouterProvider.tsx
@@ -19,6 +19,7 @@ import { PublisherSettingsPage } from '@pages/publisherSettings';
 import { OnboardingSdkGuidePageSkeleton } from '@pages/onboardingSdkGuide';
 import { CampaignCreatePage } from '@pages/campaginCreate';
 import { BlogAdmissionPage } from '@pages/onboardingBlogAdmission/ui/BlogAdmissionPage';
+import { publisherGateLoader } from '../lib';
 
 const OnboardingSdkGuidePage = lazy(() =>
   import('@pages/onboardingSdkGuide').then((m) => ({
@@ -62,6 +63,7 @@ export const router = createBrowserRouter([
       // 2-2. 퍼블리셔 대시보드 (DashboardLayout 사용)
       {
         path: 'dashboard',
+        loader: publisherGateLoader,
         element: <DashboardLayout />, // 👈 다른 레이아웃 지정
         children: [
           { path: 'main', element: <PublisherDashboardPage /> },

--- a/frontend/src/4_shared/ui/Header/Header.tsx
+++ b/frontend/src/4_shared/ui/Header/Header.tsx
@@ -1,11 +1,33 @@
+import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
+import { API_CONFIG } from '@/4_shared/lib/api';
+import { Button } from '@shared/ui/Button';
+
 interface HeaderProps {
   title: string;
 }
 
 export function Header({ title }: HeaderProps) {
+  const navigate = useNavigate();
+
+  const handleLogout = async () => {
+    try {
+      await axios.post(
+        `${API_CONFIG.baseURL}/api/auth/logout`,
+        {},
+        { withCredentials: true }
+      );
+    } finally {
+      navigate('/auth/login', { replace: true });
+    }
+  };
+
   return (
-    <header className="flex items-center w-full h-16 bg-white border-b border-gray-200 px-8 text-2xl font-bold text-gray-900 whitespace-nowrap">
-      {title}
+    <header className="flex items-center justify-between w-full h-16 bg-white border-b border-gray-200 px-8 text-2xl font-bold text-gray-900 whitespace-nowrap">
+      <h1>{title}</h1>
+      <Button variant="white" size="sm" onClick={handleLogout}>
+        로그아웃
+      </Button>
     </header>
   );
 }


### PR DESCRIPTION
<!-- PR 제목 예시 : [Feat] 로그인 기능 구현 -->
<!-- PR 제목은 위 형식을 참고하여 작성해주세요. -->
<!-- 필요 없는 내용은 지우고 작성해주세요 -->

## 🔗 관련 이슈

- close: #139 

---

## ✅ 작업 내용

### 📌 주요 검토 파일

- `frontend/src/1_app/lib/loader.ts`
  - `guestOnlyLoader`: 로그인 상태면 `/auth/*`(로그인/회원가입) 접근 시 역할별 경로로 리다이렉트
  - `publisherGateLoader` / `advertiserGateLoader`: `/publisher/*`, `/advertiser/*` 진입 시 role 기반 접근 제어
  - `publisherEntryLoader`: `POST /api/users/me/first-login` 호출 후 첫 로그인 여부에 따라 온보딩/대시보드 분기
  - `publisherBlogRequiredLoader`: 퍼블리셔 대시보드 진입 시 `GET /api/blogs/me/exists`로 블로그 등록 여부 확인 후 미등록이면 온보딩으로 리다이렉트
- `frontend/src/1_app/providers/RouterProvider.tsx`
  - Data Router에서 각 도메인(`/`, `/publisher`, `/advertiser`)에 loader를 연결해 라우팅 가드/게이트 동작 추가
- `backend/src/user/user.controller.ts`
  - `GET /api/users/me`: 로그인된 사용자 정보(userId/role/email) 반환(프론트 loader 가드용)
  - `POST /api/users/me/first-login`: 첫 로그인 시점 저장 + `isFirstLogin` 반환
- `backend/src/user/repository/typeorm-user.repository.ts`
  - `setFirstLoginAtIfNull`: `first_login_at IS NULL` 조건부 UPDATE
- `backend/src/blog/blog.controller.ts`
  - `GET /api/blogs/me/exists`: 현재 로그인 유저의 블로그 등록 여부 반환(퍼블리셔 온보딩 게이트용)

### 1. Guest 전용 라우트 접근 제어

- 로그인/회원가입 페이지(`/(index)`, `/auth/login`, `/auth/register`)에 `guestOnlyLoader`를 연결해
  - 이미 로그인된 사용자는 role에 맞는 경로로 리다이렉트되도록 구성했습니다.
  - 미로그인(401)인 경우에는 페이지를 그대로 노출하도록 처리했습니다(루프/429 방지).

### 2. Publisher 첫 로그인 분기 엔트리(`/publisher/entry`)

- 퍼블리셔 로그인 후 `/publisher/entry`로 진입하면
  - `POST /api/users/me/first-login`을 호출해 `first_login_at`을 최초 1회만 기록하고,
  - `isFirstLogin` 값에 따라 온보딩(`/publisher/onboarding/blog-admission`) 또는 대시보드(`/publisher/dashboard/main`)로 리다이렉트합니다.

### 3. Publisher 대시보드 블로그 등록 필수 게이트

- 퍼블리셔 대시보드 진입 시 `publisherBlogRequiredLoader`에서 `GET /api/blogs/me/exists`를 호출해
  - 블로그 미등록이면 `/publisher/onboarding/blog-admission`으로 리다이렉트합니다.
  - 블로그가 있으면 그대로 대시보드 라우트를 렌더링합니다.

### 4. Role 기반 접근 제어

- `/publisher/*`, `/advertiser/*` 진입 시 `GET /api/users/me`의 `role`을 기준으로
  - 역할이 다른 도메인으로 접근하면 본인 도메인으로 리다이렉트되도록 구성했습니다.

## 📸 스크린샷 / 데모 (옵션)

-

---

## 🧪 테스트 방법 (옵션)

1. 백엔드 실행 후 프론트 실행
2. 미로그인 상태에서 `/auth/login` 접속 → 로그인 페이지가 노출되는지 확인
3. 로그인된 상태에서 `/auth/login` 접속 → role에 맞는 경로로 리다이렉트되는지 확인
4. 퍼블리셔로 `/publisher/entry` 접속 → 첫 로그인 여부에 따라 온보딩/대시보드로 분기되는지 확인
5. 퍼블리셔로 `/publisher/dashboard/main` 접속
   - 블로그 미등록이면 `/publisher/onboarding/blog-admission`으로 리다이렉트
   - 블로그 등록이면 대시보드 렌더
6. 광고주가 `/publisher/*` 접근 시 광고주 도메인으로 리다이렉트되는지 확인(반대 케이스도 동일)

---

## 💬 To Reviewers

- loader적용으로 인해서 개발중에 페이지 접근이 막히는 일이 많을 것 같아서 pull받으시고 로컬 개발환경에서 loader는 주석처리하고 개발하면 될 것 같습니다.
- 로그아웃도 빠르게 구현하겠습니다.