### PR TITLE
[Feat] 입찰 로그 히스토리 페이지 구현

### DIFF
--- a/backend/src/bid-log/bid-log.controller.ts
+++ b/backend/src/bid-log/bid-log.controller.ts
@@ -1,7 +1,11 @@
 import { Controller, Get, Query, Req } from '@nestjs/common';
 import { BidLogService } from './bid-log.service';
-import { BidLogResponseDto } from './dto/bid-log-response.dto';
+import { BidLogDataDto } from './dto/bid-log-response.dto';
 import { type AuthenticatedRequest } from 'src/types/authenticated-request';
+import {
+  successResponse,
+  type SuccessResponse,
+} from '../common/response/success-response';
 
 @Controller('advertiser/bids')
 export class BidLogController {
@@ -14,17 +18,19 @@ export class BidLogController {
     @Query('offset') offset?: string,
     @Query('startDate') startDate?: string,
     @Query('endDate') endDate?: string
-  ): Promise<BidLogResponseDto> {
+  ): Promise<SuccessResponse<BidLogDataDto>> {
     const userId = req.user.userId;
     const parsedLimit = limit ? parseInt(limit, 10) : 3;
     const parsedOffset = offset ? parseInt(offset, 10) : 0;
 
-    return this.bidLogService.getRealtimeBidLogs(
+    const data = await this.bidLogService.getRealtimeBidLogs(
       userId,
       parsedLimit,
       parsedOffset,
       startDate,
       endDate
     );
+
+    return successResponse(data, '광고주 실시간 입찰 로그입니다.');
   }
 }

--- a/backend/src/bid-log/bid-log.controller.ts
+++ b/backend/src/bid-log/bid-log.controller.ts
@@ -11,7 +11,9 @@ export class BidLogController {
   async getRealtimeBids(
     @Req() req: AuthenticatedRequest,
     @Query('limit') limit?: string,
-    @Query('offset') offset?: string
+    @Query('offset') offset?: string,
+    @Query('startDate') startDate?: string,
+    @Query('endDate') endDate?: string
   ): Promise<BidLogResponseDto> {
     const userId = req.user.userId;
     const parsedLimit = limit ? parseInt(limit, 10) : 3;
@@ -20,7 +22,9 @@ export class BidLogController {
     return this.bidLogService.getRealtimeBidLogs(
       userId,
       parsedLimit,
-      parsedOffset
+      parsedOffset,
+      startDate,
+      endDate
     );
   }
 }

--- a/backend/src/bid-log/bid-log.service.ts
+++ b/backend/src/bid-log/bid-log.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { BidStatus } from './bid-log.types';
 import { BidLogRepository } from './repositories/bid-log.repository.interface';
-import { BidLogResponseDto, BidLogItemDto } from './dto/bid-log-response.dto';
+import { BidLogDataDto, BidLogItemDto } from './dto/bid-log-response.dto';
 import { CampaignRepository } from 'src/campaign/repository/campaign.repository.interface';
 import { BlogRepository } from 'src/blog/repository/blog.repository.interface';
 
@@ -19,7 +19,7 @@ export class BidLogService {
     offset: number,
     startDate?: string,
     endDate?: string
-  ): Promise<BidLogResponseDto> {
+  ): Promise<BidLogDataDto> {
     const total = await this.bidLogRepository.countByUserId(
       userId,
       startDate,
@@ -69,14 +69,9 @@ export class BidLogService {
     const hasMore = offset + limit < total;
 
     return {
-      status: 'success',
-      message: '광고주 실시간 입찰 로그입니다.',
-      data: {
-        total,
-        hasMore,
-        bids,
-      },
-      timestamp: new Date().toISOString(),
+      total,
+      hasMore,
+      bids,
     };
   }
 }

--- a/backend/src/bid-log/dto/bid-log-response.dto.ts
+++ b/backend/src/bid-log/dto/bid-log-response.dto.ts
@@ -13,9 +13,15 @@ export interface BidLogItemDto {
   behaviorScore: number | null;
 }
 
+export interface BidLogDataDto {
+  total: number;
+  hasMore: boolean;
+  bids: BidLogItemDto[];
+}
+
 export interface BidLogResponseDto {
   status: string;
   message: string;
-  data: BidLogItemDto[];
+  data: BidLogDataDto;
   timestamp: string;
 }

--- a/backend/src/bid-log/repositories/bid-log.repository.interface.ts
+++ b/backend/src/bid-log/repositories/bid-log.repository.interface.ts
@@ -22,12 +22,21 @@ export abstract class BidLogRepository {
   // 모든 입찰 로그 목록 조회
   abstract getAll(): Promise<BidLog[]>;
 
-  // userId에 해당하는 캠페인의 입찰 로그 조회 (페이지네이션, 정렬 포함)
+  // userId에 해당하는 캠페인의 입찰 로그 조회 (페이지네이션, 정렬, 기간 필터 포함)
   abstract findByUserId(
     userId: number,
     limit?: number,
     offset?: number,
     sortBy?: 'createdAt',
-    order?: 'asc' | 'desc'
+    order?: 'asc' | 'desc',
+    startDate?: string,
+    endDate?: string
   ): Promise<BidLog[]>;
+
+  // userId에 해당하는 캠페인의 입찰 로그 총 개수 조회 (기간 필터 포함)
+  abstract countByUserId(
+    userId: number,
+    startDate?: string,
+    endDate?: string
+  ): Promise<number>;
 }

--- a/backend/src/bid-log/repositories/typeorm-bid-log.repository.ts
+++ b/backend/src/bid-log/repositories/typeorm-bid-log.repository.ts
@@ -57,13 +57,27 @@ export class TypeOrmBidLogRepository extends BidLogRepository {
     limit: number = 10,
     offset: number = 0,
     sortBy: 'createdAt' = 'createdAt',
-    order: 'asc' | 'desc' = 'desc'
+    order: 'asc' | 'desc' = 'desc',
+    startDate?: string,
+    endDate?: string
   ): Promise<BidLog[]> {
-    // DB 레벨에서 JOIN, 필터링, 정렬, 페이지네이션을 한 번에 처리
-    const logs = await this.repository
+    const queryBuilder = this.repository
       .createQueryBuilder('bidLog')
       .innerJoin('bidLog.campaign', 'campaign')
-      .where('campaign.userId = :userId', { userId })
+      .where('campaign.userId = :userId', { userId });
+
+    if (startDate) {
+      queryBuilder.andWhere('bidLog.createdAt >= :startDate', {
+        startDate: new Date(startDate),
+      });
+    }
+    if (endDate) {
+      queryBuilder.andWhere('bidLog.createdAt <= :endDate', {
+        endDate: new Date(endDate),
+      });
+    }
+
+    const logs = await queryBuilder
       .orderBy(`bidLog.${sortBy}`, order.toUpperCase() as 'ASC' | 'DESC')
       .skip(offset)
       .take(limit)

--- a/backend/src/bid-log/repositories/typeorm-bid-log.repository.ts
+++ b/backend/src/bid-log/repositories/typeorm-bid-log.repository.ts
@@ -85,4 +85,28 @@ export class TypeOrmBidLogRepository extends BidLogRepository {
 
     return logs;
   }
+
+  async countByUserId(
+    userId: number,
+    startDate?: string,
+    endDate?: string
+  ): Promise<number> {
+    const queryBuilder = this.repository
+      .createQueryBuilder('bidLog')
+      .innerJoin('bidLog.campaign', 'campaign')
+      .where('campaign.userId = :userId', { userId });
+
+    if (startDate) {
+      queryBuilder.andWhere('bidLog.createdAt >= :startDate', {
+        startDate: new Date(startDate),
+      });
+    }
+    if (endDate) {
+      queryBuilder.andWhere('bidLog.createdAt <= :endDate', {
+        endDate: new Date(endDate),
+      });
+    }
+
+    return await queryBuilder.getCount();
+  }
 }

--- a/frontend/src/3_features/realtimeBids/lib/types.ts
+++ b/frontend/src/3_features/realtimeBids/lib/types.ts
@@ -19,4 +19,15 @@ export interface BidLog {
   insight?: BidInsight;
 }
 
-export type RealtimeBidsResponse = BidLog[];
+export interface RealtimeBidsData {
+  total: number;
+  hasMore: boolean;
+  bids: BidLog[];
+}
+
+export interface RealtimeBidsResponse {
+  status: string;
+  message: string;
+  data: RealtimeBidsData;
+  timestamp: string;
+}

--- a/frontend/src/3_features/realtimeBids/lib/useRealtimeBids.ts
+++ b/frontend/src/3_features/realtimeBids/lib/useRealtimeBids.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { apiClient } from '@shared/lib/api';
-import type { RealtimeBidsResponse, BidLog } from './types';
+import type { RealtimeBidsData, BidLog } from './types';
 
 interface UseRealtimeBidsParams {
   limit?: number;
@@ -31,13 +31,13 @@ export function useRealtimeBids(
         setIsLoading(true);
         setError(null);
 
-        const response = await apiClient<RealtimeBidsResponse>(
+        const response = await apiClient<RealtimeBidsData>(
           `/api/advertiser/bids/realtime?limit=${limit}&offset=${offset}`
         );
 
-        setBids(response);
-        setTotal(0);
-        setHasMore(false);
+        setBids(response.bids);
+        setTotal(response.total);
+        setHasMore(response.hasMore);
       } catch (err) {
         const message =
           err instanceof Error ? err.message : '알 수 없는 오류가 발생했습니다';

--- a/frontend/src/3_features/realtimeBids/ui/RealtimeBidsTableHeader.tsx
+++ b/frontend/src/3_features/realtimeBids/ui/RealtimeBidsTableHeader.tsx
@@ -9,7 +9,7 @@ export function RealtimeBidsTableHeader() {
           캠페인
         </th>
         <th className="px-5 py-3 text-left font-medium text-gray-600 whitespace-nowrap">
-          블로그
+          포스트 URL
         </th>
         <th className="px-5 py-3 text-left font-medium text-gray-600 whitespace-nowrap">
           나의 입찰

--- a/frontend/src/3_features/realtimeBids/ui/RealtimeBidsTableRow.tsx
+++ b/frontend/src/3_features/realtimeBids/ui/RealtimeBidsTableRow.tsx
@@ -32,15 +32,21 @@ export function RealtimeBidsTableRow({ bid }: RealtimeBidsTableRowProps) {
       <td className="px-5 py-4 whitespace-nowrap">
         {bid.postUrl ? (
           <a
-            href={`https://${bid.postUrl}`}
+            href={
+              bid.postUrl.startsWith('http')
+                ? bid.postUrl
+                : `https://${bid.postUrl}`
+            }
             target="_blank"
             rel="noopener noreferrer"
-            className="text-gray-900 hover:text-blue-600 hover:underline cursor-pointer"
+            className="text-blue-600 hover:text-blue-800 hover:underline cursor-pointer text-xs"
           >
-            {bid.blogName}
+            {bid.postUrl.length > 50
+              ? `${bid.postUrl.substring(0, 50)}...`
+              : bid.postUrl}
           </a>
         ) : (
-          <span className="text-gray-900">{bid.blogName}</span>
+          <span className="text-gray-500 text-xs">{bid.blogName}</span>
         )}
       </td>
       <td


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 이슈 번호를 입력하세요 -->

- close: #171 

## ✅ 작업 내용

### 1. 날짜 필터링 기능 구현

**Frontend**
- `useRealtimeBids`에 `startDate`, `endDate` params 추가
- URLSearchParams로 쿼리 생성

### 2. 페이지네이션 메타데이터 추가

**Backend**
- API 응답 구조 변경: `{ data: { total, hasMore, bids } }`
- `total`: 전체 로그 개수 (날짜 필터 적용)
- `hasMore`: 다음 페이지 존재 여부

**Frontend**
- `RealtimeBidsData` 타입 업데이트
- `apiClient<RealtimeBidsData>` 직접 사용 (response.bids 접근)

### 3. 입찰 히스토리 페이지 구현

**새 파일**
- `frontend/src/2_pages/realtimeBidsHistory/ui/RealtimeBidsHistoryPage.tsx`
- `frontend/src/2_pages/realtimeBidsHistory/index.ts`

**기능**
- 최근 7일간의 입찰 로그 표시 (useMemo로 startDate 고정)
- 페이지당 10개 아이템
- 페이지네이션 (이전/다음 버튼, 페이지 번호)
- Realtime 컴포넌트 재사용 (`RealtimeBidsTableHeader`, `RealtimeBidsTableRow`)

### 4. 라우팅 및 네비게이션 통합

**Router**
- `/advertiser/dashboard/history` 경로 추가
- `RealtimeBidsHistoryPage` 연결

**Sidebar**
- "입찰 히스토리" 메뉴 아이템 추가 (3번째 위치)
- Clock 아이콘 사용

**Dashboard**
- "전체 히스토리 보기 →" 링크를 `<Link to="/advertiser/dashboard/history">`로 변경
- hover 시 파란색 표시

### 5. UI 재사용

**RealtimeBids Feature**
- `index.ts`에 `RealtimeBidsTableHeader`, `RealtimeBidsTableRow` export 추가
- 히스토리 페이지에서 재사용 가능하도록 개선

**페이지 레이아웃 통일**
- `RealtimeBidsHistoryPage`: 제목을 흰색 컨테이너 안으로 이동
- `AdvertiserCampaignsPage`: 동일하게 제목 위치 조정
- 대시보드 위젯과 동일한 스타일 패턴 적용

**링크 호버 효과**
- "전체 캠페인 목록 보기 →"에 `hover:text-blue-600` 추가
- "전체 히스토리 보기 →"와 일관성 유지

### 6.  무한 루프 버그 수정

**문제**
- `getSevenDaysAgo()`를 매 렌더링마다 호출
- `new Date().toISOString()`가 밀리초 단위로 변경됨
- `useEffect([startDate])`가 계속 재실행 → API 무한 호출 → 쓰로틀 에러

**해결**
```
// Before
const startDate = getSevenDaysAgo();  // 매번 새로운 값

// After
const startDate = useMemo(() => {
  const date = new Date();
  date.setDate(date.getDate() - 7);
  return date.toISOString();
}, []);  // 컴포넌트 마운트 시 1번만 계산

**useRealtimeBids dependency array**

- `}, [limit, offset, startDate, endDate]);` 유지
- 호출하는 쪽에서 useMemo로 값 안정화

```

## **💬 To Reviewers**

### 테스트 확인 사항

1. **대시보드 (3개 로그)**
    - [ ]  최신 입찰 3개만 표시되는지
    - [ ]  postUrl이 있으면 링크로 표시, 없으면 blog domain 표시되는지
    - [ ]  "전체 히스토리 보기 →" 클릭 시 히스토리 페이지로 이동하는지
2. **입찰 히스토리 페이지**
    - [ ]  7일 이내 입찰 로그만 표시되는지
    - [ ]  페이지네이션이 정상 동작하는지 (이전/다음 버튼)
    - [ ]  무한 루프 없이 1번만 API 호출하는지 (Network 탭 확인)
3. **UI/UX**
    - [ ]  사이드바 3번째에 "입찰 히스토리" 메뉴 표시되는지
    - [ ]  링크 hover 시 파란색으로 변경되는지
    - [ ]  페이지 제목이 흰색 컨테이너 안에 위치하는지


<img width="1526" height="973" alt="image" src="https://github.com/user-attachments/assets/768dd06c-7b49-4f61-a100-1101e69fa129" />

<img width="1518" height="925" alt="image" src="https://github.com/user-attachments/assets/654a1a20-f185-4edf-a887-d020ca550f02" />


