### PR TITLE
[Hotfix] 이미지 업로드 관련 문제 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,12 @@ services:
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
       GOOGLE_REDIRECT_URI: ${GOOGLE_REDIRECT_URI:-}
+      # NCP Object Storage (image upload)
+      NCP_ACCESS_KEY: ${NCP_ACCESS_KEY:-}
+      NCP_SECRET_KEY: ${NCP_SECRET_KEY:-}
+      NCP_REGION: ${NCP_REGION:-kr-standard}
+      NCP_ENDPOINT: ${NCP_ENDPOINT:-https://kr.object.ncloudstorage.com}
+      NCP_BUCKET: ${NCP_BUCKET:-boostadad-campaign-images}
       REDIS_HOST: ${REDIS_HOST:-localhost}
       REDIS_PORT: ${REDIS_PORT:-6379}
     expose:

--- a/frontend/src/1_app/layouts/DashboardLayout.tsx
+++ b/frontend/src/1_app/layouts/DashboardLayout.tsx
@@ -1,9 +1,11 @@
-import { Outlet, useLocation } from 'react-router-dom';
+import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { Sidebar } from '@shared/ui/Sidebar';
 import { Header } from '@shared/ui/Header';
+import { Button } from '@shared/ui/Button';
 
 export function DashboardLayout() {
   const location = useLocation();
+  const navigate = useNavigate();
   const isAdvertiser = location.pathname.startsWith('/advertiser');
   const title = isAdvertiser ? 'Advertiser Dashboard' : 'Publisher Dashboard';
 
@@ -12,7 +14,16 @@ export function DashboardLayout() {
       <Sidebar />
 
       <main className="flex-1 bg-gray-50">
-        <Header title={title} />
+        <Header
+          title={title}
+          actions={
+            isAdvertiser ? (
+              <Button size="sm" onClick={() => navigate('/advertiser/campaign-create')}>
+                캠페인 생성
+              </Button>
+            ) : null
+          }
+        />
         <Outlet />
       </main>
     </div>

--- a/frontend/src/4_shared/ui/Header/Header.tsx
+++ b/frontend/src/4_shared/ui/Header/Header.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
 import { API_CONFIG } from '@/4_shared/lib/api';
@@ -6,9 +7,10 @@ import { useQueryClient } from '@tanstack/react-query';
 
 interface HeaderProps {
   title: string;
+  actions?: ReactNode;
 }
 
-export function Header({ title }: HeaderProps) {
+export function Header({ title, actions }: HeaderProps) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const handleLogout = async () => {
@@ -27,9 +29,12 @@ export function Header({ title }: HeaderProps) {
   return (
     <header className="flex items-center justify-between w-full h-16 bg-white border-b border-gray-200 px-8 text-2xl font-bold text-gray-900 whitespace-nowrap">
       <h1>{title}</h1>
-      <Button variant="white" size="sm" onClick={handleLogout}>
-        로그아웃
-      </Button>
+      <div className="flex items-center gap-2">
+        {actions}
+        <Button variant="white" size="sm" onClick={handleLogout}>
+          로그아웃
+        </Button>
+      </div>
     </header>
   );
 }


### PR DESCRIPTION
<!-- PR 제목 예시 : [Feat] 로그인 기능 구현 -->
<!-- PR 제목은 위 형식을 참고하여 작성해주세요. -->
<!-- 필요 없는 내용은 지우고 작성해주세요 -->

## 🔗 관련 이슈

- close: #

---

## ✅ 작업 내용

### 📌 주요 검토 파일

- `docker-compose.yml`
  - `backend` 컨테이너에 `NCP_ACCESS_KEY/NCP_SECRET_KEY/NCP_REGION/NCP_ENDPOINT/NCP_BUCKET` 환경변수 주입 추가
  - 배포 환경에서는 `back-deploy.yml`에서 export 한 값이 `docker compose up` 시 컨테이너로 전달되도록 정리
- `frontend/src/4_shared/ui/Header/Header.tsx`
  - 공통 헤더에 `actions?: ReactNode` 슬롯 추가 (우측 영역에 로그아웃 버튼과 함께 렌더링)
- `frontend/src/1_app/layouts/DashboardLayout.tsx`
  - 광고주 대시보드 헤더에 “캠페인 생성” 임시 버튼 노출 및 `/advertiser/campaign-create`로 이동 연결

### 1. (핫픽스) 배포 시 이미지 업로드를 위한 NCP 환경변수 주입

- 백엔드 이미지 업로드는 `NCP_*` 값을 통해 Object Storage(S3 compatible)로 업로드합니다.
- 기존에는 워크플로우에서만 `NCP_*`를 export 하고, `docker-compose.yml`에서 컨테이너로 주입하지 않아 런타임에서 값이 비어있는 문제가 있었습니다.
- `docker-compose.yml`의 `backend.environment`에 `NCP_*`를 추가하여 배포/로컬 환경 모두에서 컨테이너가 값을 받을 수 있도록 수정했습니다.

### 2. (부가) 대시보드 헤더 액션 확장 + 캠페인 생성 버튼(임시)

- 공통 `Header`에 `actions` 슬롯을 추가해, 대시보드/페이지별로 우측 액션을 주입할 수 있게 했습니다.
- `DashboardLayout`에서 광고주 대시보드에 “캠페인 생성” 버튼을 임시로 추가했습니다.

## 📸 스크린샷 / 데모 (옵션)

-
<img width="1634" height="941" alt="image" src="https://github.com/user-attachments/assets/6d91e9e0-9f11-4883-bf0e-af2573ed6422" />

---

## 🧪 테스트 방법 (옵션)

1. (로컬) `docker compose` 실행 시 사용할 환경변수를 준비합니다. (예: `NCP_ACCESS_KEY`, `NCP_SECRET_KEY`, `NCP_REGION`, `NCP_ENDPOINT`, `NCP_BUCKET`)
2. `web27-boostcamp/`에서 `docker compose up -d --build` 실행 후 `backend` 컨테이너에 `NCP_*`가 주입되는지 확인합니다.
3. 로그인 후 캠페인 생성 플로우에서 이미지 업로드 시 `/api/images`가 정상 응답(업로드 URL 반환)하는지 확인합니다.
4. 광고주 대시보드(`/advertiser/dashboard/*`) 헤더의 “캠페인 생성” 버튼 클릭 시 `/advertiser/campaign-create`로 이동하는지 확인합니다.

---

## 💬 To Reviewers

- 임시로 캠페인 생성버튼 넣어두었습니다.
