### PR TITLE
feat: 캠페인 생성에 기간 설정 및 광고 미리보기 추가

### DIFF
--- a/frontend/src/3_features/campaignCreation/lib/campaignFormStore.ts
+++ b/frontend/src/3_features/campaignCreation/lib/campaignFormStore.ts
@@ -32,6 +32,8 @@ const initialFormData: CampaignFormData = {
     dailyBudget: 0,
     totalBudget: 0,
     maxCpc: 0,
+    startDate: '',
+    endDate: '',
   },
 };
 

--- a/frontend/src/3_features/campaignCreation/lib/dateValidation.ts
+++ b/frontend/src/3_features/campaignCreation/lib/dateValidation.ts
@@ -1,0 +1,57 @@
+const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+export function getToday() {
+  return new Date().toISOString().split('T')[0];
+}
+
+export function isValidDateFormat(date: string) {
+  return date ? DATE_REGEX.test(date) : false;
+}
+
+export function isDateInPast(date: string) {
+  if (!isValidDateFormat(date)) {
+    return false;
+  }
+  return date < getToday();
+}
+
+export function isEndDateBeforeStartDate(startDate: string, endDate: string) {
+  if (!isValidDateFormat(startDate) || !isValidDateFormat(endDate)) {
+    return false;
+  }
+  return endDate < startDate;
+}
+
+export function validateStartDate(startDate: string) {
+  if (!startDate) {
+    return null;
+  }
+  if (!isValidDateFormat(startDate)) {
+    return '올바른 날짜 형식이 아닙니다';
+  }
+  if (isDateInPast(startDate)) {
+    return '시작일은 오늘 이후여야 합니다';
+  }
+  return null;
+}
+
+export function validateEndDate(startDate: string, endDate: string) {
+  if (!endDate) {
+    return null;
+  }
+  if (!isValidDateFormat(endDate)) {
+    return '올바른 날짜 형식이 아닙니다';
+  }
+  if (startDate && isEndDateBeforeStartDate(startDate, endDate)) {
+    return '종료일은 시작일 이후여야 합니다';
+  }
+  return null;
+}
+
+export function formatDateForDisplay(date: string) {
+  if (!date || !isValidDateFormat(date)) {
+    return '-';
+  }
+  const [year, month, day] = date.split('-');
+  return `${year}년 ${parseInt(month)}월 ${parseInt(day)}일`;
+}

--- a/frontend/src/3_features/campaignCreation/lib/types.ts
+++ b/frontend/src/3_features/campaignCreation/lib/types.ts
@@ -28,6 +28,8 @@ export interface BudgetSettings {
   dailyBudget: number;
   totalBudget: number;
   maxCpc: number;
+  startDate: string;
+  endDate: string;
 }
 
 export interface CampaignFormData {

--- a/frontend/src/3_features/campaignCreation/ui/AdPreview.tsx
+++ b/frontend/src/3_features/campaignCreation/ui/AdPreview.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+
+interface AdPreviewProps {
+  title: string;
+  content: string;
+  imageUrl: string | null;
+}
+
+export function AdPreview({ title, content, imageUrl }: AdPreviewProps) {
+  const [imageError, setImageError] = useState(false);
+
+  const handleImageError = () => {
+    setImageError(true);
+  };
+
+  const showImage = imageUrl && !imageError;
+
+  return (
+    <div className="flex flex-col gap-3">
+      <span className="text-sm font-bold text-gray-900">광고 미리보기</span>
+
+      <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm transition-all hover:-translate-y-0.5 hover:shadow-md">
+        <div className="mb-4 text-[10px] uppercase tracking-wide text-gray-400">
+          Sponsored
+        </div>
+
+        <div className="flex flex-wrap items-stretch gap-5">
+          {showImage && (
+            <img
+              src={imageUrl}
+              alt={title || '광고 이미지'}
+              onError={handleImageError}
+              className="h-50 w-50 shrink-0 rounded-lg object-cover"
+            />
+          )}
+
+          <div className="flex min-w-0 flex-1 flex-col">
+            <h3 className="mb-3 text-xl font-semibold leading-snug text-gray-800">
+              {title || '광고 제목'}
+            </h3>
+
+            <p className="mb-6 grow text-[15px] leading-relaxed text-gray-500">
+              {content || '광고 내용이 여기에 표시됩니다.'}
+            </p>
+
+            <div className="mt-auto flex items-center justify-between gap-3 pt-4">
+              <span className="inline-block cursor-not-allowed whitespace-nowrap rounded-lg bg-linear-to-br from-[#667eea] to-[#764ba2] px-6 py-3 text-sm font-semibold text-white opacity-80">
+                자세히 보기 →
+              </span>
+
+              <span className="whitespace-nowrap text-[11px] text-gray-400">
+                by <strong>BoostAD</strong>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/3_features/campaignCreation/ui/DateField.tsx
+++ b/frontend/src/3_features/campaignCreation/ui/DateField.tsx
@@ -1,0 +1,59 @@
+import { getToday } from '../lib/dateValidation';
+
+interface DateFieldProps {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  onBlur?: () => void;
+  hint?: string;
+  error?: string;
+  min?: string;
+}
+
+export function DateField({
+  label,
+  value,
+  onChange,
+  onBlur,
+  hint,
+  error,
+  min,
+}: DateFieldProps) {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChange(e.target.value);
+  };
+
+  const handleBlur = () => {
+    if (onBlur) {
+      onBlur();
+    }
+  };
+
+  const minDate = min || getToday();
+
+  return (
+    <div className="flex flex-col gap-2">
+      <label className="text-sm font-bold text-gray-900">{label}</label>
+
+      <input
+        type="date"
+        value={value}
+        onChange={handleChange}
+        onBlur={handleBlur}
+        min={minDate}
+        className={`h-11 rounded-lg border px-3 outline-none focus:ring-2 [&::-webkit-calendar-picker-indicator]:cursor-pointer ${
+          value
+            ? 'text-gray-900'
+            : 'text-gray-400 [&::-webkit-datetime-edit-day-field]:text-gray-400 [&::-webkit-datetime-edit-month-field]:text-gray-400 [&::-webkit-datetime-edit-text]:text-gray-400 [&::-webkit-datetime-edit-year-field]:text-gray-400'
+        } ${
+          error
+            ? 'border-red-300 focus:ring-red-200'
+            : 'border-gray-200 focus:ring-blue-200'
+        }`}
+      />
+
+      {hint && !error && <p className="text-xs text-gray-400">{hint}</p>}
+      {error && <p className="text-xs text-red-500">{error}</p>}
+    </div>
+  );
+}

--- a/frontend/src/3_features/campaignCreation/ui/Step2Content.tsx
+++ b/frontend/src/3_features/campaignCreation/ui/Step2Content.tsx
@@ -1,13 +1,16 @@
 import { ContentHeader } from './ContentHeader';
 import { CurrencyField } from './CurrencyField';
+import { DateField } from './DateField';
 import { useCampaignFormStore } from '../lib/campaignFormStore';
+import { validateStartDate, validateEndDate } from '../lib/dateValidation';
 
 const MIN_DAILY_BUDGET = 3000;
 
 export function Step2Content() {
   const { formData, updateBudgetSettings, errors, setErrors } =
     useCampaignFormStore();
-  const { dailyBudget, totalBudget, maxCpc } = formData.budgetSettings;
+  const { dailyBudget, totalBudget, maxCpc, startDate, endDate } =
+    formData.budgetSettings;
 
   const handleDailyBudgetChange = (value: number) => {
     updateBudgetSettings({ dailyBudget: value });
@@ -25,18 +28,52 @@ export function Step2Content() {
     if (dailyBudget > 0 && dailyBudget < MIN_DAILY_BUDGET) {
       setErrors({
         budgetSettings: {
+          ...errors.budgetSettings,
           dailyBudget: `최소 ${MIN_DAILY_BUDGET.toLocaleString()}원 이상 입력해주세요`,
         },
       });
     } else {
-      setErrors({});
+      setErrors({
+        budgetSettings: {
+          ...errors.budgetSettings,
+          dailyBudget: undefined,
+        },
+      });
     }
+  };
+
+  const handleStartDateChange = (value: string) => {
+    updateBudgetSettings({ startDate: value });
+  };
+
+  const handleEndDateChange = (value: string) => {
+    updateBudgetSettings({ endDate: value });
+  };
+
+  const handleStartDateBlur = () => {
+    const error = validateStartDate(startDate);
+    setErrors({
+      budgetSettings: {
+        ...errors.budgetSettings,
+        startDate: error || undefined,
+      },
+    });
+  };
+
+  const handleEndDateBlur = () => {
+    const error = validateEndDate(startDate, endDate);
+    setErrors({
+      budgetSettings: {
+        ...errors.budgetSettings,
+        endDate: error || undefined,
+      },
+    });
   };
 
   return (
     <div className="flex flex-col gap-6">
       <ContentHeader
-        title="예산 설정"
+        title="예산 및 기간 설정"
         description="광고에 사용할 예산을 설정해주세요"
       />
 
@@ -64,6 +101,25 @@ export function Step2Content() {
         hint="(광고 입찰 참여 금액)"
         error={errors.budgetSettings?.maxCpc}
       />
+
+      <div className="grid grid-cols-2 gap-4">
+        <DateField
+          label="시작일"
+          value={startDate}
+          onChange={handleStartDateChange}
+          onBlur={handleStartDateBlur}
+          error={errors.budgetSettings?.startDate}
+        />
+
+        <DateField
+          label="종료일"
+          value={endDate}
+          onChange={handleEndDateChange}
+          onBlur={handleEndDateBlur}
+          min={startDate}
+          error={errors.budgetSettings?.endDate}
+        />
+      </div>
     </div>
   );
 }

--- a/frontend/src/3_features/campaignCreation/ui/Step3Content.tsx
+++ b/frontend/src/3_features/campaignCreation/ui/Step3Content.tsx
@@ -2,15 +2,18 @@ import { useMemo } from 'react';
 import { ContentHeader } from './ContentHeader';
 import { ConfirmCard } from './ConfirmCard';
 import { ConfirmItem } from './ConfirmItem';
+import { AdPreview } from './AdPreview';
 import { useCampaignFormStore } from '../lib/campaignFormStore';
 import { formatWithComma } from '@shared/lib/format';
 import { DEFAULT_ENGAGEMENT_SCORE } from '../lib/constants';
+import { formatDateForDisplay } from '../lib/dateValidation';
 
 export function Step3Content() {
   const { formData, setStep } = useCampaignFormStore();
   const { title, content, url, tags, isHighIntent, imageFile } =
     formData.campaignContent;
-  const { dailyBudget, totalBudget, maxCpc } = formData.budgetSettings;
+  const { dailyBudget, totalBudget, maxCpc, startDate, endDate } =
+    formData.budgetSettings;
 
   const previewUrl = useMemo(() => {
     if (!imageFile) return null;
@@ -44,6 +47,18 @@ export function Step3Content() {
     {
       label: '총 예산',
       value: totalBudget > 0 ? `${formatWithComma(totalBudget)}원` : '-',
+    },
+  ];
+
+  // 기간 - 반반 차지
+  const periodGridItems = [
+    {
+      label: '시작일',
+      value: formatDateForDisplay(startDate),
+    },
+    {
+      label: '종료일',
+      value: formatDateForDisplay(endDate),
     },
   ];
 
@@ -101,8 +116,8 @@ export function Step3Content() {
         </div>
       </ConfirmCard>
 
-      {/* 예산 */}
-      <ConfirmCard title="예산" onEdit={handleEditBudget}>
+      {/* 예산 및 기간 */}
+      <ConfirmCard title="예산 및 기간" onEdit={handleEditBudget}>
         <div className="flex flex-col gap-4">
           <div className="grid grid-cols-2 gap-4">
             {budgetGridItems.map((item) => (
@@ -117,6 +132,15 @@ export function Step3Content() {
             label="클릭당 최대 입찰가(CPC)"
             value={maxCpc > 0 ? `${formatWithComma(maxCpc)}원` : '-'}
           />
+          <div className="grid grid-cols-2 gap-4">
+            {periodGridItems.map((item) => (
+              <ConfirmItem
+                key={item.label}
+                label={item.label}
+                value={item.value}
+              />
+            ))}
+          </div>
         </div>
       </ConfirmCard>
 
@@ -124,6 +148,9 @@ export function Step3Content() {
       <ConfirmCard title="고급 설정" onEdit={handleEditContent}>
         <ConfirmItem label="행동 타겟팅" value={targetingText} />
       </ConfirmCard>
+
+      {/* 광고 미리보기 */}
+      <AdPreview title={title} content={content} imageUrl={previewUrl} />
     </div>
   );
 }


### PR DESCRIPTION
<!-- PR 제목 예시 : [Feat] 로그인 기능 구현 -->
<!-- PR 제목은 위 형식을 참고하여 작성해주세요. -->
<!-- 필요 없는 내용은 지우고 작성해주세요 -->

## 🔗 관련 이슈

- close: #140 

---

## ✅ 작업 내용

### 1. 날짜 필드 기능 구현 (Step2)
- `BudgetSettings` 타입에 `startDate`, `endDate` 필드 추가
- `DateField` 컴포넌트 신규 생성 (`<input type="date">` 활용)
- 날짜 유효성 검증 유틸 구현 (`dateValidation.ts`)
  - 시작일은 오늘 이후만 선택 가능
  - 종료일은 시작일 이후만 선택 가능
- Step2에 시작일/종료일 입력 필드 추가 및 blur 이벤트 검증 연결

### 2. 광고 미리보기 기능 구현 (Step3)
- `AdPreview` 컴포넌트 신규 생성
- SDK의 `BannerAdRenderer` 스타일과 동일하게 구현
- 이미지 있는/없는 버전 모두 지원
- 이미지 로딩 실패 시 자동으로 이미지 없는 버전으로 fallback

### 3. Step3 확인 화면 업데이트
- 예산 카드에 시작일/종료일 정보 추가
- 광고 미리보기 섹션 추가

## 📸 스크린샷 / 데모 (옵션)

<!-- UI 변경사항이나 새로운 기능의 동작을 시각적으로 보여주세요. -->

---

## 🧪 테스트 방법 (옵션)

<!-- 리뷰어가 기능을 테스트할 수 있도록 구체적인 테스트 방법을 설명해주세요. -->

1. Step2에서 시작일/종료일 입력 후 유효성 검증 확인
2. Step3에서 입력한 광고 정보가 미리보기로 올바르게 표시되는지 확인

---

## 💬 To Reviewers

<!-- 리뷰어에게 전달하고 싶은 내용이나 특별히 확인이 필요한 부분을 작성해주세요. -->
날짜 입력 필드를 `<input type="date">`로 구현했는데, 브라우저 기본 DatePicker의 달력 팝업은 CSS로 커스터마이징이 제한적이더라구요..!(아이콘, 입력 필드 정도만 가능하고 달력 팝업 내부 스타일은 변경 불가) 
프로젝트 디자인과 완전히 통일된 달력이면 좋을 것 같아서 `react-datepicker` 같은 라이브러리 도입으로 리팩토링이 필요할 것 같습니다.
