### PR TITLE
[Feat/Perf] campaign 및 service 로직에 캐싱 로직 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 <br/>
 <br/>
 
-
 ## 🧐 문제 인식 (Why)
 
 1. **맥락 없는 광고 노출**
@@ -162,6 +161,11 @@ https://github.com/boostcampwm2025/web27-BoostAD/wiki/CICD-%ED%8C%8C%EC%9D%B4%ED
 
 <br/>
 <br/>
+
+## BoostAD와 협업 중인 다른 프로젝트도 살펴보세요!
+- WEB01 BoostUS: https://boostus.site
+- WEB04 우리 모두 다빈치: https://we-are-all-davinci.netlify.app/
+- WEB11 말만해: https://malmanhae.com/
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# web27-boostcamp
+# web27-BoostAD🔥
 
 ![banner3](https://github.com/user-attachments/assets/a1d7d818-8d00-42ab-8812-2e7e0a5b7db1)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # web27-boostcamp
 
+![banner3](https://github.com/user-attachments/assets/a1d7d818-8d00-42ab-8812-2e7e0a5b7db1)
+
+
 > **"광고가 정보가 되는 경험"**  
 > 개발자 기술 블로그의 **맥락(Context)** + **학습 의도(Intent)** 를 기반으로, 크리에이터가 **입찰(RTB)** 해 노출되는 투명한 광고·추천 플랫폼  
 > **Google Ads/Meta 같은 메인 광고 플랫폼을 대체하기보다**, 메인 채널이 놓치기 쉬운 **고의도·콘텐츠 맥락 구간**을 위한 *추가 채널*을 지향합니다.

--- a/backend/src/blog/blog.controller.ts
+++ b/backend/src/blog/blog.controller.ts
@@ -7,10 +7,9 @@ import {
   successResponse,
 } from 'src/common/response/success-response';
 import { BlogCacheRepository } from './repository/blog.cache.repository.interface';
-import { CachedBlog } from './types/blog.type';
-import { Public } from 'src/auth/decorators/public.decorator';
+// import { CachedBlog } from './types/blog.type';
+// import { Public } from 'src/auth/decorators/public.decorator';
 
-@Public()
 @Controller('blogs')
 export class BlogController {
   constructor(
@@ -63,83 +62,83 @@ export class BlogController {
   }
 
   // 테스트용 -- 테스트용 --
-  @Public()
-  @Post('test/cache/save')
-  async testSaveBlogCache(): Promise<
-    SuccessResponse<{ message: string; data: CachedBlog }>
-  > {
-    const mockBlog: CachedBlog = {
-      id: 999,
-      userId: 1,
-      domain: 'test-blog.tistory.com',
-      name: '테스트 블로그',
-      blogKey: 'test-blog-key-12345',
-      verified: true,
-      createdAt: new Date().toISOString(),
-    };
+  // @Public()
+  // @Post('test/cache/save')
+  // async testSaveBlogCache(): Promise<
+  //   SuccessResponse<{ message: string; data: CachedBlog }>
+  // > {
+  //   const mockBlog: CachedBlog = {
+  //     id: 999,
+  //     userId: 1,
+  //     domain: 'test-blog.tistory.com',
+  //     name: '테스트 블로그',
+  //     blogKey: 'test-blog-key-12345',
+  //     verified: true,
+  //     createdAt: new Date().toISOString(),
+  //   };
 
-    await this.blogCacheRepository.saveBlogCacheById(999, mockBlog);
+  //   await this.blogCacheRepository.saveBlogCacheById(999, mockBlog);
 
-    return successResponse(
-      { message: 'Redis 캐시 저장 완료', data: mockBlog },
-      'Redis JSON.SET 테스트 성공'
-    );
-  }
+  //   return successResponse(
+  //     { message: 'Redis 캐시 저장 완료', data: mockBlog },
+  //     'Redis JSON.SET 테스트 성공'
+  //   );
+  // }
 
-  @Public()
-  @Get('test/cache/find/:id')
-  async testFindBlogCache(
-    @Req() req: { params: { id: string } }
-  ): Promise<SuccessResponse<{ found: boolean; data: CachedBlog | null }>> {
-    const id = Number(req.params.id);
-    const cached = await this.blogCacheRepository.findBlogCacheById(id);
+  // @Public()
+  // @Get('test/cache/find/:id')
+  // async testFindBlogCache(
+  //   @Req() req: { params: { id: string } }
+  // ): Promise<SuccessResponse<{ found: boolean; data: CachedBlog | null }>> {
+  //   const id = Number(req.params.id);
+  //   const cached = await this.blogCacheRepository.findBlogCacheById(id);
 
-    return successResponse(
-      { found: !!cached, data: cached },
-      cached ? 'Redis 캐시 조회 성공' : '캐시 미스'
-    );
-  }
+  //   return successResponse(
+  //     { found: !!cached, data: cached },
+  //     cached ? 'Redis 캐시 조회 성공' : '캐시 미스'
+  //   );
+  // }
 
-  @Public()
-  @Get('test/cache/exists/:id')
-  async testExistsBlogCache(
-    @Req() req: { params: { id: string } }
-  ): Promise<SuccessResponse<{ exists: boolean }>> {
-    const id = Number(req.params.id);
-    const exists = await this.blogCacheRepository.existsBlogCacheById(id);
+  // @Public()
+  // @Get('test/cache/exists/:id')
+  // async testExistsBlogCache(
+  //   @Req() req: { params: { id: string } }
+  // ): Promise<SuccessResponse<{ exists: boolean }>> {
+  //   const id = Number(req.params.id);
+  //   const exists = await this.blogCacheRepository.existsBlogCacheById(id);
 
-    return successResponse({ exists }, 'Redis SISMEMBER 테스트 성공');
-  }
+  //   return successResponse({ exists }, 'Redis SISMEMBER 테스트 성공');
+  // }
 
-  @Public()
-  @Post('test/cache/update-embedding/:id')
-  async testUpdateEmbedding(
-    @Req() req: { params: { id: string } }
-  ): Promise<SuccessResponse<{ message: string }>> {
-    const id = Number(req.params.id);
-    const mockEmbedding = Array(384)
-      .fill(0)
-      .map(() => Math.random());
+  // @Public()
+  // @Post('test/cache/update-embedding/:id')
+  // async testUpdateEmbedding(
+  //   @Req() req: { params: { id: string } }
+  // ): Promise<SuccessResponse<{ message: string }>> {
+  //   const id = Number(req.params.id);
+  //   const mockEmbedding = Array(384)
+  //     .fill(0)
+  //     .map(() => Math.random());
 
-    await this.blogCacheRepository.updateBlogEmbeddingById(id, mockEmbedding);
+  //   await this.blogCacheRepository.updateBlogEmbeddingById(id, mockEmbedding);
 
-    return successResponse(
-      { message: `Blog ${id}의 임베딩 업데이트 완료 (384차원)` },
-      'Redis JSON.SET $.embedding 테스트 성공'
-    );
-  }
+  //   return successResponse(
+  //     { message: `Blog ${id}의 임베딩 업데이트 완료 (384차원)` },
+  //     'Redis JSON.SET $.embedding 테스트 성공'
+  //   );
+  // }
 
-  @Public()
-  @Post('test/cache/delete/:id')
-  async testDeleteBlogCache(
-    @Req() req: { params: { id: string } }
-  ): Promise<SuccessResponse<{ message: string }>> {
-    const id = Number(req.params.id);
-    await this.blogCacheRepository.deleteBlogCacheById(id);
+  // @Public()
+  // @Post('test/cache/delete/:id')
+  // async testDeleteBlogCache(
+  //   @Req() req: { params: { id: string } }
+  // ): Promise<SuccessResponse<{ message: string }>> {
+  //   const id = Number(req.params.id);
+  //   await this.blogCacheRepository.deleteBlogCacheById(id);
 
-    return successResponse(
-      { message: `Blog ${id} 캐시 삭제 완료` },
-      'Redis DEL + SREM 테스트 성공'
-    );
-  }
+  //   return successResponse(
+  //     { message: `Blog ${id} 캐시 삭제 완료` },
+  //     'Redis DEL + SREM 테스트 성공'
+  //   );
+  // }
 }

--- a/backend/src/blog/blog.service.ts
+++ b/backend/src/blog/blog.service.ts
@@ -129,6 +129,7 @@ export class BlogService {
       }
 
       // 3. Redis 캐시 저장 + exists set 추가
+      // TODO: 근데 verified 는 언제 쓰이는 거지??!?!
       await this.blogCacheRepository.saveBlogCacheById(
         createdBlog.id,
         this.convertToCachedBlogType(createdBlog)

--- a/backend/src/blog/repository/redis-blog.cache.repository.ts
+++ b/backend/src/blog/repository/redis-blog.cache.repository.ts
@@ -23,6 +23,7 @@ export class BlogRedisCacheRepository implements BlogCacheRepository {
     const key = this.getBlogKey(id);
     const expiryTime = ttl ?? this.DEFAULT_TTL;
 
+    // TODO: 블로그 삭제 로직 부재 따라서 없어진 블로그에 대해서 거르는 로직을 구현할 수가 없음
     try {
       // JSON.SET은 cacheManager가 지원 안 해서 redisClient 직접 사용
       await this.ioredisClient.call('JSON.SET', key, '$', JSON.stringify(data));

--- a/backend/src/campaign/campaign-cron.service.ts
+++ b/backend/src/campaign/campaign-cron.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { ConfigService } from '@nestjs/config';
 import { CampaignRepository } from './repository/campaign.repository.interface';
+import { CampaignCacheRepository } from './repository/campaign.cache.repository.interface';
 import { CampaignStatus } from './entities/campaign.entity';
 import { ImageService } from '../image/image.service';
 
@@ -12,6 +13,7 @@ export class CampaignCronService {
 
   constructor(
     private readonly campaignRepository: CampaignRepository,
+    private readonly campaignCacheRepository: CampaignCacheRepository,
     private readonly imageService: ImageService,
     private readonly configService: ConfigService
   ) {
@@ -55,12 +57,17 @@ export class CampaignCronService {
           now >= startDate &&
           now < endDate
         ) {
+          // DB 업데이트
           await this.campaignRepository.updateStatus(
             campaign.id,
             CampaignStatus.ACTIVE
           );
+          // Redis 동기화
+          await this.syncCacheStatus(campaign.id, CampaignStatus.ACTIVE);
           pendingToActive++;
-          this.logger.log(`캠페인 ${campaign.id} 상태 변경: PENDING -> ACTIVE`);
+          this.logger.log(
+            `캠페인 ${campaign.id} 상태 변경: PENDING -> ACTIVE (DB + Redis)`
+          );
         }
 
         // ACTIVE -> ENDED: 종료일이 지났을 때
@@ -69,8 +76,11 @@ export class CampaignCronService {
             campaign.id,
             CampaignStatus.ENDED
           );
+          await this.syncCacheStatus(campaign.id, CampaignStatus.ENDED);
           activeToEnded++;
-          this.logger.log(`캠페인 ${campaign.id} 상태 변경: ACTIVE -> ENDED`);
+          this.logger.log(
+            `캠페인 ${campaign.id} 상태 변경: ACTIVE -> ENDED (DB + Redis)`
+          );
         }
 
         // PAUSED -> ENDED: 종료일이 지났을 때
@@ -79,8 +89,11 @@ export class CampaignCronService {
             campaign.id,
             CampaignStatus.ENDED
           );
+          await this.syncCacheStatus(campaign.id, CampaignStatus.ENDED);
           pausedToEnded++;
-          this.logger.log(`캠페인 ${campaign.id} 상태 변경: PAUSED -> ENDED`);
+          this.logger.log(
+            `캠페인 ${campaign.id} 상태 변경: PAUSED -> ENDED (DB + Redis)`
+          );
         }
       }
 
@@ -109,16 +122,62 @@ export class CampaignCronService {
     await this.cleanupOrphanImages();
   }
 
-  // 일일 예산 리셋 (수동 실행 가능)
+  // 일일 예산 리셋 + Redis 동기화
   async resetDailyBudgets(): Promise<void> {
-    this.logger.log('일일 예산 리셋 시작');
+    this.logger.log('일일 예산 리셋 시작 (DB + Redis)');
 
     try {
+      // 1. DB 리셋
       await this.campaignRepository.resetAllDailySpent();
-      this.logger.log('모든 캠페인의 일일 예산이 리셋되었습니다');
+
+      // 2. Redis 동기화
+      const allCampaigns = await this.campaignRepository.getAll();
+      let syncCount = 0;
+
+      for (const campaign of allCampaigns) {
+        if (campaign.deletedAt) continue;
+
+        const cached = await this.campaignCacheRepository.findCampaignCacheById(
+          campaign.id
+        );
+
+        if (cached) {
+          cached.dailySpent = 0;
+          cached.lastResetDate = new Date().toISOString();
+          await this.campaignCacheRepository.saveCampaignCacheById(
+            campaign.id,
+            cached
+          );
+          syncCount++;
+        }
+      }
+
+      this.logger.log(`일일 예산 리셋 완료 (DB + Redis ${syncCount}건 동기화)`);
     } catch (error) {
       this.logger.error('일일 예산 리셋 중 오류 발생', error);
       throw error;
+    }
+  }
+
+  // Redis 캐시 상태 동기화 헬퍼
+  private async syncCacheStatus(
+    campaignId: string,
+    newStatus: CampaignStatus
+  ): Promise<void> {
+    try {
+      const cached =
+        await this.campaignCacheRepository.findCampaignCacheById(campaignId);
+
+      if (cached) {
+        cached.status = newStatus;
+        await this.campaignCacheRepository.saveCampaignCacheById(
+          campaignId,
+          cached
+        );
+      }
+    } catch (error) {
+      this.logger.warn(`캠페인 ${campaignId} Redis 상태 동기화 실패`, error);
+      // Redis 동기화 실패해도 Cron 전체가 실패하지 않도록
     }
   }
 

--- a/backend/src/campaign/campaign.service.ts
+++ b/backend/src/campaign/campaign.service.ts
@@ -175,6 +175,11 @@ export class CampaignService {
         this.convertToCachedCampaignType(campaign)
       );
 
+      await this.embeddingQueue.add('generate-campaign-embedding', {
+        campaignId: campaign.id,
+      });
+      this.logger.log(`캠페인 ${campaign.id} 임베딩 재생성 큐 추가`);
+
       return campaign;
     });
   }
@@ -209,6 +214,7 @@ export class CampaignService {
     campaignId: string,
     userId: number
   ): Promise<CampaignWithStats> {
+    // NOTICE : 이 부분은 RTB에 영향 없는 대쉬보드의 요청이기 때문에 바로 DB로 트랜젝션 굳이 수정할 필요 없을 거 같음
     const campaign = await this.campaignRepository.findOne(campaignId, userId);
 
     if (!campaign) {
@@ -312,6 +318,7 @@ export class CampaignService {
 
   // 캠페인 삭제 (소프트 삭제, 소유권 검증)
   async deleteCampaign(campaignId: string, userId: number): Promise<void> {
+    // TODO: 이부분도 Redis로 교체 필요
     const campaign = await this.campaignRepository.findOne(campaignId, userId);
 
     if (!campaign) {

--- a/backend/src/campaign/campaign.service.ts
+++ b/backend/src/campaign/campaign.service.ts
@@ -235,7 +235,7 @@ export class CampaignService {
     userId: number,
     dto: UpdateCampaignDto
   ): Promise<CampaignWithTags> {
-    // TODO: 여기서 Redis에서 조회하도록 수정 필요할듯
+    // TODO: (캐싱은 정상 동작) 여기서 Redis에서 조회하도록 수정 필요할듯
     const campaign = await this.campaignRepository.findOne(campaignId, userId);
 
     if (!campaign) {
@@ -283,7 +283,7 @@ export class CampaignService {
       );
 
       // 4. 태그 변경과 상관 없이 임베딩 재생성
-      // TODO: 하 근데 이거 dto.tags 변경 없을 시 임베딩 재적용 안 하도록 수정되어야 성능 개선의 의미가 있을 듯
+      // TODO: (임베딩은 정상 동작) 하 근데 이거 dto.tags 변경 없을 시 임베딩 재적용 안 하도록 수정되어야 성능 개선의 의미가 있을 듯
       await this.embeddingQueue.add('generate-campaign-embedding', {
         campaignId,
       });
@@ -318,7 +318,7 @@ export class CampaignService {
 
   // 캠페인 삭제 (소프트 삭제, 소유권 검증)
   async deleteCampaign(campaignId: string, userId: number): Promise<void> {
-    // TODO: 이부분도 Redis로 교체 필요
+    // TODO: (캐싱은 정상 동작) 이부분도 Redis로 교체 필요
     const campaign = await this.campaignRepository.findOne(campaignId, userId);
 
     if (!campaign) {

--- a/backend/src/campaign/campaign.service.ts
+++ b/backend/src/campaign/campaign.service.ts
@@ -246,7 +246,7 @@ export class CampaignService {
       newStatus = this.determineInitialStatus(dto.startDate);
     }
 
-    // TODO: 업데이트 시 DB 먼저 할지 고려 필요
+    // TODO: 업데이트 시 Redis먼저가 맞는 거 같음 -> 빨리 status를 Pending으로 변경해야함 -> redis-> db에서 업데이트 이후에 pending다시 해제
     const updatedCampaign = await this.campaignRepository.update(
       campaignId,
       dto,

--- a/backend/src/campaign/repository/campaign.cache.repository.interface.ts
+++ b/backend/src/campaign/repository/campaign.cache.repository.interface.ts
@@ -7,6 +7,10 @@ export abstract class CampaignCacheRepository {
     ttl?: number
   ): Promise<void>;
   abstract findCampaignCacheById(id: string): Promise<CachedCampaign | null>;
+
+  // 상태만 업데이트 (embeddingTags 보존)
+  abstract updateCampaignStatus(id: string, status: string): Promise<void>;
+
   abstract updateDailySpentCacheById(id: string, amount: number): Promise<void>;
 
   // 태그별 임베딩 업데이트

--- a/backend/src/campaign/repository/redis-campaign.cache.repository.ts
+++ b/backend/src/campaign/repository/redis-campaign.cache.repository.ts
@@ -47,6 +47,23 @@ export class RedisCampaignCacheRepository implements CampaignCacheRepository {
     }
   }
 
+  // 상태만 업데이트
+  async updateCampaignStatus(id: string, status: string): Promise<void> {
+    const key = this.getCampaignCacheKey(id);
+
+    try {
+      await this.ioredisClient.call(
+        'JSON.SET',
+        key,
+        '$.status',
+        JSON.stringify(status)
+      );
+    } catch (error) {
+      this.logger.error(`캠페인 상태 업데이트 실패: ${id}`, error);
+      throw error;
+    }
+  }
+
   async updateDailySpentCacheById(id: string, amount: number): Promise<void> {
     const key = this.getCampaignCacheKey(id);
 

--- a/backend/src/campaign/repository/typeorm-campaign.repository.ts
+++ b/backend/src/campaign/repository/typeorm-campaign.repository.ts
@@ -170,7 +170,8 @@ export class TypeOrmCampaignRepository extends CampaignRepository {
     if (dto.content !== undefined) campaign.content = dto.content;
     if (dto.image !== undefined) campaign.image = dto.image;
     if (dto.url !== undefined) campaign.url = dto.url;
-    if (dto.isHighIntent !== undefined) campaign.isHighIntent = dto.isHighIntent;
+    if (dto.isHighIntent !== undefined)
+      campaign.isHighIntent = dto.isHighIntent;
     if (dto.maxCpc !== undefined) campaign.maxCpc = dto.maxCpc;
     if (dto.dailyBudget !== undefined) campaign.dailyBudget = dto.dailyBudget;
     if (dto.totalBudget !== undefined) campaign.totalBudget = dto.totalBudget;

--- a/frontend/src/2_pages/auth/ui/RegisterPage.tsx
+++ b/frontend/src/2_pages/auth/ui/RegisterPage.tsx
@@ -10,7 +10,7 @@ export function RegisterPage() {
     <div className="relative flex min-h-screen w-full items-center justify-center bg-[#F6F6F8] overflow-hidden">
       {AUTH_BG === 'banners' ? <DiagonalBannersBackground /> : null}
       <div className="relative z-10">
-        <Modal height="h-[900px]">
+        <Modal height="h-[950px]">
           <div className="flex flex-col gap-3">
             <RegisterForm />
             <div className="flex items-center justify-center text-sm gap-1 ">

--- a/frontend/src/3_features/authorize/login/ui/LoginForm.tsx
+++ b/frontend/src/3_features/authorize/login/ui/LoginForm.tsx
@@ -28,17 +28,23 @@ export function LoginForm() {
 
       <FormDivider />
 
+      <div className="rounded-md text-center py-2 text-sm text-[#7A8699]">
+        로컬 로그인은 준비 중입니다. 현재는 Google 로그인만 가능합니다.
+      </div>
+
       <TextField
         name="email"
         type="email"
         label="이메일"
         placeholder="example@email.com"
+        disabled
       />
       <TextField
         name="password"
         type="password"
         label="비밀번호"
         placeholder="••••••••"
+        disabled
       />
       <button
         type="submit"

--- a/frontend/src/3_features/authorize/register/ui/RegisterForm.tsx
+++ b/frontend/src/3_features/authorize/register/ui/RegisterForm.tsx
@@ -37,23 +37,30 @@ export function RegisterForm() {
 
         <FormDivider />
 
+        <div className="rounded-md text-center py-2 text-sm text-[#7A8699]">
+          로컬 회원가입은 준비 중입니다. 현재는 Google로만 가입할 수 있어요.
+        </div>
+
         <TextField
           name="email"
           type="email"
           label="이메일"
           placeholder="exmaple@email.com"
+          disabled
         />
         <TextField
           name="password"
           type="password"
           label="비밀번호"
           placeholder="••••••••"
+          disabled
         />
         <TextField
           name="passwordConfirm"
           type="password"
           label="비밀번호 확인"
           placeholder="••••••••"
+          disabled
         />
       </div>
       <button

--- a/frontend/src/4_shared/ui/TextField/TextField.tsx
+++ b/frontend/src/4_shared/ui/TextField/TextField.tsx
@@ -7,6 +7,7 @@ type Props = InputHTMLAttributes<HTMLInputElement> & {
 
 export function TextField({ label, error, id, className, ...rest }: Props) {
   const inputId = id ?? rest.name;
+  const isDisabled = rest.disabled;
   return (
     <div className="flex flex-col gap-3">
       {label ? (
@@ -20,6 +21,10 @@ export function TextField({ label, error, id, className, ...rest }: Props) {
           error
             ? 'border-red-300 focus:ring-2 focus:ring-red-200'
             : 'border-gray-200 focus:ring-2 focus:ring-blue-200'
+        } ${
+          isDisabled
+            ? 'bg-gray-100 text-gray-400 placeholder:text-gray-300 cursor-not-allowed'
+            : ''
         } ${className ?? ''}`}
         {...rest}
       />


### PR DESCRIPTION
## 🔗 관련 이슈

- close: #238

---

## ✅ 작업 내용

**Create — DB First → Redis Write-Through**
- 캠페인 생성 시 DB 트랜잭션(캠페인 저장 + 크레딧 차감) 완료 후 Redis에 캐싱
- 생성 직후 BullMQ에 임베딩 큐 추가

**Update — Redis PAUSED 즉시 → DB 업데이트 → Redis 동기화 + 보상 트랜잭션**
- 수정 시작 시점에 Redis 상태를 PAUSED로 즉시 변경해 비딩 차단
- DB 업데이트 완료 후 Redis 전체 동기화
- `dailySpent` / `totalSpent` 는 RTB가 실시간으로 건드리는 필드이므로 수정에서 제외 (`CachedCampaignWithoutSpent` 타입으로 분리, 필드 단위 부분 업데이트)
- 태그 변경 시에만 조건부 임베딩 재생성 (`areTagsEqual` Set 기반 비교)
- DB 업데이트 실패 시 Redis 상태 원복 (보상 트랜잭션)

**Delete — Redis First → DB Soft Delete + 예산 환불**
- 삭제 즉시 Redis에서 먼저 제거해 비딩 차단
- DB soft delete 후 남은 예산(`totalBudget - totalSpent`) 환불 (pessimistic write lock)
- CreditHistory에 CHARGE 타입으로 감사 기록

---

## 💬 To Reviewers

CUD별로 전략이 다른 이유가 핵심입니다.

- **Create**: 크레딧 차감 트랜잭션 무결성이 최우선 → DB First
- **Update**: 수정 중 비딩 참여를 막는 게 최우선 → Redis PAUSED 먼저
- **Delete**: 삭제된 캠페인이 비딩에 참여하는 짧은 window를 없애는 게 최우선 → Redis First

Update에서 `dailySpent`/`totalSpent`를 건드리지 않는 이유:
RTB 비딩이 이 필드를 Lua Script로 실시간 수정하고 있어서, 전체 덮어쓰기를 하면 race condition이 발생합니다. 필드 단위 JSON.SET으로 나머지 필드만 업데이트합니다.