### PR TITLE
[Feat] sdk 가이드페이지 blogKey 연동

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -235,6 +235,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -735,7 +736,6 @@
       "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.3.3.tgz",
       "integrity": "sha512-JsXDL70gQ+1Vc2W/KUFfkAJzgb4puKwwKehNLuB+HrNKWf91O736kGfxn4KujXCCSuh6mRRL4XEB0PkAFjWS0A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "hashery": "^1.3.0",
         "keyv": "^5.5.5"
@@ -2109,8 +2109,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
       "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
@@ -2197,6 +2196,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.9.tgz",
       "integrity": "sha512-zDntUTReRbAThIfSp3dQZ9kKqI+LjgLp5YZN5c1bgNRDuoeLySAoZg46Bg1a+uV8TMgIRziHocglKGNzr6l+bQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "21.1.0",
         "iterare": "1.2.1",
@@ -2244,6 +2244,7 @@
       "integrity": "sha512-a00B0BM4X+9z+t3UxJqIZlemIwCQdYoPKrMcM+ky4z3pkqqG1eTWexjs+YXpGObnLnjtMPVKWlcZHp3adDYvUw==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -2284,6 +2285,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.12.tgz",
       "integrity": "sha512-GYK/vHI0SGz5m8mxr7v3Urx8b9t78Cf/dj5aJMZlGd9/1D9OI1hAl00BaphjEXINUJ/BQLxIlF2zUjrYsd6enQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cors": "2.8.5",
         "express": "5.2.1",
@@ -2793,6 +2795,7 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -2822,6 +2825,7 @@
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -2927,6 +2931,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.3.tgz",
       "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3065,6 +3070,7 @@
       "integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.49.0",
         "@typescript-eslint/types": "8.49.0",
@@ -3760,6 +3766,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3809,6 +3816,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4424,6 +4432,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4650,6 +4659,7 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -4703,13 +4713,15 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/class-validator": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.3.tgz",
       "integrity": "sha512-rXXekcjofVN1LTOSw+u4u9WXVEUvNBVjORW154q/IdmYWy1nMbOU9aNtZB0t8m+FJQ9q91jlr2f9CwwUFdFMRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -5491,6 +5503,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5551,6 +5564,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -6541,7 +6555,6 @@
       "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.4.0.tgz",
       "integrity": "sha512-Wn2i1In6XFxl8Az55kkgnFRiAlIAushzh26PTjL2AKtQcEfXrcLa7Hn5QOWGZEf3LU057P9TwwZjFyxfS1VuvQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "hookified": "^1.14.0"
       },
@@ -7030,6 +7043,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -9026,6 +9040,7 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9335,7 +9350,8 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -9431,6 +9447,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -10229,6 +10246,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10579,6 +10597,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -10751,6 +10770,7 @@
       "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.28.tgz",
       "integrity": "sha512-6GH7wXhtfq2D33ZuRXYwIsl/qM5685WZcODZb7noOOcRMteM9KF2x2ap3H0EBjnSV0VO4gNAfJT5Ukp0PkOlvg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^4.2.0",
@@ -10956,6 +10976,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11255,6 +11276,7 @@
       "integrity": "sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -11324,6 +11346,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -235,7 +235,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -736,6 +735,7 @@
       "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.3.3.tgz",
       "integrity": "sha512-JsXDL70gQ+1Vc2W/KUFfkAJzgb4puKwwKehNLuB+HrNKWf91O736kGfxn4KujXCCSuh6mRRL4XEB0PkAFjWS0A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "hashery": "^1.3.0",
         "keyv": "^5.5.5"
@@ -2109,7 +2109,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
       "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
@@ -2196,7 +2197,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.9.tgz",
       "integrity": "sha512-zDntUTReRbAThIfSp3dQZ9kKqI+LjgLp5YZN5c1bgNRDuoeLySAoZg46Bg1a+uV8TMgIRziHocglKGNzr6l+bQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "21.1.0",
         "iterare": "1.2.1",
@@ -2244,7 +2244,6 @@
       "integrity": "sha512-a00B0BM4X+9z+t3UxJqIZlemIwCQdYoPKrMcM+ky4z3pkqqG1eTWexjs+YXpGObnLnjtMPVKWlcZHp3adDYvUw==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -2285,7 +2284,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.12.tgz",
       "integrity": "sha512-GYK/vHI0SGz5m8mxr7v3Urx8b9t78Cf/dj5aJMZlGd9/1D9OI1hAl00BaphjEXINUJ/BQLxIlF2zUjrYsd6enQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cors": "2.8.5",
         "express": "5.2.1",
@@ -2795,7 +2793,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -2825,7 +2822,6 @@
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -2931,7 +2927,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.3.tgz",
       "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3070,7 +3065,6 @@
       "integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.49.0",
         "@typescript-eslint/types": "8.49.0",
@@ -3766,7 +3760,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3816,7 +3809,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4432,7 +4424,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4659,7 +4650,6 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -4713,15 +4703,13 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/class-validator": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.3.tgz",
       "integrity": "sha512-rXXekcjofVN1LTOSw+u4u9WXVEUvNBVjORW154q/IdmYWy1nMbOU9aNtZB0t8m+FJQ9q91jlr2f9CwwUFdFMRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -5503,7 +5491,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5564,7 +5551,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -6555,6 +6541,7 @@
       "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.4.0.tgz",
       "integrity": "sha512-Wn2i1In6XFxl8Az55kkgnFRiAlIAushzh26PTjL2AKtQcEfXrcLa7Hn5QOWGZEf3LU057P9TwwZjFyxfS1VuvQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "hookified": "^1.14.0"
       },
@@ -7043,7 +7030,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -9040,7 +9026,6 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9350,8 +9335,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -9447,7 +9431,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -10246,7 +10229,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10597,7 +10579,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -10770,7 +10751,6 @@
       "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.28.tgz",
       "integrity": "sha512-6GH7wXhtfq2D33ZuRXYwIsl/qM5685WZcODZb7noOOcRMteM9KF2x2ap3H0EBjnSV0VO4gNAfJT5Ukp0PkOlvg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^4.2.0",
@@ -10976,7 +10956,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11276,7 +11255,6 @@
       "integrity": "sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -11346,7 +11324,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/backend/src/blog/blog.controller.ts
+++ b/backend/src/blog/blog.controller.ts
@@ -46,11 +46,11 @@ export class BlogController {
   @Get('me/key')
   async getMyBlogKey(
     @Req() req: AuthenticatedRequest
-  ): Promise<SuccessResponse<{ blogKey: string }>> {
+  ): Promise<SuccessResponse<{ blogKey: string; domain: string }>> {
     const { userId } = req.user;
-    const blogKey = await this.blogService.getMyBlogKey(userId);
+    const { blogKey, domain } = await this.blogService.getMyBlogKey(userId);
     return successResponse(
-      { blogKey },
+      { blogKey, domain },
       '블로그 키가 성공적으로 반환되었습니다.'
     );
   }

--- a/backend/src/blog/blog.controller.ts
+++ b/backend/src/blog/blog.controller.ts
@@ -2,7 +2,10 @@ import { Body, Controller, Get, Post, Req } from '@nestjs/common';
 import { CreateBlogDto } from './dto/create-blog.dto';
 import { type AuthenticatedRequest } from 'src/types/authenticated-request';
 import { BlogService } from './blog.service';
-import { successResponse } from 'src/common/response/success-response';
+import {
+  SuccessResponse,
+  successResponse,
+} from 'src/common/response/success-response';
 
 @Controller('blogs')
 export class BlogController {
@@ -12,7 +15,7 @@ export class BlogController {
   async createBlog(
     @Body() createBlogDto: CreateBlogDto,
     @Req() req: AuthenticatedRequest
-  ) {
+  ): Promise<SuccessResponse<{ blogKey: string }>> {
     const { blogName, blogUrl } = createBlogDto;
     const { userId } = req.user;
 
@@ -22,11 +25,16 @@ export class BlogController {
       userId,
     });
 
-    return successResponse({ blogKey }, 'blogKey가 성공적으로 반환되었습니다.');
+    return successResponse(
+      { blogKey },
+      '블로그 키가 성공적으로 반환되었습니다.'
+    );
   }
 
   @Get('me/exists')
-  async getMyBlogExists(@Req() req: AuthenticatedRequest) {
+  async getMyBlogExists(
+    @Req() req: AuthenticatedRequest
+  ): Promise<SuccessResponse<{ exists: boolean }>> {
     const { userId } = req.user;
     const exists = await this.blogService.getMyBlogExists(userId);
     return successResponse(
@@ -36,7 +44,9 @@ export class BlogController {
   }
 
   @Get('me/key')
-  async getMyBlogKey(@Req() req: AuthenticatedRequest) {
+  async getMyBlogKey(
+    @Req() req: AuthenticatedRequest
+  ): Promise<SuccessResponse<{ blogKey: string }>> {
     const { userId } = req.user;
     const blogKey = await this.blogService.getMyBlogKey(userId);
     return successResponse(

--- a/backend/src/blog/blog.controller.ts
+++ b/backend/src/blog/blog.controller.ts
@@ -34,4 +34,14 @@ export class BlogController {
       '블로그 등록 여부가 성공적으로 반환되었습니다.'
     );
   }
+
+  @Get('me/key')
+  async getMyBlogKey(@Req() req: AuthenticatedRequest) {
+    const { userId } = req.user;
+    const blogKey = await this.blogService.getMyBlogKey(userId);
+    return successResponse(
+      { blogKey },
+      '블로그 키가 성공적으로 반환되었습니다.'
+    );
+  }
 }

--- a/backend/src/blog/blog.service.ts
+++ b/backend/src/blog/blog.service.ts
@@ -67,7 +67,7 @@ export class BlogService {
     if (await this.userRepository.verifyRole(userId, UserRole.ADVERTISER)) {
       throw new BadRequestException('잘못된 Role의 접근입니다.');
     }
-    const blog = await this.blogRepository.findById(userId);
+    const blog = await this.blogRepository.findByUserId(userId);
 
     if (!blog) {
       throw new NotFoundException('사용자의 블로그가 존재하지 않습니다.');

--- a/backend/src/blog/blog.service.ts
+++ b/backend/src/blog/blog.service.ts
@@ -3,6 +3,7 @@ import {
   ConflictException,
   Injectable,
   InternalServerErrorException,
+  NotFoundException,
 } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import { UserRole } from 'src/user/entities/user.entity';
@@ -55,16 +56,23 @@ export class BlogService {
     return blogKey;
   }
 
-  async getMyBlogExists(userId: number) {
+  async getMyBlogExists(userId: number): Promise<boolean> {
     if (await this.userRepository.verifyRole(userId, UserRole.ADVERTISER)) {
       throw new BadRequestException('잘못된 Role의 접근입니다.');
     }
     return await this.blogRepository.existsBlogByUserId(userId);
   }
 
-  async getMyBlogKey(userId: number) {
+  async getMyBlogKey(userId: number): Promise<string> {
     if (await this.userRepository.verifyRole(userId, UserRole.ADVERTISER)) {
       throw new BadRequestException('잘못된 Role의 접근입니다.');
     }
+    const blog = await this.blogRepository.findById(userId);
+
+    if (!blog) {
+      throw new NotFoundException('사용자의 블로그가 존재하지 않습니다.');
+    }
+
+    return blog.blogKey;
   }
 }

--- a/backend/src/blog/blog.service.ts
+++ b/backend/src/blog/blog.service.ts
@@ -63,7 +63,9 @@ export class BlogService {
     return await this.blogRepository.existsBlogByUserId(userId);
   }
 
-  async getMyBlogKey(userId: number): Promise<string> {
+  async getMyBlogKey(
+    userId: number
+  ): Promise<{ blogKey: string; domain: string }> {
     if (await this.userRepository.verifyRole(userId, UserRole.ADVERTISER)) {
       throw new BadRequestException('잘못된 Role의 접근입니다.');
     }
@@ -73,6 +75,6 @@ export class BlogService {
       throw new NotFoundException('사용자의 블로그가 존재하지 않습니다.');
     }
 
-    return blog.blogKey;
+    return { blogKey: blog.blogKey, domain: blog.domain };
   }
 }

--- a/backend/src/blog/blog.service.ts
+++ b/backend/src/blog/blog.service.ts
@@ -61,4 +61,10 @@ export class BlogService {
     }
     return await this.blogRepository.existsBlogByUserId(userId);
   }
+
+  async getMyBlogKey(userId: number) {
+    if (await this.userRepository.verifyRole(userId, UserRole.ADVERTISER)) {
+      throw new BadRequestException('잘못된 Role의 접근입니다.');
+    }
+  }
 }

--- a/backend/src/blog/repository/blog.repository.interface.ts
+++ b/backend/src/blog/repository/blog.repository.interface.ts
@@ -13,6 +13,9 @@ export abstract class BlogRepository {
   // blogId로 블로그 조회
   abstract findById(id: number): Promise<BlogEntity | null>;
 
+  // userId로 블로그 조회
+  abstract findByUserId(userId: number): Promise<BlogEntity | null>;
+
   // blogKey로 블로그 조회 (SDK 연동용)
   abstract findByBlogKey(blogKey: string): Promise<BlogEntity | null>;
   abstract existsBlogByUserId(userId: number): Promise<boolean>;

--- a/backend/src/blog/repository/typeorm-blog.repository.ts
+++ b/backend/src/blog/repository/typeorm-blog.repository.ts
@@ -37,6 +37,11 @@ export class TypeOrmBlogRepository extends BlogRepository {
     return await this.blogRepo.findOne({ where: { id } });
   }
 
+  // userId로 블로그 조회
+  async findByUserId(userId: number): Promise<BlogEntity | null> {
+    return await this.blogRepo.findOne({ where: { userId } });
+  }
+
   // blogKey로 블로그 조회 (SDK 연동용)
   async findByBlogKey(blogKey: string): Promise<BlogEntity | null> {
     return await this.blogRepo.findOne({ where: { blogKey } });

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.1.18",
+        "@tanstack/react-query": "^5.90.19",
         "axios": "^1.13.2",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -1793,6 +1794,32 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.19",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.19.tgz",
+      "integrity": "sha512-GLW5sjPVIvH491VV1ufddnfldyVB+teCnpPIvweEfkpRx7CfUmUGhoh9cdcUKBh/KwVxk22aNEDxeTsvmyB/WA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.19",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.19.tgz",
+      "integrity": "sha512-qTZRZ4QyTzQc+M0IzrbKHxSeISUmRB3RPGmao5bT+sI6ayxSRhn0FXEnT5Hg3as8SBFcRosrXXRFB+yAcxVxJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@types/babel__core": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.18",
+    "@tanstack/react-query": "^5.90.19",
     "axios": "^1.13.2",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/frontend/src/1_app/providers/QueryProvider.tsx
+++ b/frontend/src/1_app/providers/QueryProvider.tsx
@@ -1,0 +1,19 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      // staleTime (데이터가 '신선함'을 유지하는 시간)
+      staleTime: 1000 * 60, // 1분
+      // gcTime (메모리에 캐시가 남아있는 시간)
+      gcTime: 1000 * 60 * 5, // 5분
+    },
+  },
+});
+
+export function QueryProvider({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}

--- a/frontend/src/1_app/providers/RouterProvider.tsx
+++ b/frontend/src/1_app/providers/RouterProvider.tsx
@@ -7,7 +7,7 @@ import { AdvertiserBudgetPage } from '@pages/advertiserBudget';
 import { NotFoundPage } from '@pages/notFound';
 import { RegisterPage } from '@pages/auth/ui/RegisterPage';
 import { LoginPage } from '@pages/auth/ui/LoginPage';
-import { PublisherDashboardPage } from '@pages/publisherDashboard';
+// import { PublisherDashboardPage } from '@pages/publisherDashboard';
 import { PublisherEarningsPage } from '@pages/publisherEarnings';
 import { PublisherSettingsPage } from '@pages/publisherSettings';
 import { OnboardingSdkGuidePageSkeleton } from '@pages/onboardingSdkGuide';
@@ -72,7 +72,15 @@ export const router = createBrowserRouter([
         loader: publisherBlogRequiredLoader,
         element: <DashboardLayout />, // 👈 다른 레이아웃 지정
         children: [
-          { path: 'main', element: <PublisherDashboardPage /> },
+          // { path: 'main', element: <PublisherDashboardPage /> }, // 개발 편의상 메인을 온보딩 대시보드로연결해두었습니다.
+          {
+            path: 'main',
+            element: (
+              <Suspense fallback={<OnboardingSdkGuidePageSkeleton />}>
+                <OnboardingSdkGuidePage />
+              </Suspense>
+            ),
+          },
           { path: 'earnings', element: <PublisherEarningsPage /> },
           { path: 'settings', element: <PublisherSettingsPage /> },
         ],

--- a/frontend/src/2_pages/onboardingSdkGuide/ui/OnboardingSdkGuidePage.tsx
+++ b/frontend/src/2_pages/onboardingSdkGuide/ui/OnboardingSdkGuidePage.tsx
@@ -10,24 +10,47 @@ import {
 } from '@features/sdkInstallation';
 import type { SdkMode } from '@features/sdkInstallation';
 import { useBlogKey } from '@/3_features/sdkInstallation/lib/useBlogKey';
-
-// TODO: API 응답 or 로그인 시 받아온 실제 blogKey로 교체 필요!
-const MOCK_BLOG_KEY = 'tech-blog-1';
+import { OnboardingSdkGuidePageSkeleton } from './OnboardingSdkGuidePageSkeleton';
 
 export function OnboardingSdkGuidePage() {
   const navigate = useNavigate();
   const [mode, setMode] = useState<SdkMode>('auto');
-  const { data } = useBlogKey();
+  const { data, isPending, isError, error } = useBlogKey();
+
+  if (isPending) {
+    return <OnboardingSdkGuidePageSkeleton />;
+  }
+
+  if (isError || !data?.blogKey) {
+    return (
+      <div className="flex flex-col items-center gap-4 px-8 py-6 bg-gray-50">
+        <p className="text-sm font-medium text-gray-900">
+          블로그 키를 불러오지 못했습니다.
+        </p>
+        <p className="text-xs text-gray-500">
+          {error instanceof Error ? error.message : '잠시 후 다시 시도해주세요.'}
+        </p>
+        <button
+          className="flex flex-row bg-blue-500 items-center py-3 px-8 gap-1.5 text-white rounded-lg"
+          onClick={() => navigate('/publisher/onboarding/blog-admission')}
+        >
+          <span className="text-base font-medium cursor-pointer">
+            블로그 등록하러 가기
+          </span>
+        </button>
+      </div>
+    );
+  }
 
   const handleNavigateToDashboard = () => {
-    navigate('/publisher/dashboard');
+    navigate('/publisher/dashboard/main');
   };
 
   return (
     <div className="flex flex-col items-center gap-8 px-8 py-6 bg-gray-50">
       <SdkSuccessHeader mode={mode} />
       <SdkModeToggle mode={mode} onModeChange={setMode} />
-      <SdkCodeSnippet blogKey={MOCK_BLOG_KEY} mode={mode} />
+      <SdkCodeSnippet blogKey={data.blogKey} mode={mode} />
       <SdkInfoBox mode={mode} />
       <SdkInstallGuideList mode={mode} />
       <SdkInstallFooter onNavigateToDashboard={handleNavigateToDashboard} />

--- a/frontend/src/2_pages/onboardingSdkGuide/ui/OnboardingSdkGuidePage.tsx
+++ b/frontend/src/2_pages/onboardingSdkGuide/ui/OnboardingSdkGuidePage.tsx
@@ -28,7 +28,9 @@ export function OnboardingSdkGuidePage() {
           블로그 키를 불러오지 못했습니다.
         </p>
         <p className="text-xs text-gray-500">
-          {error instanceof Error ? error.message : '잠시 후 다시 시도해주세요.'}
+          {error instanceof Error
+            ? error.message
+            : '잠시 후 다시 시도해주세요.'}
         </p>
         <button
           className="flex flex-row bg-blue-500 items-center py-3 px-8 gap-1.5 text-white rounded-lg"
@@ -46,6 +48,18 @@ export function OnboardingSdkGuidePage() {
     navigate('/publisher/dashboard/main');
   };
 
+  const handleRedirectToMyWeb = () => {
+    const url = data.domain.startsWith('http')
+      ? data.domain
+      : `https://${data.domain}`;
+
+    const a = document.createElement('a');
+    a.href = url;
+    a.target = '_blank';
+    a.rel = 'noopener noreferrer';
+    a.click();
+  };
+
   return (
     <div className="flex flex-col items-center gap-8 px-8 py-6 bg-gray-50">
       <SdkSuccessHeader mode={mode} />
@@ -53,7 +67,10 @@ export function OnboardingSdkGuidePage() {
       <SdkCodeSnippet blogKey={data.blogKey} mode={mode} />
       <SdkInfoBox mode={mode} />
       <SdkInstallGuideList mode={mode} />
-      <SdkInstallFooter onNavigateToDashboard={handleNavigateToDashboard} />
+      <SdkInstallFooter
+        onRedirectToMyWeb={handleRedirectToMyWeb}
+        onNavigateToDashboard={handleNavigateToDashboard}
+      />
     </div>
   );
 }

--- a/frontend/src/2_pages/onboardingSdkGuide/ui/OnboardingSdkGuidePage.tsx
+++ b/frontend/src/2_pages/onboardingSdkGuide/ui/OnboardingSdkGuidePage.tsx
@@ -9,6 +9,7 @@ import {
   SdkModeToggle,
 } from '@features/sdkInstallation';
 import type { SdkMode } from '@features/sdkInstallation';
+import { useBlogKey } from '@/3_features/sdkInstallation/lib/useBlogKey';
 
 // TODO: API 응답 or 로그인 시 받아온 실제 blogKey로 교체 필요!
 const MOCK_BLOG_KEY = 'tech-blog-1';
@@ -16,6 +17,7 @@ const MOCK_BLOG_KEY = 'tech-blog-1';
 export function OnboardingSdkGuidePage() {
   const navigate = useNavigate();
   const [mode, setMode] = useState<SdkMode>('auto');
+  const { data } = useBlogKey();
 
   const handleNavigateToDashboard = () => {
     navigate('/publisher/dashboard');

--- a/frontend/src/3_features/authorize/login/ui/LoginForm.tsx
+++ b/frontend/src/3_features/authorize/login/ui/LoginForm.tsx
@@ -20,7 +20,7 @@ export function LoginForm() {
       <button
         type="button"
         className="flex h-11 items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white text-base font-semibold text-[#111318] hover:bg-gray-50"
-        onClick={()=>onClick()}
+        onClick={() => onClick()}
       >
         <Icon.Google />
         <span className="cursor-default">Google로 계속하기</span>
@@ -42,7 +42,8 @@ export function LoginForm() {
       />
       <button
         type="submit"
-        className="h-11 rounded-lg bg-blue-600 text-base font-semibold text-white hover:bg-blue-700"
+        disabled={true}
+        className="h-11 rounded-lg bg-blue-600 text-base font-semibold text-white hover:bg-blue-700 cursor-not-allowed"
       >
         로그인
       </button>

--- a/frontend/src/3_features/authorize/register/ui/RegisterForm.tsx
+++ b/frontend/src/3_features/authorize/register/ui/RegisterForm.tsx
@@ -58,7 +58,8 @@ export function RegisterForm() {
       </div>
       <button
         type="submit"
-        className="h-11 rounded-lg bg-blue-600 text-base font-semibold text-white hover:bg-blue-700"
+        disabled={true}
+        className="h-11 rounded-lg bg-blue-600 text-base font-semibold text-white hover:bg-blue-700 cursor-not-allowed"
       >
         회원가입
       </button>

--- a/frontend/src/3_features/sdkInstallation/lib/useBlogKey.ts
+++ b/frontend/src/3_features/sdkInstallation/lib/useBlogKey.ts
@@ -1,0 +1,9 @@
+import { apiClient } from '@/4_shared/lib/api';
+import { useQuery } from '@tanstack/react-query';
+
+export function useBlogKey() {
+  return useQuery({
+    queryKey: ['blog', 'me', 'key'],
+    queryFn: async () => await apiClient<string>('/api/blogs/me/key'),
+  });
+}

--- a/frontend/src/3_features/sdkInstallation/lib/useBlogKey.ts
+++ b/frontend/src/3_features/sdkInstallation/lib/useBlogKey.ts
@@ -4,6 +4,9 @@ import { useQuery } from '@tanstack/react-query';
 export function useBlogKey() {
   return useQuery({
     queryKey: ['blog', 'me', 'key'],
-    queryFn: async () => await apiClient<string>('/api/blogs/me/key'),
+    queryFn: async () =>
+      await apiClient<{ blogKey: string }>('/api/blogs/me/key'),
+    staleTime: 10 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
   });
 }

--- a/frontend/src/3_features/sdkInstallation/lib/useBlogKey.ts
+++ b/frontend/src/3_features/sdkInstallation/lib/useBlogKey.ts
@@ -5,7 +5,7 @@ export function useBlogKey() {
   return useQuery({
     queryKey: ['blog', 'me', 'key'],
     queryFn: async () =>
-      await apiClient<{ blogKey: string }>('/api/blogs/me/key'),
+      await apiClient<{ blogKey: string; domain: string }>('/api/blogs/me/key'),
     staleTime: 10 * 60 * 1000,
     gcTime: 30 * 60 * 1000,
   });

--- a/frontend/src/3_features/sdkInstallation/ui/SdkInstallFooter.tsx
+++ b/frontend/src/3_features/sdkInstallation/ui/SdkInstallFooter.tsx
@@ -13,7 +13,7 @@ export function SdkInstallFooter({
     <div className="flex flex-col w-150 items-center gap-2">
       <div className="flex gap-2">
         <button
-          className="flex flex-row bg-white items-center py-3 border border-gray-300 px-8 gap-1.5 text-gray-600 rounded-lg"
+          className="flex flex-row bg-blue-500 items-center py-3  px-8 gap-1.5 text-white rounded-lg"
           onClick={onRedirectToMyWeb}
         >
           <span className="text-base font-medium cursor-pointer">
@@ -22,7 +22,7 @@ export function SdkInstallFooter({
           <Icon.ArrowRight className="w-3" />
         </button>
         <button
-          className="flex flex-row bg-blue-500 items-center py-3  px-8 gap-1.5 text-white rounded-lg"
+          className="flex flex-row bg-white items-center py-3  px-8 gap-1.5 border border-gray-300 text-gray-600  rounded-lg"
           onClick={onNavigateToDashboard}
         >
           <span className="text-base font-medium cursor-pointer">

--- a/frontend/src/3_features/sdkInstallation/ui/SdkInstallFooter.tsx
+++ b/frontend/src/3_features/sdkInstallation/ui/SdkInstallFooter.tsx
@@ -2,22 +2,35 @@ import { Icon } from '@shared/ui/Icon';
 
 interface SdkInstallFooterProps {
   onNavigateToDashboard?: () => void;
+  onRedirectToMyWeb?: () => void;
 }
 
 export function SdkInstallFooter({
   onNavigateToDashboard,
+  onRedirectToMyWeb,
 }: SdkInstallFooterProps) {
   return (
     <div className="flex flex-col w-150 items-center gap-2">
-      <button
-        className="flex flex-row bg-blue-500 items-center py-3  px-8 gap-1.5 text-white rounded-lg"
-        onClick={onNavigateToDashboard}
-      >
-        <span className="text-base font-medium cursor-pointer">
-          대시보드로 이동
-        </span>
-        <Icon.ArrowRight className="w-3" />
-      </button>
+      <div className="flex gap-2">
+        <button
+          className="flex flex-row bg-white items-center py-3 border border-gray-300 px-8 gap-1.5 text-gray-600 rounded-lg"
+          onClick={onRedirectToMyWeb}
+        >
+          <span className="text-base font-medium cursor-pointer">
+            내 웹사이트로 이동
+          </span>
+          <Icon.ArrowRight className="w-3" />
+        </button>
+        <button
+          className="flex flex-row bg-blue-500 items-center py-3  px-8 gap-1.5 text-white rounded-lg"
+          onClick={onNavigateToDashboard}
+        >
+          <span className="text-base font-medium cursor-pointer">
+            대시보드로 이동
+          </span>
+          <Icon.ArrowRight className="w-3" />
+        </button>
+      </div>
 
       <p className="text-xs font-normal whitespace-nowrap text-gray-500">
         설치 확인 후 자동으로 광고 게재가 시작됩니다

--- a/frontend/src/4_shared/ui/Header/Header.tsx
+++ b/frontend/src/4_shared/ui/Header/Header.tsx
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
 import { API_CONFIG } from '@/4_shared/lib/api';
 import { Button } from '@shared/ui/Button';
+import { useQueryClient } from '@tanstack/react-query';
 
 interface HeaderProps {
   title: string;
@@ -9,7 +10,7 @@ interface HeaderProps {
 
 export function Header({ title }: HeaderProps) {
   const navigate = useNavigate();
-
+  const queryClient = useQueryClient();
   const handleLogout = async () => {
     try {
       await axios.post(
@@ -18,6 +19,7 @@ export function Header({ title }: HeaderProps) {
         { withCredentials: true }
       );
     } finally {
+      queryClient.clear();
       navigate('/auth/login', { replace: true });
     }
   };

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,11 +1,14 @@
 import { ToastProvider } from '@app/providers';
 import { RouterProvider } from 'react-router-dom';
 import { router } from '@app/providers';
+import { QueryProvider } from './1_app/providers/QueryProvider';
 
 export default function App() {
   return (
-    <ToastProvider>
-      <RouterProvider router={router} />
-    </ToastProvider>
+    <QueryProvider>
+      <ToastProvider>
+        <RouterProvider router={router} />
+      </ToastProvider>
+    </QueryProvider>
   );
 }


### PR DESCRIPTION
<!-- PR 제목 예시 : [Feat] 로그인 기능 구현 -->
<!-- PR 제목은 위 형식을 참고하여 작성해주세요. -->
<!-- 필요 없는 내용은 지우고 작성해주세요 -->

## 🔗 관련 이슈

- close: #

---

## ✅ 작업 내용

### 📌 주요 검토 파일

- `backend/src/blog/blog.controller.ts`
  - `GET /api/blogs/me/key`: 현재 로그인 유저의 `blogKey/domain` 조회 엔드포인트 추가
  - controller 응답 타입(`SuccessResponse<T>`) 명시
- `backend/src/blog/blog.service.ts`
  - `getMyBlogKey`: 퍼블리셔만 조회 가능하도록 role 검증 + 블로그 미존재 시 404 처리
- `backend/src/blog/repository/blog.repository.interface.ts`
  - `findByUserId` 추가 (내 블로그 조회 시 `blog.id`가 아닌 `user_id` 기준 조회)
- `backend/src/blog/repository/typeorm-blog.repository.ts`
  - `findByUserId` 구현
- `frontend/package.json`
  - `@tanstack/react-query` 추가 (blogKey 캐싱 목적)
- `frontend/src/1_app/providers/QueryProvider.tsx`
  - `QueryClientProvider` 전역 적용 (기본 `staleTime/gcTime` 설정)
- `frontend/src/App.tsx`
  - App 최상단에 `QueryProvider` 적용
- `frontend/src/3_features/sdkInstallation/lib/useBlogKey.ts`
  - `useBlogKey` 커스텀 훅 추가 (`GET /api/blogs/me/key` 호출 + 캐싱)
- `frontend/src/2_pages/onboardingSdkGuide/ui/OnboardingSdkGuidePage.tsx`
  - SDK 가이드 페이지에서 MOCK 값 제거, `useBlogKey()`로 실제 `blogKey` 사용
  - 로딩/에러 UI 처리
  - "내 웹사이트로 이동" 클릭 시 `domain` 기반 새 탭 이동
- `frontend/src/3_features/sdkInstallation/ui/SdkInstallFooter.tsx`
  - "내 웹사이트로 이동" / "대시보드로 이동" 액션 버튼 분리
- `frontend/src/4_shared/ui/Header/Header.tsx`
  - 로그아웃 시 `queryClient.clear()`로 캐시 초기화(계정 전환 시 데이터 섞임 방지)
- `frontend/src/1_app/providers/RouterProvider.tsx`
  - (개발 편의) `/publisher/dashboard/main`을 SDK 가이드 페이지로 임시 연결
- `frontend/src/3_features/authorize/login/ui/LoginForm.tsx`
  - (임시) 이메일/비밀번호 로그인 submit 버튼 비활성화
- `frontend/src/3_features/authorize/register/ui/RegisterForm.tsx`
  - (임시) 이메일/비밀번호 회원가입 submit 버튼 비활성화

### 1. 내 blogKey 조회 API 추가

- 퍼블리셔 SDK 가이드/연동 페이지에서 사용할 수 있도록 `GET /api/blogs/me/key` 엔드포인트를 추가했습니다.
- 블로그가 없는 유저는 404(`사용자의 블로그가 존재하지 않습니다.`)로 응답합니다.

### 2. TanStack Query 기반 blogKey 캐싱 훅 추가

- `useBlogKey` 훅에서 `/api/blogs/me/key` 호출 결과를 캐싱하여 동일 세션 내 불필요한 재요청을 줄였습니다.
- 로그아웃 시 캐시를 초기화하여 계정 전환 시 blogKey가 섞이지 않도록 처리했습니다.

### 3. SDK 가이드 페이지 연동(로딩/에러 처리)

- SDK 가이드 페이지에서 `blogKey`를 API로 받아 코드 스니펫에 주입하도록 연결했습니다.
- 로딩 중에는 스켈레톤을, 오류/데이터 미존재 시에는 블로그 등록 페이지로 유도하는 UI를 추가했습니다.
- 조회한 `domain`을 이용해 "내 웹사이트로 이동" 버튼에서 새 탭으로 이동할 수 있도록 연결했습니다.

### 4. (임시) 이메일/비밀번호 로그인/회원가입 버튼 비활성화

- OAuth 기반 플로우를 우선 제공하기 위해, 로그인/회원가입 form의 submit 버튼을 임시로 비활성화했습니다.

## 📸 스크린샷 / 데모 (옵션)

-
<img width="1559" height="1176" alt="image" src="https://github.com/user-attachments/assets/231f72f0-6baa-4ffe-80ed-7dab3305ba82" />

---

## 🧪 테스트 방법 (옵션)

1. 퍼블리셔 계정으로 로그인 후 블로그 등록을 완료합니다.
2. `GET /api/blogs/me/key` 호출 시 `{ blogKey, domain }`가 반환되는지 확인합니다.
3. `/publisher/onboarding/sdk-guide`(또는 임시로 연결된 `/publisher/dashboard/main`)에서 SDK 코드 스니펫에 `blogKey`가 반영되는지 확인합니다.
4. "내 웹사이트로 이동" 버튼 클릭 시 새 탭으로 이동되는지 확인합니다.
5. 로그아웃 후 다른 계정으로 로그인하여 이전 계정의 `blogKey`가 캐시에 남지 않는지 확인합니다.

---

## 💬 To Reviewers

- `RouterProvider.tsx`에서 `/publisher/dashboard/main`을 SDK 가이드 페이지로 임시 연결해둔 상태입니다(개발 편의). 머지 전 유지/롤백 여부 확인 부탁드립니다.
- 자체 로그인/회원가입 버튼은 막아두었습니다.