### PR TITLE
[Hotfix] 배포환경에서 SDK 콘솔로그 제거

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "vite build",
-    "dev": "vite build --watch",
+    "dev": "vite build --watch --mode development",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
   },

--- a/sdk/vite.config.ts
+++ b/sdk/vite.config.ts
@@ -2,50 +2,58 @@ import { defineConfig } from 'vite';
 import path from 'path';
 import { copyFileSync, mkdirSync, existsSync } from 'fs';
 
-export default defineConfig({
-  build: {
-    lib: {
-      entry: path.resolve(__dirname, 'src/index.ts'),
-      name: 'DevAd',
-      formats: ['iife'],
-      fileName: () => 'sdk.js',
-    },
-    outDir: 'dist',
-    minify: 'terser',
-    terserOptions: {
-      format: {
-        comments: false,
-      },
-    },
-    rollupOptions: {
-      output: {
-        inlineDynamicImports: true,
-      },
-    },
-  },
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
-      '@shared': path.resolve(__dirname, './src/shared'),
-    },
-  },
-  plugins: [
-    {
-      name: 'copy-to-backend',
-      closeBundle() {
-        // 개발 환경에서만 backend/public으로 복사
-        const src = path.resolve(__dirname, 'dist/sdk.js');
-        const destDir = path.resolve(__dirname, '../backend/public');
-        const dest = path.resolve(destDir, 'sdk.js');
+export default defineConfig(({ mode }) => {
+  const isProduction = mode === 'production';
 
-        // public 디렉토리 생성 (없으면)
-        if (!existsSync(destDir)) {
-          mkdirSync(destDir, { recursive: true });
-        }
-
-        copyFileSync(src, dest);
-        console.log('✅ SDK copied to backend/public/sdk.js');
+  return {
+    build: {
+      lib: {
+        entry: path.resolve(__dirname, 'src/index.ts'),
+        name: 'DevAd',
+        formats: ['iife'],
+        fileName: () => 'sdk.js',
+      },
+      outDir: 'dist',
+      minify: 'terser',
+      terserOptions: {
+        compress: {
+          drop_console: isProduction,
+          drop_debugger: isProduction,
+        },
+        format: {
+          comments: false,
+        },
+      },
+      rollupOptions: {
+        output: {
+          inlineDynamicImports: true,
+        },
       },
     },
-  ],
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+        '@shared': path.resolve(__dirname, './src/shared'),
+      },
+    },
+    plugins: [
+      {
+        name: 'copy-to-backend',
+        closeBundle() {
+          // 개발 환경에서만 backend/public으로 복사
+          const src = path.resolve(__dirname, 'dist/sdk.js');
+          const destDir = path.resolve(__dirname, '../backend/public');
+          const dest = path.resolve(destDir, 'sdk.js');
+
+          // public 디렉토리 생성 (없으면)
+          if (!existsSync(destDir)) {
+            mkdirSync(destDir, { recursive: true });
+          }
+
+          copyFileSync(src, dest);
+          console.log('✅ SDK copied to backend/public/sdk.js');
+        },
+      },
+    ],
+  };
 });


### PR DESCRIPTION
## 🔗 관련 이슈

- close: #

---

## ✅ 작업 내용

- `sdk/vite.config.ts`: production 빌드 시 콘솔 로그 제거(`drop_console`, `drop_debugger`) 옵션 적용.
- `sdk/package.json`: dev 빌드를 development 모드로 고정해 로컬 로그 유지.
### 1) 배포 빌드에서 console 제거
- `sdk/vite.config.ts`
  - `mode === 'production'`일 때 `terser`의 `drop_console/drop_debugger` 활성화.
  - production/dev 모드 분기 추가.
### 2) 로컬 개발 로그 유지
- `sdk/package.json`
  - `dev` 스크립트를 `vite build --watch --mode development`로 변경.

## 📸 스크린샷 / 데모 (옵션)

---

## 🧪 테스트 방법 (옵션)

1. `cd sdk && npm run build`

---

## 💬 To Reviewers

- 배포 빌드(`npm run build`)에서는 SDK 콘솔이 제거되고, 로컬 개발(`npm run dev`)에서는 유지됩니다.
