### PR TITLE
[Feat] RTB 로직 수정

### DIFF
--- a/backend/src/rtb/matchers/xenova.matcher.ts
+++ b/backend/src/rtb/matchers/xenova.matcher.ts
@@ -68,7 +68,6 @@ export class TransformerMatcher extends Matcher {
       allCampaigns.map(async (campaign) => ({
         campaign,
         similarity: await this.scoreCampaignByTags(
-          requestText,
           requestEmbedding,
           requestNorm,
           requestTokens,
@@ -153,7 +152,6 @@ export class TransformerMatcher extends Matcher {
    * 5) 최종 Score = 0.70*S_top + 0.25*S_cov + 0.05*S_exact
    */
   private async scoreCampaignByTags(
-    requestText: string,
     requestEmbedding: number[],
     requestNorm: string,
     requestTokens: Set<string>,

--- a/backend/src/rtb/matchers/xenova.matcher.ts
+++ b/backend/src/rtb/matchers/xenova.matcher.ts
@@ -8,8 +8,31 @@ import type { CampaignWithTags } from '../../campaign/types/campaign.types';
 export class TransformerMatcher extends Matcher {
   private readonly logger = new Logger(TransformerMatcher.name);
 
-  // 유사도 임계값
+  // 최종 매칭 점수(0~1) 임계값
   private readonly SIMILARITY_THRESHOLD = 0.4;
+
+  /**
+   * 고도화된 스코어링(요청 텍스트 vs 캠페인 태그별 유사도 집계)
+   *
+   * - 기존: (캠페인 태그들을 join한 1문장) vs (요청 태그 join 1문장) 단일 비교
+   * - 개선: 캠페인의 "각 태그"를 요청 텍스트와 각각 비교한 뒤, top-k + coverage + exact 보너스로 점수 산정
+   *
+   * 이유:
+   * - 캠페인 태그가 많아질수록 join 문장은 노이즈가 섞여 유사도가 희석될 수 있음
+   * - tag-wise 비교는 "정말 가까운 태그"가 점수에 더 직접 반영됨
+   */
+  private readonly TOP_K = 3;
+  private readonly TOP_K_WEIGHTS = [0.5, 0.3, 0.2] as const;
+  private readonly COVERAGE_THRESHOLD = 0.45;
+  private readonly COVERAGE_SATURATION = 2; // 2개 이상 임계치 넘으면 coverage는 1로 포화
+  private readonly FINAL_WEIGHTS = {
+    top: 0.7,
+    coverage: 0.25,
+    exact: 0.05,
+  } as const;
+
+  // 임베딩은 계산 비용이 높아서(모델 호출), 태그 문자열 기준으로 간단 캐싱합니다.
+  private readonly embeddingCache = new Map<string, number[]>();
 
   constructor(
     private readonly campaignRepo: CampaignRepository,
@@ -27,19 +50,31 @@ export class TransformerMatcher extends Matcher {
     }
 
     const requestText = this.buildRequestText(context.tags);
+    const requestNorm = this.normalizeText(requestText);
+    const requestTokens = new Set(this.tokenizeText(requestText));
     const allCampaigns = await this.campaignRepo.getAll();
 
-    // 모든 캠페인과 유사도 계산
-    const withSimilarity = await Promise.all(
-      allCampaigns.map(async (campaign) => {
-        const campaignText = this.buildCampaignText(campaign);
+    let requestEmbedding: number[];
+    try {
+      // 요청 임베딩은 모든 캠페인 비교에서 공통으로 사용되므로 한 번만 계산합니다.
+      requestEmbedding = await this.mlEngine.getEmbedding(requestText);
+    } catch (error) {
+      this.logger.warn('요청 태그 임베딩 생성에 실패했습니다.', error as Error);
+      return [];
+    }
 
-        const similarity = await this.mlEngine.computeTextSimilarity(
+    // 모든 캠페인과 스코어 계산 (0~1)
+    const withSimilarity = await Promise.all(
+      allCampaigns.map(async (campaign) => ({
+        campaign,
+        similarity: await this.scoreCampaignByTags(
           requestText,
-          campaignText
-        );
-        return { campaign, similarity };
-      })
+          requestEmbedding,
+          requestNorm,
+          requestTokens,
+          campaign
+        ),
+      }))
     );
 
     // 임계값 이상만 필터링
@@ -59,12 +94,151 @@ export class TransformerMatcher extends Matcher {
     return tags.join(' ');
   }
 
-  //  캠페인 정보를 임베딩을 위한 단일 텍스트로 변환합니다.
-  private buildCampaignText(campaign: CampaignWithTags): string {
-    const tagNames = (campaign.tags ?? []).map((t) => t.name).join(' ');
+  private normalizeText(text: string): string {
+    return text.toLowerCase().replace(/\s+/g, ' ').trim();
+  }
 
-    // return `${campaign.title} ${campaign.content} ${tagNames}`; // 더 풍부한 문맥은 추후에 고려
+  // 텍스트를 비교용 토큰으로 분해합니다 (camelCase/구분자 분리 + sql 접미어 분해).
+  // 예) "mongoDb" -> ["mongo","db"], "postgresSql" -> ["postgres","sql"], "mysql" -> ["my","sql"]
+  private tokenizeText(text: string): string[] {
+    const normalized = this.normalizeText(
+      text.replace(/([a-z0-9])([A-Z])/g, '$1 $2').replace(/[_\-/]+/g, ' ')
+    );
 
-    return tagNames;
+    const tokens: string[] = [];
+    for (const raw of normalized.split(' ')) {
+      const t = raw.trim();
+      if (!t) continue;
+
+      if (t.length > 3 && t.endsWith('sql')) {
+        const base = t.slice(0, -3);
+        if (base) tokens.push(base);
+        tokens.push('sql');
+      } else {
+        tokens.push(t);
+      }
+    }
+    return tokens;
+  }
+
+  private hasTokenOverlap(a: Set<string>, b: Set<string>): boolean {
+    for (const t of a) {
+      if (b.has(t)) return true;
+    }
+    return false;
+  }
+
+  private clamp01(n: number): number {
+    if (Number.isNaN(n)) return 0;
+    return Math.max(0, Math.min(1, n));
+  }
+
+  private async getEmbeddingCached(text: string): Promise<number[]> {
+    const key = this.normalizeText(text);
+    const cached = this.embeddingCache.get(key);
+    if (cached) return cached;
+
+    const embedding = await this.mlEngine.getEmbedding(text);
+    this.embeddingCache.set(key, embedding);
+    return embedding;
+  }
+
+  /**
+   * 캠페인 점수 계산
+   *
+   * 1) 캠페인 태그 각각과 요청 텍스트의 유사도(s_i) 산출
+   * 2) top-k(기본 3개) 유사도에 가중치 부여하여 S_top 계산
+   * 3) 임계치(기본 0.45) 이상인 태그 개수로 coverage(S_cov) 계산
+   * 4) exact match(문자열 기반) 보너스(S_exact) 적용
+   * 5) 최종 Score = 0.70*S_top + 0.25*S_cov + 0.05*S_exact
+   */
+  private async scoreCampaignByTags(
+    requestText: string,
+    requestEmbedding: number[],
+    requestNorm: string,
+    requestTokens: Set<string>,
+    campaign: CampaignWithTags
+  ): Promise<number> {
+    const tagNames = (campaign.tags ?? [])
+      .map((t) => (t?.name ?? '').trim())
+      .filter(Boolean);
+
+    if (tagNames.length === 0) {
+      return 0;
+    }
+
+    const sims: number[] = [];
+    let exactMatch = false;
+
+    for (const tagName of tagNames) {
+      const tagNorm = this.normalizeText(tagName);
+      const tagTokens = new Set(this.tokenizeText(tagName));
+
+      // exact match 보너스는 "비슷한 의미지만 약어라서 임베딩이 흔들리는" 케이스를 조금 보완합니다.
+      // - 토큰 교집합이 있으면(예: 요청 "sql 광고" vs 태그 "mysql") exactMatch로 간주합니다.
+      // - 다만 너무 흔한 토큰이 많아질 경우 가중치/stopword를 추가로 조정할 수 있습니다.
+      if (tagNorm.includes(' ')) {
+        if (requestNorm.includes(tagNorm)) exactMatch = true;
+      } else if (
+        requestTokens.has(tagNorm) ||
+        this.hasTokenOverlap(requestTokens, tagTokens)
+      ) {
+        exactMatch = true;
+      }
+
+      try {
+        const tagEmbedding = await this.getEmbeddingCached(tagName);
+        sims.push(
+          this.mlEngine.calculateSimilarity(requestEmbedding, tagEmbedding)
+        );
+      } catch (error) {
+        // 특정 태그 임베딩이 실패해도 전체 캠페인을 버리진 않고, 해당 태그만 스킵합니다.
+        this.logger.debug(
+          `태그 임베딩 실패로 스킵: "${tagName}" (campaign=${campaign.id})`,
+          error as Error
+        );
+      }
+    }
+
+    if (sims.length === 0) {
+      return 0;
+    }
+
+    sims.sort((a, b) => b - a);
+
+    // top-k 가중 평균: 강한 매칭(top1)을 가장 크게, 나머지는 점진적으로 반영
+    const k = Math.min(this.TOP_K, sims.length);
+    let sTop = 0;
+    let wSum = 0;
+    for (let i = 0; i < k; i++) {
+      const w = this.TOP_K_WEIGHTS[i] ?? 0;
+      wSum += w;
+      sTop += sims[i] * w;
+    }
+    // 태그 수가 1~2개인 캠페인도 과도하게 불리하지 않도록 weight 합으로 정규화합니다.
+    if (wSum > 0) sTop /= wSum;
+    sTop = this.clamp01(sTop);
+
+    // coverage: 임계치 이상으로 "의미 있게" 맞는 태그가 몇 개인지
+    const coverageCount = sims.filter(
+      (s) => s >= this.COVERAGE_THRESHOLD
+    ).length;
+    const sCov = this.clamp01(coverageCount / this.COVERAGE_SATURATION);
+
+    const sExact = exactMatch ? 1 : 0;
+
+    const finalScore =
+      this.FINAL_WEIGHTS.top * sTop +
+      this.FINAL_WEIGHTS.coverage * sCov +
+      this.FINAL_WEIGHTS.exact * sExact;
+
+    // 필요하면 아래 로그를 켜서 캠페인별 breakdown을 확인할 수 있습니다.
+    // this.logger.debug(
+    //   `Campaign ${campaign.id}: top=${sTop.toFixed(3)}, cov=${sCov.toFixed(
+    //     3
+    //   )}, exact=${sExact} => score=${finalScore.toFixed(3)}`
+    // );
+
+    return this.clamp01(finalScore);
   }
 }


### PR DESCRIPTION
<!-- PR 제목 예시 : [Feat] 로그인 기능 구현 -->
<!-- PR 제목은 위 형식을 참고하여 작성해주세요. -->
<!-- 필요 없는 내용은 지우고 작성해주세요 -->

## 🔗 관련 이슈

- close: #226 

---

## ✅ 작업 내용

## <!-- 구현한 기능이나 수정한 내용을 상세히 기술해주세요. -->
- `backend/src/rtb/matchers/xenova.matcher.ts` RTB 매칭 로직 고도화.
- `sdk/src/shared/config/sdk-config.ts` `sdk/src/shared/types/index.ts` 수동 모드 data-context 설정 추가 및 context 필드 정의, context 없을 때 자동 모드 fallback.
- `sdk/src/features/DecisionAPIClient.ts` 수동 모드에서 context 태그 우선 전송, 없으면 추출 태그 사용.
- `backend/src/config/typeorm.config.ts` TypeORM 로그를 error/warn만 출력하도록 조정.

RTB 매칭 정확도를 높이기 위해 기존의 요청 태그 문장 vs 캠페인 태그 문장 비교를 버리고, 캠페인 태그를 개별로 비교한 뒤 가중치로 합산하는 방식으로 전환했습니다.

- ***

## 📸 스크린샷 / 데모 (옵션)

<!-- UI 변경사항이나 새로운 기능의 동작을 시각적으로 보여주세요. -->

---

## 🧪 테스트 방법 (옵션)

<!-- 리뷰어가 기능을 테스트할 수 있도록 구체적인 테스트 방법을 설명해주세요. -->

1.
2.

---

## 💬 To Reviewers

<!-- 리뷰어에게 전달하고 싶은 내용이나 특별히 확인이 필요한 부분을 작성해주세요. -->
