### PR TITLE
[Feat] 캠페인 상세 페이지 구현 완료

### DIFF
--- a/backend/src/campaign/dto/update-campaign.dto.ts
+++ b/backend/src/campaign/dto/update-campaign.dto.ts
@@ -9,6 +9,7 @@ import {
   Min,
   IsOptional,
   IsIn,
+  IsBoolean,
 } from 'class-validator';
 
 export class UpdateCampaignDto {
@@ -34,6 +35,10 @@ export class UpdateCampaignDto {
   @IsArray()
   @IsString({ each: true })
   tags?: string[];
+
+  @IsOptional()
+  @IsBoolean({ message: '고의도 학습자 여부는 boolean이어야 합니다.' })
+  isHighIntent?: boolean;
 
   @IsOptional()
   @Type(() => Number)

--- a/backend/src/campaign/repository/typeorm-campaign.repository.ts
+++ b/backend/src/campaign/repository/typeorm-campaign.repository.ts
@@ -170,6 +170,7 @@ export class TypeOrmCampaignRepository extends CampaignRepository {
     if (dto.content !== undefined) campaign.content = dto.content;
     if (dto.image !== undefined) campaign.image = dto.image;
     if (dto.url !== undefined) campaign.url = dto.url;
+    if (dto.isHighIntent !== undefined) campaign.isHighIntent = dto.isHighIntent;
     if (dto.maxCpc !== undefined) campaign.maxCpc = dto.maxCpc;
     if (dto.dailyBudget !== undefined) campaign.dailyBudget = dto.dailyBudget;
     if (dto.totalBudget !== undefined) campaign.totalBudget = dto.totalBudget;

--- a/frontend/src/2_pages/campaignDetail/ui/CampaignDetailPage.tsx
+++ b/frontend/src/2_pages/campaignDetail/ui/CampaignDetailPage.tsx
@@ -2,10 +2,14 @@ import { useParams, useNavigate } from 'react-router-dom';
 import {
   useCampaignDetail,
   usePauseCampaign,
+  useUpdateBudget,
   CampaignDetailHeader,
   CampaignInfoCard,
   CampaignMetricsCards,
+  BudgetStatusCard,
+  SpendingLogCard,
 } from '@features/campaignDetail';
+import { useAdvertiserBalance } from '@shared/lib/hooks/useAdvertiserBalance';
 import { useToast } from '@shared/lib/toast';
 
 export function CampaignDetailPage() {
@@ -15,6 +19,8 @@ export function CampaignDetailPage() {
 
   const { campaign, isLoading, error, refetch } = useCampaignDetail(id || '');
   const { togglePause, isLoading: isPauseLoading } = usePauseCampaign();
+  const { updateBudget, isLoading: isUpdateBudgetLoading } = useUpdateBudget();
+  const { balance } = useAdvertiserBalance();
 
   const handleBack = () => {
     navigate('/advertiser/dashboard/campaigns');
@@ -40,6 +46,26 @@ export function CampaignDetailPage() {
   const handleEdit = () => {
     // TODO: 수정 모달 열기
     console.log('Edit campaign');
+  };
+
+  const handleChargeBudget = () => {
+    navigate('/advertiser/dashboard/budget');
+  };
+
+  const handleUpdateBudget = async (data: {
+    totalBudget: number;
+    dailyBudget: number;
+    maxCpc: number;
+  }) => {
+    if (!campaign) return;
+
+    try {
+      await updateBudget(campaign.id, data);
+      toast.showToast('예산이 수정되었습니다', 'success');
+      refetch();
+    } catch {
+      toast.showToast('예산 수정에 실패했습니다', 'error');
+    }
   };
 
   if (isLoading) {
@@ -86,8 +112,21 @@ export function CampaignDetailPage() {
         ctr={campaign.ctr}
       />
 
-      {/* TODO: Phase 3 - BudgetStatusCard */}
-      {/* TODO: Phase 4 - SpendingLogCard */}
+      <BudgetStatusCard
+        dailySpent={campaign.dailySpent}
+        dailyBudget={campaign.dailyBudget}
+        dailySpentPercent={campaign.dailySpentPercent}
+        totalSpent={campaign.totalSpent}
+        totalBudget={campaign.totalBudget}
+        totalSpentPercent={campaign.totalSpentPercent}
+        maxCpc={campaign.maxCpc}
+        balance={balance}
+        onChargeBudget={handleChargeBudget}
+        onUpdateBudget={handleUpdateBudget}
+        isUpdateLoading={isUpdateBudgetLoading}
+      />
+
+      <SpendingLogCard />
     </div>
   );
 }

--- a/frontend/src/3_features/campaignDetail/index.ts
+++ b/frontend/src/3_features/campaignDetail/index.ts
@@ -7,6 +7,8 @@ export { useSpendingLog } from './lib/useSpendingLog';
 export { CampaignDetailHeader } from './ui/CampaignDetailHeader';
 export { CampaignInfoCard } from './ui/CampaignInfoCard';
 export { CampaignMetricsCards } from './ui/CampaignMetricsCards';
+export { BudgetStatusCard } from './ui/BudgetStatusCard';
+export { SpendingLogCard } from './ui/SpendingLogCard';
 
 export type {
   CampaignStatus,

--- a/frontend/src/3_features/campaignDetail/index.ts
+++ b/frontend/src/3_features/campaignDetail/index.ts
@@ -9,6 +9,7 @@ export { CampaignInfoCard } from './ui/CampaignInfoCard';
 export { CampaignMetricsCards } from './ui/CampaignMetricsCards';
 export { BudgetStatusCard } from './ui/BudgetStatusCard';
 export { SpendingLogCard } from './ui/SpendingLogCard';
+export { CampaignEditModal } from './ui/CampaignEditModal';
 
 export type {
   CampaignStatus,

--- a/frontend/src/3_features/campaignDetail/lib/types.ts
+++ b/frontend/src/3_features/campaignDetail/lib/types.ts
@@ -39,6 +39,7 @@ export interface UpdateCampaignRequest {
   image?: string;
   url?: string;
   tags?: string[];
+  isHighIntent?: boolean;
   maxCpc?: number;
   dailyBudget?: number;
   totalBudget?: number;

--- a/frontend/src/3_features/campaignDetail/ui/BudgetStatusCard/BudgetEditMode.tsx
+++ b/frontend/src/3_features/campaignDetail/ui/BudgetStatusCard/BudgetEditMode.tsx
@@ -68,7 +68,7 @@ export function BudgetEditMode({
 
           {/* 추가 예산 입력 */}
           <div className="bg-white">
-            <CurrencyField value={addBudget} onChange={setAddBudget} />
+            <CurrencyField value={addBudget} onChange={setAddBudget} prefix="+" />
           </div>
 
           {/* 퀵버튼 */}

--- a/frontend/src/3_features/campaignDetail/ui/BudgetStatusCard/BudgetEditMode.tsx
+++ b/frontend/src/3_features/campaignDetail/ui/BudgetStatusCard/BudgetEditMode.tsx
@@ -1,0 +1,143 @@
+import { useState } from 'react';
+import { CurrencyField } from '@shared/ui/CurrencyField';
+import { formatWithComma } from '@shared/lib/format';
+
+interface BudgetEditModeProps {
+  currentTotalBudget: number | null;
+  currentDailyBudget: number;
+  currentMaxCpc: number;
+  balance: number | null;
+  onSave: (data: {
+    totalBudget: number;
+    dailyBudget: number;
+    maxCpc: number;
+  }) => void;
+  onCancel: () => void;
+  isLoading?: boolean;
+}
+
+const QUICK_ADD_OPTIONS = [
+  { label: '+1만원', value: 10000 },
+  { label: '+3만원', value: 30000 },
+  { label: '+5만원', value: 50000 },
+];
+
+export function BudgetEditMode({
+  currentTotalBudget,
+  currentDailyBudget,
+  currentMaxCpc,
+  balance,
+  onSave,
+  onCancel,
+  isLoading = false,
+}: BudgetEditModeProps) {
+  const [addBudget, setAddBudget] = useState(0);
+  const [dailyBudget, setDailyBudget] = useState(currentDailyBudget);
+  const [maxCpc, setMaxCpc] = useState(currentMaxCpc);
+
+  const finalTotalBudget = (currentTotalBudget || 0) + addBudget;
+
+  const handleQuickAdd = (value: number) => {
+    setAddBudget((prev) => prev + value);
+  };
+
+  const handleSave = () => {
+    onSave({
+      totalBudget: finalTotalBudget,
+      dailyBudget,
+      maxCpc,
+    });
+  };
+
+  return (
+    <div className="flex flex-col items-start gap-4 w-full">
+      {/* 총예산 영역 */}
+      <div className="flex flex-row items-start gap-4 w-full">
+        <span className="text-sm font-bold text-slate-500 uppercase shrink-0">
+          총 예산
+        </span>
+
+        <div className="flex flex-col gap-2 flex-1">
+          {/* 현재 총예산 값 */}
+          <div className="flex flex-row items-center gap-1">
+            <span className="text-base font-bold text-blue-500">
+              {formatWithComma(finalTotalBudget)}
+            </span>
+            <span className="text-sm font-medium text-slate-400">원</span>
+          </div>
+
+          {/* 추가 예산 입력 */}
+          <div className="bg-white">
+            <CurrencyField value={addBudget} onChange={setAddBudget} />
+          </div>
+
+          {/* 퀵버튼 */}
+          <div className="flex flex-row justify-between items-center gap-2">
+            {QUICK_ADD_OPTIONS.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => handleQuickAdd(option.value)}
+                className="flex flex-1 justify-center items-center px-3 h-8 bg-white border border-gray-100 rounded-lg text-sm font-medium text-gray-400 hover:bg-gray-50 transition-colors"
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+
+          {/* 예산 잔액 표시 */}
+          <span className="text-xs font-bold text-right text-slate-400 uppercase">
+            예산 잔액: {balance !== null ? formatWithComma(balance) : '-'} 원
+          </span>
+        </div>
+      </div>
+
+      {/* 일일 예산 */}
+      <div className="flex flex-row items-center gap-3.5 w-full self-stretch">
+        <span className="text-sm font-bold text-slate-500 uppercase">
+          일일 예산
+        </span>
+        <div className="flex-1 bg-white">
+          <CurrencyField value={dailyBudget} onChange={setDailyBudget} />
+        </div>
+      </div>
+
+      {/* 최대 CPC */}
+      <div className="flex flex-row items-center gap-3 w-full self-stretch">
+        <span className="text-sm font-bold text-slate-500 uppercase">
+          최대 CPC
+        </span>
+        <div className="flex-1 bg-white">
+          <CurrencyField value={maxCpc} onChange={setMaxCpc} />
+        </div>
+      </div>
+
+      {/* 버튼 영역 */}
+      <div className="flex flex-col items-start pt-2 w-full">
+        <div className="flex flex-row items-start gap-2 w-full self-stretch">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={isLoading}
+            className="flex-1 flex justify-center items-center py-2 bg-slate-200 rounded-lg text-xs font-bold text-slate-700 hover:bg-slate-300 transition-colors disabled:opacity-50"
+          >
+            취소
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={isLoading}
+            className="flex-1 flex justify-center items-center py-2 bg-blue-500 rounded-lg text-xs font-bold text-white shadow-sm hover:bg-blue-600 transition-colors disabled:opacity-50"
+          >
+            저장
+          </button>
+        </div>
+      </div>
+
+      {/* 안내 문구 */}
+      <span className="text-xs font-bold text-slate-400 uppercase w-full text-right">
+        일일 예산, CPC값은 다음 날부터 적용됩니다.
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/3_features/campaignDetail/ui/BudgetStatusCard/BudgetInfoSection.tsx
+++ b/frontend/src/3_features/campaignDetail/ui/BudgetStatusCard/BudgetInfoSection.tsx
@@ -1,0 +1,36 @@
+import { formatWithComma } from '@shared/lib/format';
+
+interface BudgetInfoSectionProps {
+  totalBudget: number | null;
+  dailyBudget: number;
+  maxCpc: number;
+}
+
+export function BudgetInfoSection({
+  totalBudget,
+  dailyBudget,
+  maxCpc,
+}: BudgetInfoSectionProps) {
+  return (
+    <div className="flex flex-col gap-4 w-full">
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-gray-500">총 예산</span>
+        <span className="text-sm font-semibold text-gray-900">
+          {totalBudget ? formatWithComma(totalBudget) : '-'}원
+        </span>
+      </div>
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-gray-500">일일 예산</span>
+        <span className="text-sm font-semibold text-gray-900">
+          {formatWithComma(dailyBudget)}원
+        </span>
+      </div>
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-gray-500">최대 CPC</span>
+        <span className="text-sm font-semibold text-gray-900">
+          {formatWithComma(maxCpc)}원
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/3_features/campaignDetail/ui/BudgetStatusCard/BudgetProgressSection.tsx
+++ b/frontend/src/3_features/campaignDetail/ui/BudgetStatusCard/BudgetProgressSection.tsx
@@ -1,0 +1,65 @@
+import { ProgressBar } from '@shared/ui/ProgressBar';
+import { formatWithComma } from '@shared/lib/format';
+
+interface BudgetProgressSectionProps {
+  dailySpent: number;
+  dailyBudget: number;
+  dailySpentPercent: number;
+  totalSpent: number;
+  totalBudget: number | null;
+  totalSpentPercent: number;
+}
+
+export function BudgetProgressSection({
+  dailySpent,
+  dailyBudget,
+  dailySpentPercent,
+  totalSpent,
+  totalBudget,
+  totalSpentPercent,
+}: BudgetProgressSectionProps) {
+  return (
+    <div className="flex flex-col gap-6">
+      {/* 오늘 소진 예산 */}
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-gray-600">오늘 소진 예산</span>
+          <span className="text-sm text-gray-900">
+            <span className="font-semibold">{formatWithComma(dailySpent)}원</span>
+            <span className="text-gray-400"> / {formatWithComma(dailyBudget)}원</span>
+          </span>
+        </div>
+        <div className="w-full">
+          <ProgressBar
+            percentage={dailySpentPercent}
+            colorScheme="blue"
+            showLabel={false}
+            size="md"
+          />
+        </div>
+      </div>
+
+      {/* 총 소진 예산 */}
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-gray-600">총 소진 예산</span>
+          <span className="text-sm text-gray-900">
+            <span className="font-semibold">{formatWithComma(totalSpent)}원</span>
+            <span className="text-gray-400">
+              {' '}
+              / {totalBudget ? formatWithComma(totalBudget) : '-'}원
+            </span>
+          </span>
+        </div>
+        <div className="w-full">
+          <ProgressBar
+            percentage={totalSpentPercent}
+            colorScheme="blue"
+            showLabel={false}
+            size="md"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/3_features/campaignDetail/ui/BudgetStatusCard/BudgetStatusCard.tsx
+++ b/frontend/src/3_features/campaignDetail/ui/BudgetStatusCard/BudgetStatusCard.tsx
@@ -1,0 +1,124 @@
+import { useState } from 'react';
+import { Icon } from '@shared/ui/Icon';
+import { Button } from '@shared/ui/Button';
+import { BudgetProgressSection } from './BudgetProgressSection';
+import { BudgetInfoSection } from './BudgetInfoSection';
+import { BudgetEditMode } from './BudgetEditMode';
+
+interface BudgetStatusCardProps {
+  dailySpent: number;
+  dailyBudget: number;
+  dailySpentPercent: number;
+  totalSpent: number;
+  totalBudget: number | null;
+  totalSpentPercent: number;
+  maxCpc: number;
+  balance: number | null;
+  onChargeBudget: () => void;
+  onUpdateBudget: (data: {
+    totalBudget: number;
+    dailyBudget: number;
+    maxCpc: number;
+  }) => Promise<void>;
+  isUpdateLoading?: boolean;
+}
+
+export function BudgetStatusCard({
+  dailySpent,
+  dailyBudget,
+  dailySpentPercent,
+  totalSpent,
+  totalBudget,
+  totalSpentPercent,
+  maxCpc,
+  balance,
+  onChargeBudget,
+  onUpdateBudget,
+  isUpdateLoading = false,
+}: BudgetStatusCardProps) {
+  const [isEditing, setIsEditing] = useState(false);
+
+  const handleSave = async (data: {
+    totalBudget: number;
+    dailyBudget: number;
+    maxCpc: number;
+  }) => {
+    await onUpdateBudget(data);
+    setIsEditing(false);
+  };
+
+  const handleCancel = () => {
+    setIsEditing(false);
+  };
+
+  return (
+    <div
+      className={`p-6 bg-white rounded-xl border-2 transition-colors ${
+        isEditing ? 'border-blue-500' : 'border-gray-200'
+      }`}
+    >
+      {/* 헤더 */}
+      <div className="flex items-center justify-between mb-6">
+        <h3 className="text-base font-semibold text-gray-900">
+          예산 및 지출 현황
+        </h3>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="white"
+            size="xs"
+            icon={<Icon.Saving className="w-4 h-4" />}
+            iconPosition="left"
+            onClick={onChargeBudget}
+          >
+            예산 충전
+          </Button>
+          <Button
+            variant={isEditing ? 'white' : 'blue'}
+            size="xs"
+            icon={<Icon.Pen className="w-4 h-4" />}
+            iconPosition="left"
+            onClick={() => setIsEditing(!isEditing)}
+          >
+            빠른 예산 수정
+          </Button>
+        </div>
+      </div>
+
+      {/* 바디 */}
+      <div className="flex gap-6">
+        {/* 프로그래스바*/}
+        <div className="flex-3">
+          <BudgetProgressSection
+            dailySpent={dailySpent}
+            dailyBudget={dailyBudget}
+            dailySpentPercent={dailySpentPercent}
+            totalSpent={totalSpent}
+            totalBudget={totalBudget}
+            totalSpentPercent={totalSpentPercent}
+          />
+        </div>
+
+        {/* 예산 정보 또는 편집 */}
+        <div className="flex-2 flex flex-col items-end p-5 gap-4 bg-slate-50 border border-slate-200 rounded-xl">
+          {isEditing ? (
+            <BudgetEditMode
+              currentTotalBudget={totalBudget}
+              currentDailyBudget={dailyBudget}
+              currentMaxCpc={maxCpc}
+              balance={balance}
+              onSave={handleSave}
+              onCancel={handleCancel}
+              isLoading={isUpdateLoading}
+            />
+          ) : (
+            <BudgetInfoSection
+              totalBudget={totalBudget}
+              dailyBudget={dailyBudget}
+              maxCpc={maxCpc}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/3_features/campaignDetail/ui/BudgetStatusCard/index.ts
+++ b/frontend/src/3_features/campaignDetail/ui/BudgetStatusCard/index.ts
@@ -1,0 +1,1 @@
+export { BudgetStatusCard } from './BudgetStatusCard';

--- a/frontend/src/3_features/campaignDetail/ui/CampaignEditModal.tsx
+++ b/frontend/src/3_features/campaignDetail/ui/CampaignEditModal.tsx
@@ -1,0 +1,148 @@
+import { useEffect } from 'react';
+import {
+  CampaignForm,
+  Step1Content,
+  Step2Content,
+  Step3Content,
+  useCampaignFormStore,
+} from '@shared/ui/CampaignForm';
+import type { CampaignFormData } from '@shared/ui/CampaignForm';
+import { useImageUpload } from '@shared/lib/hooks';
+
+interface CampaignEditModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (data: CampaignFormData) => Promise<void>;
+  isSubmitting: boolean;
+  initialData: {
+    title: string;
+    content: string;
+    url: string;
+    tags: { id: number; name: string }[];
+    isHighIntent: boolean;
+    image: string | null;
+    dailyBudget: number;
+    totalBudget: number | null;
+    maxCpc: number;
+    startDate: string;
+    endDate: string;
+  };
+  balance: number | null;
+  error?: string | null;
+}
+
+// 날짜 포맷 변환 (ISO -> YYYY-MM-DD)
+function formatDateForInput(dateString: string): string {
+  if (!dateString) return '';
+  const date = new Date(dateString);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+export function CampaignEditModal({
+  isOpen,
+  onClose,
+  onSubmit,
+  isSubmitting,
+  initialData,
+  balance,
+  error,
+}: CampaignEditModalProps) {
+  const {
+    currentStep,
+    setMode,
+    setStep,
+    setFormData,
+    setBalance,
+    setInitialTotalBudget,
+    formData,
+    resetForm,
+  } = useCampaignFormStore();
+  const { upload: uploadImage } = useImageUpload();
+
+  useEffect(() => {
+    if (isOpen) {
+      setMode('edit');
+      setStep(1);
+      setBalance(balance);
+      setInitialTotalBudget(initialData.totalBudget);
+      setFormData({
+        campaignContent: {
+          title: initialData.title,
+          content: initialData.content,
+          url: initialData.url,
+          tags: initialData.tags.map((tag) => ({
+            id: tag.id,
+            name: tag.name,
+            category: '기타' as const,
+          })),
+          isHighIntent: initialData.isHighIntent,
+          image: initialData.image,
+        },
+        budgetSettings: {
+          dailyBudget: initialData.dailyBudget,
+          totalBudget: initialData.totalBudget || 0,
+          maxCpc: initialData.maxCpc,
+          startDate: formatDateForInput(initialData.startDate),
+          endDate: formatDateForInput(initialData.endDate),
+        },
+      });
+    }
+  }, [isOpen, initialData, balance, setMode, setStep, setFormData, setBalance, setInitialTotalBudget]);
+
+  const handleSubmit = async () => {
+    await onSubmit(formData);
+  };
+
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget && !isSubmitting) {
+      resetForm();
+      onClose();
+    }
+  };
+
+  const handleClose = () => {
+    if (!isSubmitting) {
+      resetForm();
+      onClose();
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-8"
+      onClick={handleBackdropClick}
+    >
+      <div className="flex flex-col gap-2">
+        {/* 닫기 버튼 */}
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={handleClose}
+            className="flex h-8 w-8 items-center justify-center rounded-full bg-white/20 hover:bg-white/30 transition-colors"
+            disabled={isSubmitting}
+          >
+            <span className="text-white text-lg">✕</span>
+          </button>
+        </div>
+
+        <CampaignForm
+          onSubmit={handleSubmit}
+          isSubmitting={isSubmitting}
+          maxContentHeight="calc(100vh - 250px)"
+        >
+          {currentStep === 1 && <Step1Content onImageUpload={uploadImage} />}
+          {currentStep === 2 && <Step2Content />}
+          {currentStep === 3 && <Step3Content />}
+          {error && (
+            <p className="mt-4 text-center text-sm text-red-500">{error}</p>
+          )}
+        </CampaignForm>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/3_features/campaignDetail/ui/SpendingLogCard/SpendingLogCard.tsx
+++ b/frontend/src/3_features/campaignDetail/ui/SpendingLogCard/SpendingLogCard.tsx
@@ -1,0 +1,103 @@
+import { useState } from 'react';
+import { Pagination } from '@shared/ui/Pagination';
+import { SpendingLogTableHeader } from './SpendingLogTableHeader';
+import {
+  SpendingLogTableRow,
+  type SpendingLogRowData,
+} from './SpendingLogTableRow';
+
+// Mock 데이터 생성
+function generateMockData(): SpendingLogRowData[] {
+  const blogs = [
+    { name: '데브로그', url: 'https://devlog.io/react-hooks-guide' },
+    { name: '코딩하는 플레미', url: 'https://flemi.dev/typescript-tips' },
+    { name: '프론트엔드 마스터', url: 'https://femaster.kr/nextjs-tutorial' },
+    { name: '백엔드 개발 일지', url: 'https://backend-daily.com/nodejs-best' },
+    { name: 'JS 마스터 블로그', url: 'https://jsmaster.blog/es2024-features' },
+    { name: '테크 인사이트', url: 'https://techinsight.io/web-performance' },
+    { name: '개발자 K', url: 'https://dev-k.blog/clean-code-tips' },
+    { name: '코드랩', url: 'https://codelab.kr/docker-kubernetes' },
+  ];
+
+  const cpcValues = [500, 550, 480, 620, 450, 580, 520, 490];
+  const now = new Date();
+  const logs: SpendingLogRowData[] = [];
+
+  for (let i = 0; i < 15; i++) {
+    const date = new Date(now);
+    date.setMinutes(date.getMinutes() - i * 8);
+
+    const isHighIntent = i % 3 !== 1;
+    const blog = blogs[i % blogs.length];
+
+    logs.push({
+      id: i + 1,
+      createdAt: date.toISOString(),
+      postUrl: blog.url,
+      blogName: blog.name,
+      cpc: cpcValues[i % cpcValues.length],
+      behaviorScore: isHighIntent ? Math.floor(Math.random() * 25) + 75 : null,
+      isHighIntent,
+    });
+  }
+
+  return logs;
+}
+
+const MOCK_DATA = generateMockData();
+
+export function SpendingLogCard() {
+  const [offset, setOffset] = useState(0);
+  const limit = 5;
+
+  const total = MOCK_DATA.length;
+  const hasMore = offset + limit < total;
+  const currentPage = Math.floor(offset / limit) + 1;
+  const totalPages = Math.ceil(total / limit);
+
+  const logs = MOCK_DATA.slice(offset, offset + limit);
+
+  const handlePrevPage = () => {
+    if (offset > 0) {
+      setOffset(offset - limit);
+    }
+  };
+
+  const handleNextPage = () => {
+    if (hasMore) {
+      setOffset(offset + limit);
+    }
+  };
+
+  return (
+    <div className="flex flex-col bg-white border border-gray-200 rounded-xl">
+      {/* 헤더 */}
+      <div className="p-5 flex flex-row justify-between items-center border-b border-gray-100">
+        <h3 className="text-base font-semibold text-gray-900">예산 소진 현황</h3>
+        <span className="text-sm text-gray-500">클릭당 예산 소진 기록</span>
+      </div>
+
+      {/* 테이블 */}
+      <table className="w-full">
+        <SpendingLogTableHeader />
+        <tbody>
+          {logs.map((log) => (
+            <SpendingLogTableRow key={log.id} log={log} />
+          ))}
+        </tbody>
+      </table>
+
+      {/* 페이지네이션 */}
+      <Pagination
+        currentPage={currentPage}
+        totalPages={totalPages}
+        totalItems={total}
+        itemsPerPage={limit}
+        offset={offset}
+        hasMore={hasMore}
+        onPrevPage={handlePrevPage}
+        onNextPage={handleNextPage}
+      />
+    </div>
+  );
+}

--- a/frontend/src/3_features/campaignDetail/ui/SpendingLogCard/SpendingLogTableHeader.tsx
+++ b/frontend/src/3_features/campaignDetail/ui/SpendingLogCard/SpendingLogTableHeader.tsx
@@ -1,0 +1,23 @@
+export function SpendingLogTableHeader() {
+  return (
+    <thead className="bg-gray-50 text-sm">
+      <tr>
+        <th className="px-5 py-3 text-left font-medium text-gray-600 whitespace-nowrap">
+          시간
+        </th>
+        <th className="min-w-48 px-5 py-3 text-left font-medium text-gray-600 whitespace-nowrap">
+          포스트 / 블로그
+        </th>
+        <th className="px-5 py-3 text-left font-medium text-gray-600 whitespace-nowrap">
+          CPC
+        </th>
+        <th className="px-5 py-3 text-left font-medium text-gray-600 whitespace-nowrap">
+          방문자 유형
+        </th>
+        <th className="px-5 py-3 text-left font-medium text-gray-600 whitespace-nowrap">
+          상세 내역
+        </th>
+      </tr>
+    </thead>
+  );
+}

--- a/frontend/src/3_features/campaignDetail/ui/SpendingLogCard/SpendingLogTableRow.tsx
+++ b/frontend/src/3_features/campaignDetail/ui/SpendingLogCard/SpendingLogTableRow.tsx
@@ -1,0 +1,87 @@
+import { Icon } from '@shared/ui/Icon';
+import { formatWithComma } from '@shared/lib/format';
+
+export interface SpendingLogRowData {
+  id: number;
+  createdAt: string;
+  postUrl: string;
+  blogName: string;
+  cpc: number;
+  behaviorScore: number | null;
+  isHighIntent: boolean;
+}
+
+interface SpendingLogTableRowProps {
+  log: SpendingLogRowData;
+}
+
+function formatDateTime(timestamp: string): string {
+  const date = new Date(timestamp);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  return `${year}.${month}.${day} ${hours}:${minutes}`;
+}
+
+export function SpendingLogTableRow({ log }: SpendingLogTableRowProps) {
+  return (
+    <tr className="text-sm border-b border-gray-100 hover:bg-gray-50">
+      {/* 시간 */}
+      <td className="px-5 py-4 text-gray-900 whitespace-nowrap">
+        {formatDateTime(log.createdAt)}
+      </td>
+
+      {/* 포스트 / 블로그 */}
+      <td className="min-w-48 max-w-64 px-5 py-4">
+        <div className="flex flex-col gap-0.5">
+          <span className="text-gray-900 font-medium truncate">
+            {log.blogName}
+          </span>
+          <a
+            href={log.postUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-blue-500 hover:underline truncate"
+          >
+            {log.postUrl}
+          </a>
+        </div>
+      </td>
+
+      {/* CPC */}
+      <td className="px-5 py-4 text-gray-900 whitespace-nowrap font-medium">
+        {formatWithComma(log.cpc)}원
+      </td>
+
+      {/* 방문자 유형 */}
+      <td className="px-5 py-4 whitespace-nowrap">
+        {log.isHighIntent ? (
+          <div className="flex items-center gap-2">
+            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-50 text-blue-600">
+              {log.behaviorScore}점
+            </span>
+            <span className="inline-flex items-center gap-1 text-xs text-gray-600">
+              <Icon.BadgeCheck className="w-3.5 h-3.5" />
+              고의도
+            </span>
+          </div>
+        ) : (
+          <span className="text-xs text-gray-500">일반 방문자</span>
+        )}
+      </td>
+
+      {/* 상세 내역 */}
+      <td className="px-5 py-4 whitespace-nowrap">
+        <span className="inline-flex items-center px-3 py-1.5 rounded-lg text-xs bg-gray-100">
+          <span className="text-gray-700">클릭으로</span>
+          <span className="text-red-700 font-bold mx-1">
+            -{formatWithComma(log.cpc)}원
+          </span>
+          <span className="text-gray-700">지출되었습니다</span>
+        </span>
+      </td>
+    </tr>
+  );
+}

--- a/frontend/src/3_features/campaignDetail/ui/SpendingLogCard/index.ts
+++ b/frontend/src/3_features/campaignDetail/ui/SpendingLogCard/index.ts
@@ -1,0 +1,1 @@
+export { SpendingLogCard } from './SpendingLogCard';

--- a/frontend/src/3_features/realtimeBids/ui/RealtimeBidsTableRow.tsx
+++ b/frontend/src/3_features/realtimeBids/ui/RealtimeBidsTableRow.tsx
@@ -40,7 +40,7 @@ export function RealtimeBidsTableRow({ bid }: RealtimeBidsTableRowProps) {
       <td className="px-5 py-4 text-gray-900 whitespace-nowrap">
         {formatDateTime(bid.createdAt)}
       </td>
-      <td className="px-5 py-4 text-gray-900 font-semibold max-w-[200px]">
+      <td className="px-5 py-4 text-gray-900 font-semibold max-w-50">
         <div className="line-clamp-2">{bid.campaignTitle}</div>
       </td>
       <td className="px-5 py-4">

--- a/frontend/src/4_shared/ui/CampaignForm/lib/campaignFormStore.ts
+++ b/frontend/src/4_shared/ui/CampaignForm/lib/campaignFormStore.ts
@@ -14,6 +14,7 @@ interface CampaignFormState {
   formData: CampaignFormData;
   errors: FormErrors;
   balance: number | null;
+  initialTotalBudget: number | null;
 
   setMode: (mode: CampaignFormMode) => void;
   setStep: (step: FormStep) => void;
@@ -22,6 +23,7 @@ interface CampaignFormState {
   setErrors: (errors: FormErrors) => void;
   setBalance: (balance: number | null) => void;
   setFormData: (data: CampaignFormData) => void;
+  setInitialTotalBudget: (budget: number | null) => void;
   resetForm: () => void;
 }
 
@@ -49,6 +51,7 @@ export const useCampaignFormStore = create<CampaignFormState>((set) => ({
   formData: initialFormData,
   errors: {},
   balance: null,
+  initialTotalBudget: null,
 
   setMode: (mode) => set({ mode }),
 
@@ -57,6 +60,8 @@ export const useCampaignFormStore = create<CampaignFormState>((set) => ({
   setBalance: (balance) => set({ balance }),
 
   setFormData: (data) => set({ formData: data }),
+
+  setInitialTotalBudget: (budget) => set({ initialTotalBudget: budget }),
 
   updateCampaignContent: (data) =>
     set((state) => ({
@@ -89,5 +94,6 @@ export const useCampaignFormStore = create<CampaignFormState>((set) => ({
       formData: initialFormData,
       errors: {},
       balance: null,
+      initialTotalBudget: null,
     }),
 }));

--- a/frontend/src/4_shared/ui/CampaignForm/ui/CampaignForm.tsx
+++ b/frontend/src/4_shared/ui/CampaignForm/ui/CampaignForm.tsx
@@ -10,14 +10,16 @@ interface CampaignFormProps {
   children?: ReactNode;
   onSubmit?: () => void;
   isSubmitting?: boolean;
+  maxContentHeight?: string;
 }
 
 export function CampaignForm({
   children,
   onSubmit,
   isSubmitting = false,
+  maxContentHeight,
 }: CampaignFormProps) {
-  const { currentStep, setStep, formData, balance, mode } = useCampaignFormStore();
+  const { currentStep, setStep, formData, balance, mode, initialTotalBudget } = useCampaignFormStore();
 
   const isNextDisabled = () => {
     if (isSubmitting) return true;
@@ -25,7 +27,12 @@ export function CampaignForm({
       return !isStep1Valid(formData.campaignContent);
     }
     if (currentStep === 2) {
-      return !isStep2Valid({ ...formData.budgetSettings, balance });
+      return !isStep2Valid({
+        ...formData.budgetSettings,
+        balance,
+        isEditMode: mode === 'edit',
+        initialTotalBudget: initialTotalBudget ?? undefined,
+      });
     }
     return false;
   };
@@ -50,9 +57,14 @@ export function CampaignForm({
 
   return (
     <div className="flex w-150 flex-col gap-4">
-      <StepIndicator currentStep={currentStep} />
+      <StepIndicator currentStep={currentStep} mode={mode} />
       <Modal showHeader={false}>
-        <div className="p-6">{children}</div>
+        <div
+          className="p-6"
+          style={maxContentHeight ? { maxHeight: maxContentHeight, overflowY: 'auto' } : undefined}
+        >
+          {children}
+        </div>
       </Modal>
       <FormNavigation
         currentStep={currentStep}

--- a/frontend/src/4_shared/ui/CampaignForm/ui/FormNavigation.tsx
+++ b/frontend/src/4_shared/ui/CampaignForm/ui/FormNavigation.tsx
@@ -67,7 +67,7 @@ export function FormNavigation({
         </Button>
       </div>
 
-      <p className="text-right text-xs text-gray-500">
+      <p className={`text-right text-xs ${mode === 'edit' ? 'text-white/70' : 'text-gray-500'}`}>
         {hintText}
       </p>
     </div>

--- a/frontend/src/4_shared/ui/CampaignForm/ui/Step2Content.tsx
+++ b/frontend/src/4_shared/ui/CampaignForm/ui/Step2Content.tsx
@@ -12,10 +12,11 @@ import {
 } from '../lib/step2Validation';
 
 export function Step2Content() {
-  const { formData, updateBudgetSettings, errors, setErrors, balance } =
+  const { formData, updateBudgetSettings, errors, setErrors, balance, mode, initialTotalBudget } =
     useCampaignFormStore();
   const { dailyBudget, totalBudget, maxCpc, startDate, endDate } =
     formData.budgetSettings;
+  const isEditMode = mode === 'edit';
 
   const totalBudgetHint =
     balance !== null
@@ -55,7 +56,12 @@ export function Step2Content() {
   };
 
   const handleTotalBudgetBlur = () => {
-    const error = validateTotalBudget(totalBudget, dailyBudget, balance);
+    const error = validateTotalBudget(
+      totalBudget,
+      dailyBudget,
+      balance,
+      isEditMode ? (initialTotalBudget ?? undefined) : undefined
+    );
     setErrors({
       budgetSettings: {
         ...errors.budgetSettings,
@@ -73,7 +79,7 @@ export function Step2Content() {
   };
 
   const handleStartDateBlur = () => {
-    const error = validateStartDate(startDate);
+    const error = validateStartDate(startDate, isEditMode);
     setErrors({
       budgetSettings: {
         ...errors.budgetSettings,

--- a/frontend/src/4_shared/ui/CampaignForm/ui/StepIndicator.tsx
+++ b/frontend/src/4_shared/ui/CampaignForm/ui/StepIndicator.tsx
@@ -1,13 +1,15 @@
-import type { FormStep } from '../lib/types';
+import type { FormStep, CampaignFormMode } from '../lib/types';
 
 interface StepIndicatorProps {
   currentStep: FormStep;
   totalSteps?: number;
+  mode?: CampaignFormMode;
 }
 
 export function StepIndicator({
   currentStep,
   totalSteps = 3,
+  mode = 'create',
 }: StepIndicatorProps) {
   const progressPercentage = (currentStep / totalSteps) * 100;
 
@@ -20,16 +22,18 @@ export function StepIndicator({
     return titles[step];
   };
 
+  const isEditMode = mode === 'edit';
+
   return (
     <div className="flex flex-col gap-2">
       <div className="flex flex-row items-center justify-between">
-        <span className="text-sm font-medium text-gray-900">
+        <span className={`text-sm font-medium ${isEditMode ? 'text-white' : 'text-gray-900'}`}>
           STEP {currentStep} OF {totalSteps}
-          <span className="pl-2 text-gray-500">
+          <span className={`pl-2 ${isEditMode ? 'text-white/70' : 'text-gray-500'}`}>
             {getStepTitle(currentStep)}
           </span>
         </span>
-        <span className="text-sm font-medium text-blue-500">
+        <span className={`text-sm font-medium ${isEditMode ? 'text-white' : 'text-blue-500'}`}>
           {Math.round(progressPercentage)}%
         </span>
       </div>

--- a/frontend/src/4_shared/ui/CurrencyField/CurrencyField.tsx
+++ b/frontend/src/4_shared/ui/CurrencyField/CurrencyField.tsx
@@ -9,6 +9,7 @@ interface CurrencyFieldProps {
   error?: string;
   placeholder?: string;
   unit?: string;
+  prefix?: string;
 }
 
 export function CurrencyField({
@@ -20,6 +21,7 @@ export function CurrencyField({
   error,
   placeholder = '0',
   unit = '원',
+  prefix,
 }: CurrencyFieldProps) {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const numberValue = parseNumber(e.target.value);
@@ -43,6 +45,7 @@ export function CurrencyField({
             : 'border-gray-200 focus-within:ring-blue-200'
         }`}
       >
+        {prefix && <span className="text-sm text-gray-500 mr-1">{prefix}</span>}
         <input
           type="text"
           inputMode="numeric"


### PR DESCRIPTION
## 🔗 관련 이슈
- close: #181 

---

## ✅ 작업 내용

캠페인 상세 페이지의 예산 관리, 소진 기록 조회, 캠페인 수정 기능을 구현했습니다.
나머지 핵심 기능들을 완성했습니다.

### 캠페인 수정 모달 구현
### 예산 및 지출 현황 카드 구현
### 예산 소진 현황 카드 구현

**주요 검토 파일:**
* `frontend/src/3_features/campaignDetail/ui/CampaignEditModal.tsx` - 캠페인 수정 모달
* `frontend/src/3_features/campaignDetail/ui/BudgetStatusCard/` - 예산 현황 카드
* `frontend/src/3_features/campaignDetail/ui/SpendingLogCard/` - 소진 기록 카드
* `frontend/src/2_pages/campaignDetail/ui/CampaignDetailPage.tsx` - 페이지에 통합
* `frontend/src/4_shared/ui/CampaignForm/` - 수정 모드 지원 개선
* `backend/src/campaign/` - isHighIntent 수정 API 추가

## 1️⃣ 캠페인 수정 모달
### CampaignEditModal
- 기존 CampaignForm을 재사용하여 수정 모달 구현
- 모달 배경 클릭 시 닫기 (제출 중이 아닐 때만)
- 우측 상단 X 버튼으로 닫기
- 초기 데이터 자동 설정
- 3단계 폼 (캠페인 내용 → 예산 설정 → 최종 확인)

### 초기 데이터 처리
- 캠페인 상세 정보를 폼에 자동 입력
- 날짜 형식 변환 (ISO → YYYY-MM-DD)
- 태그 데이터 구조 변환 (id, name → id, name, category)
- balance, initialTotalBudget 설정

### 제출 처리
- UpdateCampaignRequest 타입으로 API 호출
- 성공 시 토스트 메시지 + 모달 닫기 + 데이터 refetch
- 실패 시 에러 토스트 메시지

## 2️⃣ 예산 및 지출 현황 카드
### BudgetStatusCard (컨테이너)
- 예산 충전 버튼 (예산 페이지로 이동)
- 빠른 예산 수정 버튼 (편집 모드 토글)
- 편집 모드 활성화 시 파란색 테두리 (border-blue-500)
- 로딩 상태 처리

### BudgetProgressSection
- 오늘 소진 예산 프로그레스바
  - 소진 금액 / 일일 예산 표시
  - ProgressBar 컴포넌트 사용 (blue, md)
- 총 소진 예산 프로그레스바
  - 소진 금액 / 총 예산 표시
  - totalBudget이 null일 경우 "-" 표시

### BudgetInfoSection (일반 모드)
- 총 예산, 일일 예산, 최대 CPC 정보 표시
- 천 단위 콤마 포맷팅

### BudgetEditMode (편집 모드)
- **총 예산 추가**
  - 현재 총 예산에 추가할 금액 입력
  - 실시간 최종 예산 계산 표시 (기존 + 추가)
  - CurrencyField로 금액 입력
  - 퀵버튼 (+1만원, +3만원, +5만원)
  - 예산 잔액 표시
- **일일 예산 수정**
  - CurrencyField로 직접 수정
- **최대 CPC 수정**
  - CurrencyField로 직접 수정
- 취소/저장 버튼
- 안내 문구: "일일 예산, CPC값은 다음 날부터 적용됩니다."

### 레이아웃 구조
- flex-3: 프로그레스 영역
- flex-2: 정보/편집 영역 (회색 배경 카드)

## 3️⃣ 예산 소진 현황 카드 (MOCK)
### SpendingLogCard
- Mock 데이터 15개 생성 (실제 API 연동 대기)
- 페이지당 5개 항목 표시
- Pagination 컴포넌트 사용

### SpendingLogTableHeader
- 5개 컬럼: 시간, 포스트/블로그, CPC, 방문자 유형, 상세 내역

### SpendingLogTableRow
- **시간**: YYYY.MM.DD HH:MM 형식
- **포스트/블로그**: 
  - 블로그 이름 (font-medium)
  - 포스트 URL (파란색 링크, 새 탭)
- **CPC**: 천 단위 콤마 + "원"
- **방문자 유형**:
  - 고의도: 행동 점수 뱃지 (파란색) + 체크 아이콘
  - 일반: "일반 방문자" 텍스트
- **상세 내역**: "클릭으로 -XXX원 지출되었습니다" (회색 배경)
- hover 시 배경 회색 변경

### Mock 데이터 생성
- 8개 블로그 데이터 순환
- CPC 랜덤 값 (450~620원)
- 고의도 비율 약 67% (behaviorScore 75~100점)
- 8분 간격으로 시간 생성

## 4️⃣ CampaignForm 수정 모드 개선
### 수정 모드 지원 확장
- **campaignFormStore**:
  - `initialTotalBudget` 상태 추가
  - `setInitialTotalBudget` 액션 추가
  - resetForm에서 initialTotalBudget도 초기화

### step2Validation 개선
- **validateStartDate**: 
  - `isEditMode` 파라미터 추가
  - 수정 모드에서는 과거 날짜 허용 (이미 시작된 캠페인)
- **validateTotalBudget**:
  - `initialTotalBudget` 파라미터 추가
  - 수정 모드에서 기존 예산보다 적게 수정 불가 검증
  - 에러 메시지: "총 예산은 기존 예산(XXX원) 이상이어야 합니다."
- **isStep2Valid**: 
  - `isEditMode`, `initialTotalBudget` 파라미터 추가
  - 조건부 검증 적용

### UI 개선
- **StepIndicator**: 
  - `mode` prop 추가
  - 수정 모드일 때 텍스트 색상 흰색으로 변경
- **FormNavigation**:
  - 수정 모드일 때 힌트 텍스트 색상 변경 (text-white/70)
- **CampaignForm**:
  - `maxContentHeight` prop 추가 (모달에서 스크롤 처리)
  - isStep2Valid에 isEditMode, initialTotalBudget 전달

## 5️⃣ 백엔드 API 개선
### UpdateCampaignDto
- `isHighIntent` 필드 추가
- `@IsBoolean` 데코레이터로 유효성 검증

### TypeOrmCampaignRepository
- `isHighIntent` 업데이트 로직 추가
- 캠페인 수정 시 고의도 학습자 여부 변경 가능

## 6️⃣ 기타 개선사항
### RealtimeBidsTableRow
- 캠페인 제목 컬럼 max-width 개선
  - 기존: `max-w-[200px]` (픽셀 값)
  - 변경: `max-w-50` (Tailwind 유틸리티)

### CampaignDetailPage 통합
- `handleChargeBudget`: 예산 페이지로 이동
- `handleUpdateBudget`: 예산 수정 API 호출 + refetch
- `handleEditSubmit`: 캠페인 수정 API 호출 + refetch
- `handleEdit`: 수정 모달 열기
- balance 조회 (useAdvertiserBalance)
- 모든 카드 컴포넌트 연결

---

## 📸 스크린샷 / 데모 (옵션)

### 이 브랜치에서 확인했을 때 아래 동작이 정상적으로 작동하면 됩니다!

**캠페인 수정 모달**
- 수정 버튼 클릭 → 모달 열림
- 기존 데이터 자동 입력
- 3단계 폼 진행
- 수정 완료 → 토스트 + 모달 닫기

**예산 및 지출 현황 카드**
- 일반 모드: 총 예산, 일일 예산, 최대 CPC 표시
- 편집 모드: 예산 추가, 일일 예산/CPC 수정
- 퀵버튼으로 빠른 추가
- 저장 → 토스트 + refetch

**예산 소진 현황 카드**
- 5개 항목 테이블 표시
- 고의도/일반 방문자 구분
- 페이지네이션 작동
- 포스트 URL 클릭 시 새 탭 열림

![화면 기록 2026-01-28 오전 9 46 14](https://github.com/user-attachments/assets/b7c5ac22-787b-4fff-bf5c-9d95257a045f)

- + 추가 완료
<img width="362" height="427" alt="스크린샷 2026-01-28 오후 2 02 21" src="https://github.com/user-attachments/assets/aa601e50-bc24-494a-b4ea-6c33ebf50126" />


---

## 🧪 테스트 방법 (옵션)

1. **캠페인 수정 모달**
   - 상세 페이지에서 "수정" 버튼 클릭
   - 기존 데이터 자동 입력 확인
   - 제목, 내용, URL, 태그 수정 가능 확인
   - 예산 설정 단계에서 검증 확인:
     - 시작일이 과거여도 허용되는지 확인 (수정 모드)
     - 총 예산을 기존보다 적게 입력 시 에러 확인
   - 수정 완료 → 토스트 메시지 + 페이지 새로고침 확인

2. **예산 및 지출 현황 카드**
   - 프로그레스바 정상 표시 확인
   - "빠른 예산 수정" 버튼 클릭 → 편집 모드 전환
   - 퀵버튼 (+1만원, +3만원, +5만원) 클릭 시 금액 추가 확인
   - 총 예산 = 기존 + 추가 계산 확인
   - 일일 예산, 최대 CPC 수정
   - "저장" 버튼 → 토스트 + refetch 확인
   - "취소" 버튼 → 편집 모드 종료 확인

3. **예산 소진 현황 카드**
   - 5개 항목 테이블 표시 확인
   - 시간, 블로그명, URL, CPC 표시 확인
   - 고의도 방문자: 점수 뱃지 + 체크 아이콘 확인
   - 일반 방문자: "일반 방문자" 텍스트 확인
   - 페이지네이션 이전/다음 버튼 작동 확인
   - 포스트 URL 클릭 시 새 탭에서 열리는지 확인

4. **통합 테스트**
   - 상세 페이지에서 모든 카드 정상 표시 확인
   - 예산 충전 버튼 → 예산 페이지 이동 확인
   - 수정/저장 후 데이터 refetch 확인

---

## 💬 To Reviewers

캠페인 상세 페이지의 나머지 기능 구현도 완료했습니다!

**핵심 구현 내용:**
- 캠페인 수정 모달: CampaignForm 재사용 + 수정 모드 지원
- 예산 현황 카드: 조회/편집 모드 전환 + 빠른 예산 수정
- 소진 현황 카드: Mock 데이터 테이블 + 페이지네이션