### PR TITLE
[Feat] 입찰 로그 API 기간 필터링 기능 추가 및 대시보드 PostUrl 명확성 업데이트

### DIFF
--- a/backend/src/bid-log/bid-log.controller.ts
+++ b/backend/src/bid-log/bid-log.controller.ts
@@ -1,7 +1,11 @@
 import { Controller, Get, Query, Req } from '@nestjs/common';
 import { BidLogService } from './bid-log.service';
-import { BidLogResponseDto } from './dto/bid-log-response.dto';
+import { BidLogDataDto } from './dto/bid-log-response.dto';
 import { type AuthenticatedRequest } from 'src/types/authenticated-request';
+import {
+  successResponse,
+  type SuccessResponse,
+} from '../common/response/success-response';
 
 @Controller('advertiser/bids')
 export class BidLogController {
@@ -14,17 +18,19 @@ export class BidLogController {
     @Query('offset') offset?: string,
     @Query('startDate') startDate?: string,
     @Query('endDate') endDate?: string
-  ): Promise<BidLogResponseDto> {
+  ): Promise<SuccessResponse<BidLogDataDto>> {
     const userId = req.user.userId;
     const parsedLimit = limit ? parseInt(limit, 10) : 3;
     const parsedOffset = offset ? parseInt(offset, 10) : 0;
 
-    return this.bidLogService.getRealtimeBidLogs(
+    const data = await this.bidLogService.getRealtimeBidLogs(
       userId,
       parsedLimit,
       parsedOffset,
       startDate,
       endDate
     );
+
+    return successResponse(data, '광고주 실시간 입찰 로그입니다.');
   }
 }

--- a/backend/src/bid-log/bid-log.controller.ts
+++ b/backend/src/bid-log/bid-log.controller.ts
@@ -11,7 +11,9 @@ export class BidLogController {
   async getRealtimeBids(
     @Req() req: AuthenticatedRequest,
     @Query('limit') limit?: string,
-    @Query('offset') offset?: string
+    @Query('offset') offset?: string,
+    @Query('startDate') startDate?: string,
+    @Query('endDate') endDate?: string
   ): Promise<BidLogResponseDto> {
     const userId = req.user.userId;
     const parsedLimit = limit ? parseInt(limit, 10) : 3;
@@ -20,7 +22,9 @@ export class BidLogController {
     return this.bidLogService.getRealtimeBidLogs(
       userId,
       parsedLimit,
-      parsedOffset
+      parsedOffset,
+      startDate,
+      endDate
     );
   }
 }

--- a/backend/src/bid-log/bid-log.service.ts
+++ b/backend/src/bid-log/bid-log.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { BidStatus } from './bid-log.types';
 import { BidLogRepository } from './repositories/bid-log.repository.interface';
-import { BidLogResponseDto, BidLogItemDto } from './dto/bid-log-response.dto';
+import { BidLogDataDto, BidLogItemDto } from './dto/bid-log-response.dto';
 import { CampaignRepository } from 'src/campaign/repository/campaign.repository.interface';
 import { BlogRepository } from 'src/blog/repository/blog.repository.interface';
 
@@ -19,7 +19,7 @@ export class BidLogService {
     offset: number,
     startDate?: string,
     endDate?: string
-  ): Promise<BidLogResponseDto> {
+  ): Promise<BidLogDataDto> {
     const total = await this.bidLogRepository.countByUserId(
       userId,
       startDate,
@@ -69,14 +69,9 @@ export class BidLogService {
     const hasMore = offset + limit < total;
 
     return {
-      status: 'success',
-      message: '광고주 실시간 입찰 로그입니다.',
-      data: {
-        total,
-        hasMore,
-        bids,
-      },
-      timestamp: new Date().toISOString(),
+      total,
+      hasMore,
+      bids,
     };
   }
 }

--- a/backend/src/bid-log/dto/bid-log-response.dto.ts
+++ b/backend/src/bid-log/dto/bid-log-response.dto.ts
@@ -13,9 +13,15 @@ export interface BidLogItemDto {
   behaviorScore: number | null;
 }
 
+export interface BidLogDataDto {
+  total: number;
+  hasMore: boolean;
+  bids: BidLogItemDto[];
+}
+
 export interface BidLogResponseDto {
   status: string;
   message: string;
-  data: BidLogItemDto[];
+  data: BidLogDataDto;
   timestamp: string;
 }

--- a/backend/src/bid-log/repositories/bid-log.repository.interface.ts
+++ b/backend/src/bid-log/repositories/bid-log.repository.interface.ts
@@ -22,12 +22,21 @@ export abstract class BidLogRepository {
   // 모든 입찰 로그 목록 조회
   abstract getAll(): Promise<BidLog[]>;
 
-  // userId에 해당하는 캠페인의 입찰 로그 조회 (페이지네이션, 정렬 포함)
+  // userId에 해당하는 캠페인의 입찰 로그 조회 (페이지네이션, 정렬, 기간 필터 포함)
   abstract findByUserId(
     userId: number,
     limit?: number,
     offset?: number,
     sortBy?: 'createdAt',
-    order?: 'asc' | 'desc'
+    order?: 'asc' | 'desc',
+    startDate?: string,
+    endDate?: string
   ): Promise<BidLog[]>;
+
+  // userId에 해당하는 캠페인의 입찰 로그 총 개수 조회 (기간 필터 포함)
+  abstract countByUserId(
+    userId: number,
+    startDate?: string,
+    endDate?: string
+  ): Promise<number>;
 }

--- a/backend/src/bid-log/repositories/typeorm-bid-log.repository.ts
+++ b/backend/src/bid-log/repositories/typeorm-bid-log.repository.ts
@@ -57,13 +57,27 @@ export class TypeOrmBidLogRepository extends BidLogRepository {
     limit: number = 10,
     offset: number = 0,
     sortBy: 'createdAt' = 'createdAt',
-    order: 'asc' | 'desc' = 'desc'
+    order: 'asc' | 'desc' = 'desc',
+    startDate?: string,
+    endDate?: string
   ): Promise<BidLog[]> {
-    // DB 레벨에서 JOIN, 필터링, 정렬, 페이지네이션을 한 번에 처리
-    const logs = await this.repository
+    const queryBuilder = this.repository
       .createQueryBuilder('bidLog')
       .innerJoin('bidLog.campaign', 'campaign')
-      .where('campaign.userId = :userId', { userId })
+      .where('campaign.userId = :userId', { userId });
+
+    if (startDate) {
+      queryBuilder.andWhere('bidLog.createdAt >= :startDate', {
+        startDate: new Date(startDate),
+      });
+    }
+    if (endDate) {
+      queryBuilder.andWhere('bidLog.createdAt <= :endDate', {
+        endDate: new Date(endDate),
+      });
+    }
+
+    const logs = await queryBuilder
       .orderBy(`bidLog.${sortBy}`, order.toUpperCase() as 'ASC' | 'DESC')
       .skip(offset)
       .take(limit)

--- a/backend/src/bid-log/repositories/typeorm-bid-log.repository.ts
+++ b/backend/src/bid-log/repositories/typeorm-bid-log.repository.ts
@@ -85,4 +85,28 @@ export class TypeOrmBidLogRepository extends BidLogRepository {
 
     return logs;
   }
+
+  async countByUserId(
+    userId: number,
+    startDate?: string,
+    endDate?: string
+  ): Promise<number> {
+    const queryBuilder = this.repository
+      .createQueryBuilder('bidLog')
+      .innerJoin('bidLog.campaign', 'campaign')
+      .where('campaign.userId = :userId', { userId });
+
+    if (startDate) {
+      queryBuilder.andWhere('bidLog.createdAt >= :startDate', {
+        startDate: new Date(startDate),
+      });
+    }
+    if (endDate) {
+      queryBuilder.andWhere('bidLog.createdAt <= :endDate', {
+        endDate: new Date(endDate),
+      });
+    }
+
+    return await queryBuilder.getCount();
+  }
 }

--- a/frontend/src/3_features/realtimeBids/lib/types.ts
+++ b/frontend/src/3_features/realtimeBids/lib/types.ts
@@ -19,4 +19,15 @@ export interface BidLog {
   insight?: BidInsight;
 }
 
-export type RealtimeBidsResponse = BidLog[];
+export interface RealtimeBidsData {
+  total: number;
+  hasMore: boolean;
+  bids: BidLog[];
+}
+
+export interface RealtimeBidsResponse {
+  status: string;
+  message: string;
+  data: RealtimeBidsData;
+  timestamp: string;
+}

--- a/frontend/src/3_features/realtimeBids/lib/useRealtimeBids.ts
+++ b/frontend/src/3_features/realtimeBids/lib/useRealtimeBids.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { apiClient } from '@shared/lib/api';
-import type { RealtimeBidsResponse, BidLog } from './types';
+import type { RealtimeBidsData, BidLog } from './types';
 
 interface UseRealtimeBidsParams {
   limit?: number;
@@ -31,13 +31,13 @@ export function useRealtimeBids(
         setIsLoading(true);
         setError(null);
 
-        const response = await apiClient<RealtimeBidsResponse>(
+        const response = await apiClient<RealtimeBidsData>(
           `/api/advertiser/bids/realtime?limit=${limit}&offset=${offset}`
         );
 
-        setBids(response);
-        setTotal(0);
-        setHasMore(false);
+        setBids(response.bids);
+        setTotal(response.total);
+        setHasMore(response.hasMore);
       } catch (err) {
         const message =
           err instanceof Error ? err.message : '알 수 없는 오류가 발생했습니다';

--- a/frontend/src/3_features/realtimeBids/ui/RealtimeBidsTableHeader.tsx
+++ b/frontend/src/3_features/realtimeBids/ui/RealtimeBidsTableHeader.tsx
@@ -9,7 +9,7 @@ export function RealtimeBidsTableHeader() {
           캠페인
         </th>
         <th className="px-5 py-3 text-left font-medium text-gray-600 whitespace-nowrap">
-          블로그
+          포스트 URL
         </th>
         <th className="px-5 py-3 text-left font-medium text-gray-600 whitespace-nowrap">
           나의 입찰

--- a/frontend/src/3_features/realtimeBids/ui/RealtimeBidsTableRow.tsx
+++ b/frontend/src/3_features/realtimeBids/ui/RealtimeBidsTableRow.tsx
@@ -32,15 +32,21 @@ export function RealtimeBidsTableRow({ bid }: RealtimeBidsTableRowProps) {
       <td className="px-5 py-4 whitespace-nowrap">
         {bid.postUrl ? (
           <a
-            href={`https://${bid.postUrl}`}
+            href={
+              bid.postUrl.startsWith('http')
+                ? bid.postUrl
+                : `https://${bid.postUrl}`
+            }
             target="_blank"
             rel="noopener noreferrer"
-            className="text-gray-900 hover:text-blue-600 hover:underline cursor-pointer"
+            className="text-blue-600 hover:text-blue-800 hover:underline cursor-pointer text-xs"
           >
-            {bid.blogName}
+            {bid.postUrl.length > 50
+              ? `${bid.postUrl.substring(0, 50)}...`
+              : bid.postUrl}
           </a>
         ) : (
-          <span className="text-gray-900">{bid.blogName}</span>
+          <span className="text-gray-500 text-xs">{bid.blogName}</span>
         )}
       </td>
       <td


### PR DESCRIPTION
## 🔗 관련 이슈

- close : #170 

---

## ✅ 작업 내용

### 1) 입찰 로그 API 기간 필터링 기능 추가

**변경 파일:**
- `backend/src/bid-log/bid-log.controller.ts`
- `backend/src/bid-log/bid-log.service.ts`
- `backend/src/bid-log/repositories/bid-log.repository.interface.ts`
- `backend/src/bid-log/repositories/typeorm-bid-log.repository.ts`

**변경 내용:**
- `startDate`, `endDate` 쿼리 파라미터 추가 (선택적)
- Repository에 날짜 범위 필터링 쿼리 구현
- 파라미터 없으면 전체 기간 조회 (기존 동작 유지)

---

### 2) 페이지네이션을 위한 total, hasMore 필드 추가

**변경 파일:**
- `backend/src/bid-log/dto/bid-log-response.dto.ts`
- `backend/src/bid-log/bid-log.service.ts`
- `backend/src/bid-log/repositories/bid-log.repository.interface.ts`
- `backend/src/bid-log/repositories/typeorm-bid-log.repository.ts`

**변경 내용:**
- 응답 구조 변경: `data: BidLog[]` → `data: { total, hasMore, bids }`
- `countByUserId()` 메서드 추가로 전체 개수 조회
- `hasMore` 계산 로직 추가 (offset + limit < total)

---

### 3) 프론트엔드 포스트 URL 표시

**변경 파일:**
- `frontend/src/3_features/realtimeBids/ui/RealtimeBidsTableHeader.tsx`
- `frontend/src/3_features/realtimeBids/ui/RealtimeBidsTableRow.tsx`

**변경 내용:**
- 테이블 헤더: "블로그" → "포스트 URL"
- blogName 대신 postUrl 직접 표시
- URL이 50자 넘으면 축약 표시
- postUrl 없으면 blogName으로 fallback

---

### 4) 프론트엔드 응답 구조 변경 대응

**변경 파일:**
- `frontend/src/3_features/realtimeBids/lib/types.ts`
- `frontend/src/3_features/realtimeBids/lib/useRealtimeBids.ts`

**변경 내용:**
- `RealtimeBidsData` 타입 추가 (total, hasMore, bids)
- `useRealtimeBids` 훅에서 `response.bids` 접근
- total, hasMore 상태 관리 추가

---

## 💬 To Reviewers

### 1. API 사용 방법

**실시간 대시보드 (기존 동작 유지)**

`GET /api/advertiser/bids/realtime?limit=3`
→ 전체 기간에서 최신 3개

<img width="720" height="239" alt="image" src="https://github.com/user-attachments/assets/eadd90f7-ebc5-4ab0-ad10-3f0026098eb2" />
