### PR TITLE
[Feat] 광고주 대시보드 캠페인 목록 API 연동

### DIFF
--- a/backend/src/campaign/campaign.service.ts
+++ b/backend/src/campaign/campaign.service.ts
@@ -7,6 +7,7 @@ import { CampaignRepository } from './repository/campaign.repository';
 import { CreateCampaignDto } from './dto/create-campaign.dto';
 import { UpdateCampaignDto } from './dto/update-campaign.dto';
 import { GetCampaignListDto } from './dto/get-campaign-list.dto';
+import { CampaignStatus } from './entities/campaign.entity';
 import type {
   CampaignWithTags,
   CampaignWithStats,
@@ -17,7 +18,7 @@ import { AVAILABLE_TAGS } from '../common/constants';
 export class CampaignService {
   constructor(private readonly campaignRepository: CampaignRepository) {}
 
-  // 캠페인 생성 (태그 검증 + 날짜 유효성 체크)
+  // 캠페인 생성 (태그 검증 + 날짜 유효성 체크 + 시작일 기준 상태 설정)
   async createCampaign(
     userId: number,
     dto: CreateCampaignDto
@@ -28,7 +29,23 @@ export class CampaignService {
       throw new BadRequestException('시작일은 종료일보다 앞서야 합니다.');
     }
 
-    return this.campaignRepository.create(userId, dto, tagIds);
+    // 시작일이 오늘 이하면 ACTIVE, 내일 이상이면 PENDING
+    const initialStatus = this.determineInitialStatus(dto.startDate);
+
+    return this.campaignRepository.create(userId, dto, tagIds, initialStatus);
+  }
+
+  // 시작일 기준 초기 상태 결정
+  private determineInitialStatus(
+    startDate: string
+  ): CampaignStatus.ACTIVE | CampaignStatus.PENDING {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    const start = new Date(startDate);
+    start.setHours(0, 0, 0, 0);
+
+    return start <= today ? CampaignStatus.ACTIVE : CampaignStatus.PENDING;
   }
 
   // 태그 이름 배열을 태그 ID 배열로 변환
@@ -164,7 +181,7 @@ export class CampaignService {
     return this.addStatsToCampaign(campaign);
   }
 
-  // 캠페인 수정 (소유권 + 날짜 + 태그 검증)
+  // 캠페인 수정 (소유권 + 날짜 + 태그 검증 + 시작일 변경 시 상태 재결정)
   async updateCampaign(
     campaignId: string,
     userId: number,
@@ -182,7 +199,16 @@ export class CampaignService {
 
     const tagIds = dto.tags ? this.validateAndGetTagIds(dto.tags) : undefined;
 
-    return this.campaignRepository.update(campaignId, dto, tagIds);
+    // 시작일이 변경된 경우, 상태 재결정 (PENDING/ACTIVE 상태인 경우에만)
+    let newStatus: CampaignStatus | undefined;
+    if (
+      dto.startDate &&
+      (campaign.status === 'PENDING' || campaign.status === 'ACTIVE')
+    ) {
+      newStatus = this.determineInitialStatus(dto.startDate);
+    }
+
+    return this.campaignRepository.update(campaignId, dto, tagIds, newStatus);
   }
 
   // 캠페인 삭제 (소프트 삭제, 소유권 검증)

--- a/backend/src/campaign/dto/update-campaign.dto.ts
+++ b/backend/src/campaign/dto/update-campaign.dto.ts
@@ -56,6 +56,10 @@ export class UpdateCampaignDto {
   status?: 'ACTIVE' | 'PAUSED';
 
   @IsOptional()
+  @IsDateString({}, { message: '시작일은 ISO 8601 형식이어야 합니다.' })
+  startDate?: string;
+
+  @IsOptional()
   @IsDateString({}, { message: '종료일은 ISO 8601 형식이어야 합니다.' })
   endDate?: string;
 }

--- a/backend/src/campaign/repository/campaign.repository.ts
+++ b/backend/src/campaign/repository/campaign.repository.ts
@@ -12,7 +12,8 @@ export abstract class CampaignRepository {
   abstract create(
     userId: number,
     dto: CreateCampaignDto,
-    tagIds: number[]
+    tagIds: number[],
+    initialStatus?: CampaignStatus
   ): Promise<CampaignWithTags>;
 
   abstract findByUserId(
@@ -35,7 +36,8 @@ export abstract class CampaignRepository {
   abstract update(
     campaignId: string,
     dto: UpdateCampaignDto,
-    tagIds?: number[]
+    tagIds?: number[],
+    newStatus?: CampaignStatus
   ): Promise<CampaignWithTags>;
 
   abstract delete(campaignId: string): Promise<void>;

--- a/backend/src/campaign/repository/json-campaign.repository.ts
+++ b/backend/src/campaign/repository/json-campaign.repository.ts
@@ -74,7 +74,8 @@ export class JsonCampaignRepository extends CampaignRepository {
   create(
     userId: number,
     dto: CreateCampaignDto,
-    tagIds: number[]
+    tagIds: number[],
+    initialStatus: CampaignStatus = CampaignStatus.PENDING
   ): Promise<CampaignWithTags> {
     const now = new Date();
     const campaign: CampaignWithTags = {
@@ -91,7 +92,7 @@ export class JsonCampaignRepository extends CampaignRepository {
       totalSpent: 0,
       lastResetDate: now,
       isHighIntent: dto.isHighIntent,
-      status: CampaignStatus.PENDING,
+      status: initialStatus,
       startDate: new Date(dto.startDate),
       endDate: new Date(dto.endDate),
       createdAt: now,

--- a/frontend/src/2_pages/advertiserCampaigns/ui/AdvertiserCampaignsPage.tsx
+++ b/frontend/src/2_pages/advertiserCampaigns/ui/AdvertiserCampaignsPage.tsx
@@ -1,8 +1,91 @@
+import { useState } from 'react';
+import {
+  useCampaignStats,
+  CampaignStatsTableHeader,
+  CampaignStatsTableRow,
+} from '@features/campaignStats';
+
+const ITEMS_PER_PAGE = 10;
+
 export function AdvertiserCampaignsPage() {
+  const [offset, setOffset] = useState(0);
+  const { campaigns, total, hasMore, isLoading, error } = useCampaignStats({
+    limit: ITEMS_PER_PAGE,
+    offset,
+  });
+
+  const currentPage = Math.floor(offset / ITEMS_PER_PAGE) + 1;
+  const totalPages = Math.ceil(total / ITEMS_PER_PAGE);
+
+  const handlePrevPage = () => {
+    if (offset > 0) {
+      setOffset(offset - ITEMS_PER_PAGE);
+    }
+  };
+
+  const handleNextPage = () => {
+    if (hasMore) {
+      setOffset(offset + ITEMS_PER_PAGE);
+    }
+  };
+
   return (
-    <div className="min-h-screen bg-gray-50">
-      <h1 className="text-3xl font-bold p-8">캠페인 관리</h1>
-      <p className="px-8 text-gray-600">Mock 페이지 - 나중에 구현</p>
+    <div className="min-h-screen bg-gray-50 p-8">
+      <div className="max-w-7xl mx-auto">
+        <h1 className="text-2xl font-bold text-gray-900 mb-6">캠페인 관리</h1>
+
+        <div className="bg-white border border-gray-200 rounded-xl shadow">
+          {isLoading ? (
+            <div className="p-10 text-center text-gray-500">로딩 중...</div>
+          ) : error ? (
+            <div className="p-10 text-center text-red-500">{error}</div>
+          ) : campaigns.length === 0 ? (
+            <div className="p-10 text-center text-gray-500">
+              등록된 캠페인이 없습니다.
+            </div>
+          ) : (
+            <>
+              <table className="w-full">
+                <CampaignStatsTableHeader />
+                <tbody>
+                  {campaigns.map((campaign) => (
+                    <CampaignStatsTableRow
+                      key={campaign.id}
+                      campaign={campaign}
+                    />
+                  ))}
+                </tbody>
+              </table>
+
+              <div className="flex items-center justify-between px-5 py-4 border-t border-gray-100">
+                <div className="text-sm text-gray-600">
+                  전체 {total}개 중 {offset + 1}-
+                  {Math.min(offset + ITEMS_PER_PAGE, total)}개
+                </div>
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={handlePrevPage}
+                    disabled={offset === 0}
+                    className="px-3 py-1.5 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    이전
+                  </button>
+                  <span className="text-sm text-gray-600">
+                    {currentPage} / {totalPages || 1}
+                  </span>
+                  <button
+                    onClick={handleNextPage}
+                    disabled={!hasMore}
+                    className="px-3 py-1.5 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    다음
+                  </button>
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/3_features/campaignStats/index.ts
+++ b/frontend/src/3_features/campaignStats/index.ts
@@ -1,3 +1,10 @@
 export { CampaignStatsTable } from './ui/CampaignStatsTable';
+export { CampaignStatsTableHeader } from './ui/CampaignStatsTableHeader';
+export { CampaignStatsTableRow } from './ui/CampaignStatsTableRow';
 export { BudgetProgressBar } from './ui/BudgetProgressBar';
-export type { CampaignStats, CampaignStatus, CampaignStatsResponse } from './lib/types';
+export { useCampaignStats } from './lib/useCampaignStats';
+export type {
+  CampaignStats,
+  CampaignStatus,
+  CampaignStatsResponse,
+} from './lib/types';

--- a/frontend/src/3_features/campaignStats/lib/types.ts
+++ b/frontend/src/3_features/campaignStats/lib/types.ts
@@ -12,4 +12,8 @@ export interface CampaignStats {
   isHighIntent: boolean;
 }
 
-export type CampaignStatsResponse = CampaignStats[];
+export interface CampaignStatsResponse {
+  campaigns: CampaignStats[];
+  total: number;
+  hasMore: boolean;
+}

--- a/frontend/src/3_features/campaignStats/lib/useCampaignStats.ts
+++ b/frontend/src/3_features/campaignStats/lib/useCampaignStats.ts
@@ -15,7 +15,9 @@ interface UseCampaignStatsReturn {
   error: string | null;
 }
 
-export function useCampaignStats(params: UseCampaignStatsParams = {}): UseCampaignStatsReturn {
+export function useCampaignStats(
+  params: UseCampaignStatsParams = {}
+): UseCampaignStatsReturn {
   const { limit = 3, offset = 0 } = params;
   const [campaigns, setCampaigns] = useState<CampaignStats[]>([]);
   const [total, setTotal] = useState(0);
@@ -30,12 +32,12 @@ export function useCampaignStats(params: UseCampaignStatsParams = {}): UseCampai
         setError(null);
 
         const response = await apiClient<CampaignStatsResponse>(
-          `/api/advertiser/campaigns?limit=${limit}&offset=${offset}`
+          `/api/campaigns?limit=${limit}&offset=${offset}`
         );
 
-        setCampaigns(response);
-        setTotal(0);
-        setHasMore(false);
+        setCampaigns(response.campaigns);
+        setTotal(response.total);
+        setHasMore(response.hasMore);
       } catch (err) {
         const message =
           err instanceof Error ? err.message : '알 수 없는 오류가 발생했습니다';

--- a/frontend/src/3_features/campaignStats/ui/CampaignStatsTable.tsx
+++ b/frontend/src/3_features/campaignStats/ui/CampaignStatsTable.tsx
@@ -1,59 +1,22 @@
-import type { CampaignStats } from '../lib/types';
+import { Link } from 'react-router-dom';
+import { useCampaignStats } from '../lib/useCampaignStats';
 import { CampaignStatsTableHeader } from './CampaignStatsTableHeader';
 import { CampaignStatsTableRow } from './CampaignStatsTableRow';
 
-// Mock 데이터 (API 연동 시 삭제)
-const mockCampaigns: CampaignStats[] = [
-  {
-    id: 'campaign-001',
-    title: '캠페인 A next.js 배워보기',
-    status: 'ACTIVE',
-    impressions: 384,
-    clicks: 109,
-    ctr: 28.84,
-    dailySpentPercent: 23,
-    totalSpentPercent: 80.14,
-    isHighIntent: true,
-  },
-  {
-    id: 'campaign-002',
-    title: '캠페인 B nest.js 배워보기',
-    status: 'PAUSED',
-    impressions: 384,
-    clicks: 109,
-    ctr: 28.84,
-    dailySpentPercent: 81,
-    totalSpentPercent: 25.24,
-    isHighIntent: true,
-  },
-  {
-    id: 'campaign-003',
-    title: '캠페인 C Mysql 완전 정복',
-    status: 'ENDED',
-    impressions: 384,
-    clicks: 109,
-    ctr: 28.84,
-    dailySpentPercent: 94,
-    totalSpentPercent: 65.23,
-    isHighIntent: false,
-  },
-];
-
 export function CampaignStatsTable() {
-  // TODO: API 연동 시 useCampaignStats 사용할 것!
-  // const { campaigns, isLoading, error } = useCampaignStats({ limit: 3 });
-  const campaigns = mockCampaigns;
-  const isLoading = false;
-  const error = null;
+  const { campaigns, isLoading, error } = useCampaignStats({ limit: 3 });
 
   if (isLoading) {
     return (
       <div className="text-gray-600 flex flex-col bg-white border border-gray-200 rounded-xl shadow">
         <div className="p-5 flex flex-row justify-between items-center border-b border-gray-100">
           <h2 className="text-gray-900 text-xl font-bold">캠페인</h2>
-          <a href="#" className="text-base font-bold">
+          <Link
+            to="/advertiser/dashboard/campaigns"
+            className="text-base font-bold"
+          >
             전체 캠페인 목록 보기 →
-          </a>
+          </Link>
         </div>
         <div className="p-10 text-center text-gray-500">로딩 중...</div>
       </div>
@@ -65,9 +28,12 @@ export function CampaignStatsTable() {
       <div className="text-gray-600 flex flex-col bg-white border border-gray-200 rounded-xl shadow">
         <div className="p-5 flex flex-row justify-between items-center border-b border-gray-100">
           <h2 className="text-gray-900 text-xl font-bold">캠페인</h2>
-          <a href="#" className="text-base font-bold">
+          <Link
+            to="/advertiser/dashboard/campaigns"
+            className="text-base font-bold"
+          >
             전체 캠페인 목록 보기 →
-          </a>
+          </Link>
         </div>
         <div className="p-10 text-center text-red-500">{error}</div>
       </div>
@@ -78,9 +44,12 @@ export function CampaignStatsTable() {
     <div className="text-gray-600 flex flex-col bg-white border border-gray-200 rounded-xl shadow">
       <div className="p-5 flex flex-row justify-between items-center border-b border-gray-100">
         <h2 className="text-gray-900 text-xl font-bold">캠페인</h2>
-        <a href="#" className="text-base font-bold">
+        <Link
+          to="/advertiser/dashboard/campaigns"
+          className="text-base font-bold"
+        >
           전체 캠페인 목록 보기 →
-        </a>
+        </Link>
       </div>
 
       <table>

--- a/frontend/src/4_shared/ui/Sidebar/Sidebar.tsx
+++ b/frontend/src/4_shared/ui/Sidebar/Sidebar.tsx
@@ -15,19 +15,19 @@ export function Sidebar() {
   const advertiserMenuItems: MenuItem[] = [
     {
       id: '1',
-      to: '/advertiser/dashboard',
+      to: '/advertiser/dashboard/main',
       icon: 'Dashboard',
       label: '대시보드',
     },
     {
       id: '2',
-      to: '/advertiser/campaigns',
+      to: '/advertiser/dashboard/campaigns',
       icon: 'LoudSpeaker',
       label: '캠페인 관리',
     },
     {
       id: '3',
-      to: '/advertiser/budget',
+      to: '/advertiser/dashboard/budget',
       icon: 'Wallet',
       label: '예산 관리',
     },
@@ -36,19 +36,19 @@ export function Sidebar() {
   const publisherMenuItems: MenuItem[] = [
     {
       id: '1',
-      to: '/publisher/dashboard',
+      to: '/publisher/dashboard/main',
       icon: 'Dashboard',
       label: '대시보드',
     },
     {
       id: '2',
-      to: '/publisher/earnings',
+      to: '/publisher/dashboard/earnings',
       icon: 'Wallet',
       label: '수익 관리',
     },
     {
       id: '3',
-      to: '/publisher/settings',
+      to: '/publisher/dashboard/settings',
       icon: 'Dashboard',
       label: '광고 설정',
     },


### PR DESCRIPTION
## 🔗 관련 이슈

- #이슈번호

---

## ✅ 작업 내용

### 1) 광고주 대시보드 캠페인 목록 API 연동

**변경 파일:**

- `frontend/src/3_features/campaignStats/ui/CampaignStatsTable.tsx`
- `frontend/src/3_features/campaignStats/lib/useCampaignStats.ts`
- `frontend/src/3_features/campaignStats/lib/types.ts`
- `frontend/src/3_features/campaignStats/index.ts`

**변경 내용:**

- Mock 데이터 제거 → 실제 API (`GET /api/campaigns`) 연동
- `useCampaignStats` 훅에서 API 엔드포인트 수정: `/api/advertiser/campaigns` → `/api/campaigns`
- API 응답 타입 수정: `CampaignStatsResponse`를 `{ campaigns, total, hasMore }` 객체로 변경
- "전체 캠페인 목록 보기" 링크를 `<a href="#">` → `<Link to="/advertiser/dashboard/campaigns">`로 변경

---

### 2) 캠페인 목록 페이지 구현

**변경 파일:**

- `frontend/src/2_pages/advertiserCampaigns/ui/AdvertiserCampaignsPage.tsx`

**변경 내용:**

- Mock 페이지 → 실제 캠페인 목록 페이지로 구현
- 기존 컴포넌트 재사용: `CampaignStatsTableHeader`, `CampaignStatsTableRow`
- 페이지네이션 추가 (10개씩 조회, 이전/다음 버튼)
- `useCampaignStats` 훅 사용하여 API 연동
- 로딩/에러/빈 목록 상태 처리

**페이지네이션 UI:**

- 하단에 "전체 N개 중 X-Y개" 표시
- 이전/다음 버튼으로 페이지 이동
- `hasMore` 값으로 다음 버튼 활성화 여부 결정

---

### 3) 컴포넌트 Export 추가

**변경 파일:**

- `frontend/src/3_features/campaignStats/index.ts`

**추가된 Export:**

- `CampaignStatsTableHeader` - 테이블 헤더 컴포넌트
- `CampaignStatsTableRow` - 테이블 행 컴포넌트
- `useCampaignStats` - 캠페인 목록 조회 훅

---

## 💬 To Reviewers

### 1. 대시보드 vs 캠페인 관리 페이지 차이

| 구분 | 대시보드 | 캠페인 관리 |
|------|---------|------------|
| 경로 | `/advertiser/dashboard/main` | `/advertiser/dashboard/campaigns` |
| 조회 개수 | 3개 (미리보기) | 10개씩 (페이지네이션) |
| 용도 | 요약 보기 | 전체 목록 관리 |

### 2. 컴포넌트 재사용

`CampaignStatsTableHeader`와 `CampaignStatsTableRow`를 대시보드와 캠페인 관리 페이지에서 공유한다. 스타일과 표시 항목이 동일하기 때문에 별도 컴포넌트 생성 없이 재사용했다.

### 3. 테스트 방법

<img width="1531" height="883" alt="image" src="https://github.com/user-attachments/assets/d28c8fe6-14d3-40c5-a869-7eb5409ecec9" />

<img width="1534" height="871" alt="image" src="https://github.com/user-attachments/assets/09f86fa2-1f9f-42ea-8dcf-41d73962534d" />



1. 로그인 후 대시보드 접속
2. 캠페인 3개가 표시되는지 확인
3. "전체 캠페인 목록 보기 →"  or 사이드바의 캠페인 관리 클릭
4. `/advertiser/dashboard/campaigns`로 이동 확인
5. 페이지네이션 동작 확인 (10개 이상 캠페인 필요)