### PR TITLE
[Feat] React 환경에서 수동 광고 삽입 문제 해결 및 태그 매칠 실패시 기본 캠페인 반환

### DIFF
--- a/backend/src/sdk/dto/create-view-log.dto.ts
+++ b/backend/src/sdk/dto/create-view-log.dto.ts
@@ -18,7 +18,7 @@ export class CreateViewLogDto {
   @IsNotEmpty()
   campaignId: string;
 
-  @IsUrl()
+  @IsUrl({ require_tld: false })
   @IsNotEmpty()
   postUrl: string;
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,5 +9,13 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+
+    <!-- BoostAd SDK (수동 모드) -->
+    <script
+      src="https://kr.object.ncloudstorage.com/boostad-sdk-dev/sdk/sdk.js"
+      data-blog-key="test-blog"
+      data-auto="false"
+      async
+    ></script>
   </body>
 </html>

--- a/frontend/src/2_pages/advertiserCampaigns/ui/AdvertiserCampaignsPage.tsx
+++ b/frontend/src/2_pages/advertiserCampaigns/ui/AdvertiserCampaignsPage.tsx
@@ -85,6 +85,8 @@ export function AdvertiserCampaignsPage() {
             </>
           )}
         </div>
+        {/* BoostAd 광고 영역 */}
+        <div data-boostad-zone className="mb-6" />
       </div>
     </div>
   );

--- a/sdk/src/features/BoostAdSDK.ts
+++ b/sdk/src/features/BoostAdSDK.ts
@@ -20,9 +20,10 @@ declare global {
 // BoostAD SDK 메인 클래스 (전략 패턴)
 export class BoostAdSDK {
   private hasRequestedSecondAd = false;
-  private retryCount = 0;
-  private readonly MAX_RETRIES = 5;
   private mutationObserver: MutationObserver | null = null;
+  private renderedZones = new Set<Element>(); // SPA 라우팅 대응: 이미 렌더링된 zone 추적
+  private behaviorTrackerStarted = false; // 행동 추적 시작 여부
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null; // DOM 변화 감지 디바운스
   private readonly CONTENT_SELECTORS = [
     '#area_view',
     '#article-view',
@@ -274,23 +275,20 @@ export class BoostAdSDK {
   // ========================================
 
   private async initManualMode(): Promise<void> {
-    // 초기 광고 로드 시도
-    await this.tryLoadManualAds();
+    // MutationObserver 시작 (초기 로드 + SPA 라우팅 모두 대응)
+    this.setupMutationObserver();
   }
 
   // MutationObserver 설정 (React 등 SPA의 동적 DOM 변화 감지)
   private setupMutationObserver(): void {
     this.mutationObserver = new MutationObserver(() => {
-      const zones = document.querySelectorAll('[data-boostad-zone]');
-      if (zones.length > 0) {
-        console.log('[BoostAD SDK] DOM 변화 감지: data-boostad-zone 요소 발견');
-        // Observer 해제 (한번만 실행)
-        this.mutationObserver?.disconnect();
-        // 재시도 카운트 리셋
-        this.retryCount = 0;
-        // 광고 로드
-        this.tryLoadManualAds();
+      // Debounce: 100ms 동안 추가 변화가 없으면 실행
+      if (this.debounceTimer) {
+        clearTimeout(this.debounceTimer);
       }
+      this.debounceTimer = setTimeout(() => {
+        this.checkAndLoadAds();
+      }, 100);
     });
 
     // body 전체를 감시 (하위 요소 포함)
@@ -302,60 +300,66 @@ export class BoostAdSDK {
     console.log('[BoostAD SDK] MutationObserver 활성화 (SPA 대응)');
   }
 
-  private async tryLoadManualAds(): Promise<void> {
+  // 광고존 체크 및 로드
+  private async checkAndLoadAds(): Promise<void> {
     const allZones = document.querySelectorAll('[data-boostad-zone]');
 
     if (allZones.length === 0) {
-      // SPA 환경을 위한 재시도 로직 (최대 5번)
-      if (this.retryCount < this.MAX_RETRIES) {
-        this.retryCount++;
-        console.warn(
-          `[BoostAD SDK] data-boostad-zone 요소를 찾을 수 없습니다. ${this.retryCount}초 후 재시도합니다... (${this.retryCount}/${this.MAX_RETRIES})`
-        );
-        setTimeout(() => {
-          this.tryLoadManualAds();
-        }, 1000);
-        return;
-      } else {
-        // 재시도 5번 모두 실패 → MutationObserver 시작
-        console.warn(
-          '[BoostAD SDK] data-boostad-zone 요소를 찾을 수 없습니다. MutationObserver를 시작합니다.'
-        );
-        this.setupMutationObserver();
-        return;
-      }
+      return; // zone이 없으면 아무것도 안 함
     }
 
-    // 광고존을 찾았으면 MutationObserver 중지 (혹시 실행 중이라면)
-    this.mutationObserver?.disconnect();
+    // 새로운 광고존만 필터링 (이미 렌더링된 zone 제외)
+    const newZones = Array.from(allZones).filter(
+      (zone) => !this.renderedZones.has(zone)
+    );
 
-    console.log(`[BoostAD SDK] ${allZones.length}개의 광고존을 찾았습니다.`);
+    if (newZones.length === 0) {
+      return; // 새로운 zone이 없으면 아무것도 안 함
+    }
 
-    const zones = Array.from(allZones).slice(0, 2);
+    console.log(`[BoostAD SDK] ${newZones.length}개의 새로운 광고존 발견`);
 
-    if (allZones.length > 2) {
+    // 새로운 광고존에 광고 로드
+    await this.loadAdsForZones(newZones);
+  }
+
+  // 광고존에 광고 로드 (중복 렌더링 방지)
+  private async loadAdsForZones(zones: Element[]): Promise<void> {
+    const limitedZones = zones.slice(0, 2);
+
+    if (zones.length > 2) {
       console.warn(
-        `[BoostAD SDK] 광고존은 최대 2개까지 허용됩니다. ${allZones.length}개 중 처음 2개만 사용합니다.`
+        `[BoostAD SDK] 광고존은 최대 2개까지 허용됩니다. ${zones.length}개 중 처음 2개만 사용합니다.`
       );
     }
+
+    // 먼저 모든 zone을 renderedZones에 추가 (중복 방지)
+    limitedZones.forEach((zone) => this.renderedZones.add(zone));
 
     const tags = this.tagExtractor.extract();
     console.log('[BoostAD SDK] 추출된 태그:', tags);
     const postUrl = window.location.href;
 
     // 각 광고존에 1차 광고 삽입
-    zones.forEach(async (zone) => {
+    for (const zone of limitedZones) {
       const container = zone as HTMLElement;
       container.style.margin = '30px 0';
 
       await this.fetchAndRenderAd(container, tags, postUrl, 0, false);
-    });
+    }
 
-    // 행동 추적 시작 + 70점 도달 시 2차 광고로 교체 (같은 위치)
-    this.behaviorTracker.onThresholdReached(() => {
-      this.requestSecondAdManualMode(tags, postUrl, zones);
-    });
-    this.behaviorTracker.start();
+    // 행동 추적은 한 번만 시작
+    if (!this.behaviorTrackerStarted) {
+      this.behaviorTrackerStarted = true;
+      this.behaviorTracker.onThresholdReached(() => {
+        this.requestSecondAdManualMode(
+          tags,
+          postUrl,
+          Array.from(this.renderedZones)
+        );
+      });
+      this.behaviorTracker.start();
+    }
   }
 
   private async requestSecondAdManualMode(

--- a/sdk/src/features/BoostAdSDK.ts
+++ b/sdk/src/features/BoostAdSDK.ts
@@ -274,9 +274,6 @@ export class BoostAdSDK {
   // ========================================
 
   private async initManualMode(): Promise<void> {
-    // MutationObserver로 DOM 변화 감지 (SPA 대응)
-    this.setupMutationObserver();
-
     // 초기 광고 로드 시도
     await this.tryLoadManualAds();
   }
@@ -320,14 +317,16 @@ export class BoostAdSDK {
         }, 1000);
         return;
       } else {
+        // 재시도 5번 모두 실패 → MutationObserver 시작
         console.warn(
-          '[BoostAD SDK] data-boostad-zone 요소를 찾을 수 없습니다. MutationObserver가 DOM 변화를 감지하면 자동으로 재시도합니다.'
+          '[BoostAD SDK] data-boostad-zone 요소를 찾을 수 없습니다. MutationObserver를 시작합니다.'
         );
+        this.setupMutationObserver();
         return;
       }
     }
 
-    // 광고존을 찾았으면 MutationObserver 중지
+    // 광고존을 찾았으면 MutationObserver 중지 (혹시 실행 중이라면)
     this.mutationObserver?.disconnect();
 
     console.log(`[BoostAD SDK] ${allZones.length}개의 광고존을 찾았습니다.`);


### PR DESCRIPTION
## 🔗 관련 이슈

- #이슈번호

---

## ✅ 작업 내용

### 1) SDK 수동 모드 SPA 환경 지원

**변경 파일:**

- `sdk/src/features/BoostAdSDK.ts`

**변경 내용:**

- MutationObserver 기반 DOM 감지 시스템 구현
- React 등 SPA 프레임워크의 클라이언트 사이드 라우팅 대응
- Debounce(100ms) 적용으로 성능 최적화
- `renderedZones` Set을 통한 중복 렌더링 방지

**핵심 로직:**

- 이미 렌더링된 zone은 제외
```
private async checkAndLoadAds(): Promise<void> {
  const newZones = Array.from(allZones).filter(
    (zone) => !this.renderedZones.has(zone)
  );
  // ...
}
```
- 광고 로드 전에 먼저 zone 추가 (중복 방지)

```
private async loadAdsForZones(zones: Element[]): Promise<void> {
  limitedZones.forEach((zone) => this.renderedZones.add(zone));
  // 그 다음 광고 로드
}`
```
**제거된 로직:**

- ❌ retry 로직 (5회 재시도) - 불필요함
- ❌ `initManualMode()`에서 초기 광고 로드 - MutationObserver가 대응

---

### 2) Fallback 캠페인 시스템

**변경 파일:**

- `backend/src/rtb/rtb.service.ts`

**변경 내용:**

- 태그 매칭 실패 시 기본 캠페인 반환
- `FALLBACK_CAMPAIGN_ID` 상수 선언: `54e92912-e23d-471f-b700-81caf834da51`
- 고의도/일반 필터링 후 후보가 없을 때 작동
- 후보가 없으면 fallback 캠페인 조회!!

---

### 3) localhost URL 검증 허용

**변경 파일:**

- `backend/src/sdk/dto/create-view-log.dto.ts`

**변경 내용:**

- ViewLog DTO의 `postUrl` 필드에 `{ require_tld: false }` 옵션 추가
- 로컬 개발 환경(`localhost:5173` 등)에서 ViewLog 기록 가능

```
@IsUrl({ require_tld: false })
@IsNotEmpty()
postUrl: string;
```

---

## 💬 To Reviewers

### 1. SPA 지원 동작 방식

| 시나리오 | 기존 문제 | 해결 방법 |
| --- | --- | --- |
| 초기 로드 | React가 DOM 생성 전 SDK 실행 | MutationObserver가 zone 감지 후 광고 로드 |
| 페이지 이동 | zone이 사라졌다가 재생성됨 | `renderedZones`에서 새 zone 필터링 후 로드 |
| 중복 호출 | 광고 로드 중 MutationObserver 재감지 | zone을 먼저 Set에 추가 후 광고 로드 |
| 성능 저하 | 수백 번의 DOM 변화마다 실행 | Debounce(100ms)로 마지막 변화만 처리 |

### 2. Fallback 캠페인 사용 사례

- 신규 블로그로 태그가 없는 경우
- 특정 태그에 매칭되는 광고가 없는 경우
- 고의도 광고를 요청했으나 고의도 캠페인이 없는 경우

현재 Fallback 캠페인 ID(`54e92912-e23d-471f-b700-81caf834da51`)는 "Boostcamp 공식 캠페인"으로 설정되어 있다.

### 3. 테스트 방법

<img width="1441" height="913" alt="image" src="https://github.com/user-attachments/assets/8d2b6af2-e8dc-46d4-9ce4-b76842db0f0c" />


**SDK SPA 지원:**

1.  실행 (`npm run dev`) 및 로그인.
2. 광고주 캠페인 페이지 접속
3. 광고가 1개만 로드되는지 확인 (콘솔 로그)
4. 사이드바로 다른 페이지 이동
5. 다시 캠페인 페이지로 돌아옴
6. 광고가 다시 1개만 로드되는지 확인 (중복 X)

> 발견한 문제: 현재는 SPA인데 페이지 옮길 때마다(광고가 뜨는 페이지로 돌아올때마다) 새 decision, viewlog가 발생된다. 페이지가 바뀔때마다 React가 DOM을 파괴하고 새로 그리기 때문이다. 이를 새로고침하지 않는한 한번만 decisioin, viewlog가 발생하는 구조로 개선 가능할 것 같다.