### PR TITLE
[Feat] postUrl 필드 추가 및 저장 로직 구현

### DIFF
--- a/backend/src/bid-log/bid-log.service.ts
+++ b/backend/src/bid-log/bid-log.service.ts
@@ -46,7 +46,7 @@ export class BidLogService {
         campaignTitle: campaign?.title || 'Unknown Campaign',
         blogKey: blog?.blogKey || 'Unknown Blog Key',
         blogName: blog?.name || 'Unknown Blog',
-        blogDomain: log.postUrl || blog?.domain || 'unknown.com',
+        postUrl: log.postUrl || blog?.domain || 'unknown.com',
         bidAmount: log.bidPrice,
         winAmount: winAmount,
         isWon: log.status === BidStatus.WIN,

--- a/backend/src/bid-log/bid-log.service.ts
+++ b/backend/src/bid-log/bid-log.service.ts
@@ -46,7 +46,7 @@ export class BidLogService {
         campaignTitle: campaign?.title || 'Unknown Campaign',
         blogKey: blog?.blogKey || 'Unknown Blog Key',
         blogName: blog?.name || 'Unknown Blog',
-        blogDomain: blog?.domain || 'unknown.com',
+        blogDomain: log.postUrl || blog?.domain || 'unknown.com',
         bidAmount: log.bidPrice,
         winAmount: winAmount,
         isWon: log.status === BidStatus.WIN,

--- a/backend/src/bid-log/bid-log.types.ts
+++ b/backend/src/bid-log/bid-log.types.ts
@@ -14,4 +14,5 @@ export interface BidLog {
   createdAt?: Date;
   isHighIntent: boolean;
   behaviorScore: number | null;
+  postUrl?: string | null;
 }

--- a/backend/src/bid-log/dto/bid-log-response.dto.ts
+++ b/backend/src/bid-log/dto/bid-log-response.dto.ts
@@ -5,7 +5,7 @@ export interface BidLogItemDto {
   campaignTitle: string;
   blogKey: string;
   blogName: string;
-  blogDomain: string;
+  postUrl: string;
   bidAmount: number;
   winAmount: number | null;
   isWon: boolean;

--- a/backend/src/bid-log/entities/bid-log.entity.ts
+++ b/backend/src/bid-log/entities/bid-log.entity.ts
@@ -63,6 +63,15 @@ export class BidLogEntity {
   })
   behaviorScore: number | null;
 
+  @Column({
+    name: 'post_url',
+    type: 'varchar',
+    length: 500,
+    nullable: true,
+    comment: '광고가 게재된 블로그 포스트 URL',
+  })
+  postUrl: string | null;
+
   @CreateDateColumn({ name: 'created_at', comment: 'TTL 적용' })
   createdAt: Date;
 

--- a/backend/src/rtb/rtb.service.ts
+++ b/backend/src/rtb/rtb.service.ts
@@ -134,6 +134,7 @@ export class RTBService {
         bidPrice: candidate.maxCpc,
         isHighIntent: context.isHighIntent,
         behaviorScore: context.behaviorScore,
+        postUrl: context.postUrl,
         reason: '', // 추후에 수정 필요
       }));
       await this.bidLogRepository.saveMany(bidLogs);

--- a/frontend/src/3_features/campaignCreation/lib/useCreateCampaign.ts
+++ b/frontend/src/3_features/campaignCreation/lib/useCreateCampaign.ts
@@ -39,13 +39,16 @@ interface CreateCampaignResponse {
 }
 
 interface UseCreateCampaignReturn {
-  createCampaign: (formData: CampaignFormData) => Promise<CreateCampaignResponse>;
+  createCampaign: (
+    formData: CampaignFormData
+  ) => Promise<CreateCampaignResponse>;
   isLoading: boolean;
   error: string | null;
 }
 
 function toISOString(dateString: string): string {
-  return new Date(dateString).toISOString();
+  // KST 00:00 명시
+  return `${dateString}T00:00:00+09:00`;
 }
 
 export function useCreateCampaign(): UseCreateCampaignReturn {

--- a/frontend/src/3_features/realtimeBids/lib/types.ts
+++ b/frontend/src/3_features/realtimeBids/lib/types.ts
@@ -10,7 +10,7 @@ export interface BidLog {
   campaignTitle: string;
   blogKey: string;
   blogName: string;
-  blogDomain: string;
+  postUrl: string;
   bidAmount: number;
   winAmount: number | null;
   isWon: boolean;

--- a/frontend/src/3_features/realtimeBids/ui/RealtimeBidsTableRow.tsx
+++ b/frontend/src/3_features/realtimeBids/ui/RealtimeBidsTableRow.tsx
@@ -30,9 +30,9 @@ export function RealtimeBidsTableRow({ bid }: RealtimeBidsTableRowProps) {
         {bid.campaignTitle}
       </td>
       <td className="px-5 py-4 whitespace-nowrap">
-        {bid.blogDomain ? (
+        {bid.postUrl ? (
           <a
-            href={`https://${bid.blogDomain}`}
+            href={`https://${bid.postUrl}`}
             target="_blank"
             rel="noopener noreferrer"
             className="text-gray-900 hover:text-blue-600 hover:underline cursor-pointer"


### PR DESCRIPTION
## 🔗 관련 이슈

- close : #169 

---

## ✅ 작업 내용

### 1) BidLog 테이블에 postUrl 컬럼 추가

**변경 파일:**
- DB: `BidLog` 테이블
- `backend/src/bid-log/entities/bid-log.entity.ts`
- `backend/src/bid-log/bid-log.types.ts`

**변경 내용:**
- `post_url` 컬럼 추가 (VARCHAR(500), nullable)
- 광고가 게재된 블로그 포스트의 정확한 URL 저장
- 기존 레코드는 자동으로 NULL 처리

---

### 2) RTB 입찰 로그 저장 시 postUrl 포함

**변경 파일:**
- `backend/src/rtb/rtb.service.ts`

**변경 내용:**
- BidLog 생성 시 `context.postUrl` 추가
- 모든 입찰 참여 캠페인 로그에 postUrl 저장

---

### 3) API 응답에서 blogDomain에 postUrl 우선 반영

**변경 파일:**
- `backend/src/bid-log/bid-log.service.ts`
- `backend/src/bid-log/dto/bid-log-response.dto.ts`

**변경 내용:**
- `blogDomain` 필드에 postUrl 우선순위 적용
- 우선순위: `postUrl → blog.domain → 'unknown.com'`
- 별도 postUrl 필드 추가 없이 기존 구조 활용

---

## 💬 To Reviewers

### 1. blogDomain 필드 동작

| 상황 | 반환 값 | 의미 |
| --- | --- | --- |
| postUrl 있음 | `https://blog.tistory.com/123` | 정확한 게시글 URL |
| postUrl 없음 (기존 데이터) | `blog.tistory.com` | 블로그 도메인 |
| 둘 다 없음 | `unknown.com` | Fallback |

### 2. 데이터 마이그레이션

- 기존 BidLog: `post_url = NULL` (자동)
- 신규 BidLog: RTB 요청의 postUrl 저장
- API 호환성: 기존 데이터 조회 시 에러 없음