### PR TITLE
[Feat] 캠페인 생성 페이지에 '네부캠' 카테고리 탭 및 태그 추가

### DIFF
--- a/backend/src/common/constants.ts
+++ b/backend/src/common/constants.ts
@@ -124,6 +124,16 @@ export const AVAILABLE_TAGS: Tag[] = [
   { id: 100, name: 'Electron' },
   { id: 101, name: 'Tauri' },
 
+  // 네부캠
+  { id: 116, name: '게임' },
+  { id: 117, name: '학습도구' },
+  { id: 118, name: '실시간 협업' },
+  { id: 119, name: '기록/CS' },
+  { id: 120, name: '시뮬레이터' },
+  { id: 121, name: '메타버스' },
+  { id: 122, name: '확장프로그램' },
+  { id: 123, name: '소셜' },
+
   // AI & Machine Learning
   { id: 102, name: 'AI' },
   { id: 103, name: 'Machine Learning' },

--- a/frontend/src/4_shared/ui/CampaignForm/lib/constants.ts
+++ b/frontend/src/4_shared/ui/CampaignForm/lib/constants.ts
@@ -1,13 +1,13 @@
 import type { Tag, CampaignCategory } from './types';
 
 export const CAMPAIGN_CATEGORIES: CampaignCategory[] = [
+  '네부캠',
   '언어',
   'FE',
   'BE',
   'DB',
   '클라우드',
   '모바일',
-  '네부캠',
   '기타',
 ];
 

--- a/frontend/src/4_shared/ui/CampaignForm/lib/constants.ts
+++ b/frontend/src/4_shared/ui/CampaignForm/lib/constants.ts
@@ -7,6 +7,7 @@ export const CAMPAIGN_CATEGORIES: CampaignCategory[] = [
   'DB',
   '클라우드',
   '모바일',
+  '네부캠',
   '기타',
 ];
 
@@ -102,6 +103,16 @@ export const AVAILABLE_TAGS: Tag[] = [
   { id: 99, name: 'Flutter', category: '모바일' },
   { id: 100, name: 'Electron', category: '모바일' },
   { id: 101, name: 'Tauri', category: '모바일' },
+
+  // 네부캠
+  { id: 116, name: '게임', category: '네부캠' },
+  { id: 117, name: '학습도구', category: '네부캠' },
+  { id: 118, name: '실시간 협업', category: '네부캠' },
+  { id: 119, name: '기록/CS', category: '네부캠' },
+  { id: 120, name: '시뮬레이터', category: '네부캠' },
+  { id: 121, name: '메타버스', category: '네부캠' },
+  { id: 122, name: '확장프로그램', category: '네부캠' },
+  { id: 123, name: '소셜', category: '네부캠' },
 
   // 기타
   { id: 63, name: 'Git', category: '기타' },

--- a/frontend/src/4_shared/ui/CampaignForm/lib/types.ts
+++ b/frontend/src/4_shared/ui/CampaignForm/lib/types.ts
@@ -5,6 +5,7 @@ export type CampaignCategory =
   | 'DB'
   | '클라우드'
   | '모바일'
+  | '네부캠'
   | '기타';
 
 export interface Tag {

--- a/frontend/src/4_shared/ui/CampaignForm/ui/KeywordSelector.tsx
+++ b/frontend/src/4_shared/ui/CampaignForm/ui/KeywordSelector.tsx
@@ -19,9 +19,12 @@ export function KeywordSelector({
   error,
 }: KeywordSelectorProps) {
   const [activeCategory, setActiveCategory] =
-    useState<CampaignCategory>('언어');
+    useState<CampaignCategory>('네부캠');
 
   const selectedTagIds = value.map((tag) => tag.id);
+
+  const hasNebucamTag = value.some((tag) => tag.category === '네부캠');
+  const hasGeneralTag = value.some((tag) => tag.category !== '네부캠');
 
   const isTagSelected = (tagId: number) => {
     return selectedTagIds.includes(tagId);
@@ -32,6 +35,13 @@ export function KeywordSelector({
       return;
     }
     if (isTagSelected(tag.id)) {
+      return;
+    }
+
+    if (tag.category === '네부캠' && hasGeneralTag) {
+      return;
+    }
+    if (tag.category !== '네부캠' && hasNebucamTag) {
       return;
     }
     onChange([...value, tag]);
@@ -92,11 +102,22 @@ export function KeywordSelector({
           ))}
         </div>
 
+        {/* 네부캠 안내 문구 */}
+        {activeCategory === '네부캠' && (
+          <p className="text-xs text-yellow-600 bg-yellow-50 px-3 py-2 rounded-md">
+            네부캠 태그는 기술 태그와 함께 사용할 수 없습니다.
+          </p>
+        )}
+
         {/* 태그 목록 */}
         <div className="flex flex-wrap gap-2">
           {categoryTags.map((tag) => {
             const selected = isTagSelected(tag.id);
-            const disabled = !selected && value.length >= MAX_SELECTED_TAGS;
+            const isMaxReached = value.length >= MAX_SELECTED_TAGS;
+            const isCategoryBlocked =
+              (activeCategory === '네부캠' && hasGeneralTag) ||
+              (activeCategory !== '네부캠' && hasNebucamTag);
+            const disabled = !selected && (isMaxReached || isCategoryBlocked);
 
             return (
               <button
@@ -117,6 +138,18 @@ export function KeywordSelector({
             );
           })}
         </div>
+
+        {/* 혼용 불가 안내 */}
+        {hasNebucamTag && activeCategory !== '네부캠' && (
+          <p className="text-xs text-gray-500">
+            네부캠 태그가 선택되어 있어 기술 태그를 선택할 수 없습니다.
+          </p>
+        )}
+        {hasGeneralTag && activeCategory === '네부캠' && (
+          <p className="text-xs text-gray-500">
+            기술 태그가 선택되어 있어 네부캠 태그를 선택할 수 없습니다.
+          </p>
+        )}
       </div>
 
       {error && <p className="text-sm text-red-500">{error}</p>}


### PR DESCRIPTION
## 🔗 관련 이슈
- close: #

---

## ✅ 작업 내용

캠페인 생성 시 네이버 부스트캠프 프로젝트 분류를 위한 '네부캠' 카테고리를 추가했습니다.

### 프론트엔드 변경
- `CampaignCategory` 타입에 `'네부캠'` 추가
- `CAMPAIGN_CATEGORIES`에 네부캠 탭 추가
- `AVAILABLE_TAGS`에 8개 네부캠 태그 추가 (id: 116~123)

### 백엔드 변경
- `AVAILABLE_TAGS`에 동일한 8개 태그 추가 (API 유효성 검증용)

### 추가된 태그
게임, 학습도구, 실시간 협업, 기록/CS, 시뮬레이터, 메타버스, 확장프로그램, 소셜

---

## 📸 스크린샷 / 데모 (옵션)

<img width="588" height="299" alt="스크린샷 2026-01-28 오후 2 27 08" src="https://github.com/user-attachments/assets/112b6d22-ed8b-4230-84aa-d4f973eed770" />

![화면 기록 2026-01-28 오후 3 00 50](https://github.com/user-attachments/assets/01987db2-efd5-47ef-829f-1ceb70faccb4)


---

## 🧪 테스트 방법 (옵션)

1. 캠페인 생성 페이지 접속 (`/advertiser/campaign/create`)
2. STEP 1에서 키워드 태그 선택 영역 확인
3. '네부캠' 탭 클릭
4. 8개 태그(게임, 학습도구 등) 표시 확인
5. 태그 선택 후 캠페인 생성 진행
6. 태그가 정상적으로 저장되는지 확인

---

## 💬 To Reviewers

**백엔드에도 태그 추가했습니다!**

캠페인 생성 API에서 태그 유효성 검증을 수행하는데, 백엔드의 `AVAILABLE_TAGS`에 없는 태그를 보내면 `"존재하지 않는 태그입니다"` 오류가 발생합니다..!
그래서 프론트엔드 UI에 태그를 추가하는 것과 동시에 백엔드 검증 로직에도 동일한 태그를 추가해야 정상 작동해 이 부분도 수정했습니다.