### PR TITLE
[Fix] 어뷰징 방지가 2차광고 로그생성 막는 문제 해결

### DIFF
--- a/backend/src/cache/repository/cache.repository.interface.ts
+++ b/backend/src/cache/repository/cache.repository.interface.ts
@@ -23,6 +23,7 @@ export abstract class CacheRepository {
   abstract acquireViewIdempotencyKey(
     postUrl: string,
     visitorId: string,
+    isHighIntent: boolean,
     ttlMs?: number
   ): Promise<
     | { status: 'acquired' }
@@ -33,17 +34,19 @@ export abstract class CacheRepository {
   abstract setViewIdempotencyKey(
     postUrl: string,
     visitorId: string,
+    isHighIntent: boolean,
     viewId: number,
     ttlMs?: number
   ): Promise<void>;
 
   abstract getViewIdByIdempotencyKey(
     postUrl: string,
-    visitorId: string
+    visitorId: string,
+    isHighIntent: boolean
   ): Promise<number | null>;
 
   abstract setClickIdempotencyKey(
-    postUrl: string,
-    visitorId: string
+    viewId: number,
+    ttlMs?: number
   ): Promise<boolean>;
 }

--- a/backend/src/sdk/sdk.controller.ts
+++ b/backend/src/sdk/sdk.controller.ts
@@ -54,10 +54,7 @@ export class SdkController {
     if (!visitorId) {
       throw new BadRequestException('비정상적인 API 요청입니다.');
     }
-    const clickId = await this.sdkService.recordClick(
-      createClickLogDto,
-      visitorId
-    );
+    const clickId = await this.sdkService.recordClick(createClickLogDto);
     return successResponse(
       { clickId },
       '캠페인 클릭 로그가 성공적으로 저장되었습니다.'

--- a/backend/src/sdk/sdk.service.ts
+++ b/backend/src/sdk/sdk.service.ts
@@ -35,7 +35,8 @@ export class SdkService {
 
     const dedupResult = await this.cacheRepository.acquireViewIdempotencyKey(
       postUrl,
-      visitorId
+      visitorId,
+      isHighIntent
     );
     if (dedupResult.status === 'exists') {
       return dedupResult.viewId;
@@ -45,7 +46,8 @@ export class SdkService {
       const existingViewId =
         await this.cacheRepository.getViewIdByIdempotencyKey(
           postUrl,
-          visitorId
+          visitorId,
+          isHighIntent
         );
       if (existingViewId !== null) {
         return existingViewId;
@@ -67,23 +69,18 @@ export class SdkService {
     await this.cacheRepository.setViewIdempotencyKey(
       postUrl,
       visitorId,
+      isHighIntent,
       viewId
     );
 
     return viewId;
   }
 
-  async recordClick(
-    dto: CreateClickLogDto,
-    visitorId: string
-  ): Promise<number | null> {
-    const { viewId, postUrl } = dto;
+  async recordClick(dto: CreateClickLogDto): Promise<number | null> {
+    const { viewId } = dto;
     // todo: 어뷰징 방지
 
-    const isDup = await this.cacheRepository.setClickIdempotencyKey(
-      postUrl,
-      visitorId
-    );
+    const isDup = await this.cacheRepository.setClickIdempotencyKey(viewId);
 
     if (isDup) {
       return null;

--- a/sdk/src/features/DecisionAPIClient.ts
+++ b/sdk/src/features/DecisionAPIClient.ts
@@ -31,7 +31,7 @@ export class DecisionAPIClient implements APIClient {
         headers: {
           'Content-Type': 'application/json',
         },
-        credentials:'include', // todo: 제거
+        credentials:'include',
         body: JSON.stringify(requestBody),
       });
 


### PR DESCRIPTION
<!-- PR 제목 예시 : [Feat] 로그인 기능 구현 -->
<!-- PR 제목은 위 형식을 참고하여 작성해주세요. -->
<!-- 필요 없는 내용은 지우고 작성해주세요 -->

## 🔗 관련 이슈

- close: #

---

## ✅ 작업 내용

### 📌 주요 검토 파일

- `backend/src/cache/repository/cache.repository.interface.ts`
  - view/click idempotency 메서드 시그니처 변경 (isHighIntent, viewId 반영)
- `backend/src/cache/repository/redis-cache.repository.ts`
  - View dedup 키에 `isHighIntent` 포함, Click dedup 키를 `viewId` 기반으로 변경
- `backend/src/sdk/sdk.service.ts`
  - viewLog dedup에 `isHighIntent` 반영, clickLog dedup을 `viewId` 기준으로 처리

### 1. 2차(고의도) 광고 viewLog 누락 문제 해결

- 기존에는 `postUrl + visitorId` 기준으로만 View dedup을 걸어 2차 광고(고의도)도 **중복으로 처리**되는 문제가 있었습니다.
- dedup 키에 `isHighIntent`를 포함해 **1차(일반) / 2차(고의도)** 로그를 분리하도록 변경했습니다.

### 2. ClickLog 중복 방지 기준 개선

- Click dedup 키를 `postUrl + visitorId`에서 **`viewId` 기준**으로 변경했습니다.
- 서로 다른 viewId(1차/2차 광고, 여러 광고존)의 클릭이 **서로 영향을 주지 않도록** 했습니다.

---

## 📸 스크린샷 / 데모 (옵션)

-

---

## 🧪 테스트 방법 (옵션)

1. `npm -C web27-boostcamp/backend run build`
2. 동일 `postUrl/visitorId`에서 `isHighIntent=false`로 `/sdk/campaign-view` 호출 → viewId 생성 확인
3. 같은 `postUrl/visitorId`에서 `isHighIntent=true`로 `/sdk/campaign-view` 호출 → **새 viewId 생성** 확인
4. `/sdk/campaign-click` 호출 → 동일 `viewId`에 대해 1회만 clickId 생성되는지 확인

---

## 💬 To Reviewers

- viewLog dedup 키가 `postUrl + visitorId + isHighIntent`로 바뀌었고, clickLog dedup 기준이 `viewId`로 변경되었습니다. 