### PR TITLE
[Feat] 광고주 키워드 통계 목록 조회 API 백엔드 (+프론트)

### DIFF
--- a/backend/src/advertiser/advertiser.controller.ts
+++ b/backend/src/advertiser/advertiser.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Get, Post, Req, Body, Query } from '@nestjs/common';
 import { AdvertiserService } from './advertiser.service';
 import { successResponse } from 'src/common/response/success-response';
 import { type AuthenticatedRequest } from 'src/types/authenticated-request';
+import { KeywordStatsRequestDto } from './dto/keyword-stats-request.dto';
 import { ChargeCreditDto, GetCreditHistoryDto } from './dto/credit.dto';
 
 @Controller('advertiser')
@@ -52,5 +53,24 @@ export class AdvertiserController {
     );
 
     return successResponse(result, '크레딧 사용 내역 조회 성공');
+  }
+
+  // 테스트 필요
+  @Get('keywords/stats')
+  async getKeywordStats(
+    @Req() req: AuthenticatedRequest,
+    @Query() query: KeywordStatsRequestDto
+  ) {
+    const userId = req.user.userId;
+    const { limit, offset, sortBy, order } = query;
+
+    const result = await this.advertiserService.getKeywordStats(
+      userId,
+      limit,
+      offset,
+      sortBy,
+      order
+    );
+    return successResponse(result, '키워드 성과 통계 목록입니다.');
   }
 }

--- a/backend/src/advertiser/advertiser.controller.ts
+++ b/backend/src/advertiser/advertiser.controller.ts
@@ -62,8 +62,8 @@ export class AdvertiserController {
     @Req() req: AuthenticatedRequest,
     @Query() query: KeywordStatsRequestDto
   ) {
-    const userId = 1;
-    // const userId = req.user.userId;
+    // const userId = 1;
+    const userId = req.user.userId;
     const { limit, offset, sortBy, order } = query;
 
     const result = await this.advertiserService.getKeywordStats(

--- a/backend/src/advertiser/advertiser.controller.ts
+++ b/backend/src/advertiser/advertiser.controller.ts
@@ -4,6 +4,7 @@ import { successResponse } from 'src/common/response/success-response';
 import { type AuthenticatedRequest } from 'src/types/authenticated-request';
 import { KeywordStatsRequestDto } from './dto/keyword-stats-request.dto';
 import { ChargeCreditDto, GetCreditHistoryDto } from './dto/credit.dto';
+// import { Public } from 'src/auth/decorators/public.decorator';
 
 @Controller('advertiser')
 export class AdvertiserController {
@@ -61,7 +62,8 @@ export class AdvertiserController {
     @Req() req: AuthenticatedRequest,
     @Query() query: KeywordStatsRequestDto
   ) {
-    const userId = req.user.userId;
+    const userId = 1;
+    // const userId = req.user.userId;
     const { limit, offset, sortBy, order } = query;
 
     const result = await this.advertiserService.getKeywordStats(

--- a/backend/src/advertiser/dto/keyword-stats-request.dto.ts
+++ b/backend/src/advertiser/dto/keyword-stats-request.dto.ts
@@ -1,0 +1,25 @@
+import { IsOptional, IsIn, IsInt, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class KeywordStatsRequestDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  offset?: number = 0;
+
+  @IsOptional()
+  @IsIn(['avgCtr', 'totalImpressions', 'totalClicks'])
+  sortBy?: 'avgCtr' | 'totalImpressions' | 'totalClicks' = 'avgCtr';
+
+  @IsOptional()
+  @IsIn(['asc', 'desc'])
+  order?: 'asc' | 'desc' = 'desc';
+}

--- a/backend/src/advertiser/dto/keyword-stats-response.dto.ts
+++ b/backend/src/advertiser/dto/keyword-stats-response.dto.ts
@@ -1,0 +1,15 @@
+// 키워드별 통계 아이템
+export interface KeywordStatItem {
+  id: number;
+  name: string;
+  totalImpressions: number;
+  totalClicks: number;
+  avgCtr: number;
+}
+
+// 키워드 통계 응답
+export interface KeywordStatsResponse {
+  total: number;
+  hasMore: boolean;
+  keywords: KeywordStatItem[];
+}

--- a/backend/src/sdk/sdk.service.ts
+++ b/backend/src/sdk/sdk.service.ts
@@ -78,7 +78,6 @@ export class SdkService {
 
   async recordClick(dto: CreateClickLogDto): Promise<number | null> {
     const { viewId } = dto;
-    // todo: 어뷰징 방지
 
     const isDup = await this.cacheRepository.setClickIdempotencyKey(viewId);
 

--- a/frontend/src/3_features/campaignDetail/ui/BudgetStatusCard/BudgetEditMode.tsx
+++ b/frontend/src/3_features/campaignDetail/ui/BudgetStatusCard/BudgetEditMode.tsx
@@ -68,7 +68,11 @@ export function BudgetEditMode({
 
           {/* 추가 예산 입력 */}
           <div className="bg-white">
-            <CurrencyField value={addBudget} onChange={setAddBudget} prefix="+" />
+            <CurrencyField
+              value={addBudget}
+              onChange={setAddBudget}
+              prefix="+"
+            />
           </div>
 
           {/* 퀵버튼 */}
@@ -133,11 +137,6 @@ export function BudgetEditMode({
           </button>
         </div>
       </div>
-
-      {/* 안내 문구 */}
-      <span className="text-xs font-bold text-slate-400 uppercase w-full text-right">
-        일일 예산, CPC값은 다음 날부터 적용됩니다.
-      </span>
     </div>
   );
 }

--- a/frontend/src/3_features/keywordStats/ui/KeywordStatsCard.tsx
+++ b/frontend/src/3_features/keywordStats/ui/KeywordStatsCard.tsx
@@ -1,152 +1,18 @@
 import { useState, useRef, useCallback } from 'react';
-import type { KeywordStats, SortBy } from '../lib/types';
-// import { useKeywordStats } from '../lib/useKeywordStats';
+import type { SortBy } from '../lib/types';
+import { useKeywordStats } from '../lib/useKeywordStats';
 import { KeywordStatsHeader } from './KeywordStatsHeader';
 import { KeywordStatsItem } from './KeywordStatsItem';
 
-// Mock 데이터 (API 연동 시 삭제)
-const allMockKeywords: KeywordStats[] = [
-  {
-    id: 1,
-    name: 'Python',
-    totalImpressions: 521,
-    totalClicks: 98,
-    avgCtr: 18.5,
-  },
-  {
-    id: 2,
-    name: 'Django',
-    totalImpressions: 411,
-    totalClicks: 60,
-    avgCtr: 14.6,
-  },
-  {
-    id: 3,
-    name: 'React',
-    totalImpressions: 380,
-    totalClicks: 45,
-    avgCtr: 11.8,
-  },
-  { id: 4, name: 'AWS', totalImpressions: 320, totalClicks: 21, avgCtr: 6.5 },
-  {
-    id: 5,
-    name: 'Node.js',
-    totalImpressions: 290,
-    totalClicks: 35,
-    avgCtr: 12.1,
-  },
-  {
-    id: 6,
-    name: 'TypeScript',
-    totalImpressions: 250,
-    totalClicks: 18,
-    avgCtr: 7.2,
-  },
-  {
-    id: 7,
-    name: 'JavaScript',
-    totalImpressions: 480,
-    totalClicks: 72,
-    avgCtr: 15.0,
-  },
-  { id: 8, name: 'Go', totalImpressions: 200, totalClicks: 28, avgCtr: 14.0 },
-  { id: 9, name: 'Rust', totalImpressions: 150, totalClicks: 12, avgCtr: 8.0 },
-  {
-    id: 10,
-    name: 'Java',
-    totalImpressions: 350,
-    totalClicks: 42,
-    avgCtr: 12.0,
-  },
-  {
-    id: 11,
-    name: 'Kotlin',
-    totalImpressions: 180,
-    totalClicks: 15,
-    avgCtr: 8.3,
-  },
-  {
-    id: 12,
-    name: 'Swift',
-    totalImpressions: 220,
-    totalClicks: 30,
-    avgCtr: 13.6,
-  },
-  {
-    id: 13,
-    name: 'Flutter',
-    totalImpressions: 170,
-    totalClicks: 14,
-    avgCtr: 8.2,
-  },
-  {
-    id: 14,
-    name: 'Docker',
-    totalImpressions: 300,
-    totalClicks: 38,
-    avgCtr: 12.7,
-  },
-  {
-    id: 15,
-    name: 'Kubernetes',
-    totalImpressions: 140,
-    totalClicks: 10,
-    avgCtr: 7.1,
-  },
-  {
-    id: 16,
-    name: 'GraphQL',
-    totalImpressions: 160,
-    totalClicks: 13,
-    avgCtr: 8.1,
-  },
-  {
-    id: 17,
-    name: 'MongoDB',
-    totalImpressions: 190,
-    totalClicks: 22,
-    avgCtr: 11.6,
-  },
-  {
-    id: 18,
-    name: 'PostgreSQL',
-    totalImpressions: 210,
-    totalClicks: 25,
-    avgCtr: 11.9,
-  },
-];
-
-const LIMIT = 4;
-
-// Mock: 정렬 후 페이지네이션을 위한 코드 (API 연동 시 삭제)
-function getMockKeywords(sortBy: SortBy, offset: number, limit: number) {
-  const sorted = [...allMockKeywords].sort((a, b) => b[sortBy] - a[sortBy]);
-  return sorted.slice(offset, offset + limit);
-}
-
 export function KeywordStatsCard() {
   const [sortBy, setSortBy] = useState<SortBy>('avgCtr');
-  const [keywords, setKeywords] = useState<KeywordStats[]>(() =>
-    getMockKeywords('avgCtr', 0, LIMIT)
-  );
-  const [isLoading, setIsLoading] = useState(false);
-  const [isLoadingMore, setIsLoadingMore] = useState(false);
-  const [hasMore, setHasMore] = useState(true);
   const scrollRef = useRef<HTMLDivElement>(null);
 
-  // TODO: API 연동 시 useKeywordStats 사용할 것!
-  // const { keywords, isLoading, isLoadingMore, error, hasMore, loadMore } = useKeywordStats({ sortBy });
+  const { keywords, isLoading, isLoadingMore, error, hasMore, loadMore } =
+    useKeywordStats({ sortBy });
 
   const handleSortChange = useCallback((newSortBy: SortBy) => {
     setSortBy(newSortBy);
-    setIsLoading(true);
-
-    // Mock: 정렬 변경을  위한 코드 (API 연동 시 삭제)
-    setTimeout(() => {
-      setKeywords(getMockKeywords(newSortBy, 0, LIMIT));
-      setHasMore(allMockKeywords.length > LIMIT);
-      setIsLoading(false);
-    }, 300);
   }, []);
 
   const handleScroll = useCallback(() => {
@@ -156,31 +22,24 @@ export function KeywordStatsCard() {
     const isNearBottom = scrollTop + clientHeight >= scrollHeight - 10;
 
     if (isNearBottom) {
-      setIsLoadingMore(true);
-
-      // Mock: 추가 로딩을 위한 코드 (API 연동 시 삭제)
-      setTimeout(() => {
-        const currentLength = keywords.length;
-        const newKeywords = getMockKeywords(sortBy, currentLength, LIMIT);
-
-        if (newKeywords.length > 0) {
-          setKeywords((prev) => [...prev, ...newKeywords]);
-          setHasMore(
-            currentLength + newKeywords.length < allMockKeywords.length
-          );
-        } else {
-          setHasMore(false);
-        }
-        setIsLoadingMore(false);
-      }, 500);
+      loadMore();
     }
-  }, [isLoadingMore, hasMore, keywords.length, sortBy]);
+  }, [isLoadingMore, hasMore, loadMore]);
 
   if (isLoading) {
     return (
       <div className="text-gray-600 flex flex-col bg-white border border-gray-200 rounded-xl shadow">
         <KeywordStatsHeader sortBy={sortBy} onSortChange={handleSortChange} />
         <div className="p-10 text-center text-gray-500">로딩 중...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="text-gray-600 flex flex-col bg-white border border-gray-200 rounded-xl shadow">
+        <KeywordStatsHeader sortBy={sortBy} onSortChange={handleSortChange} />
+        <div className="p-10 text-center text-red-500">{error}</div>
       </div>
     );
   }


### PR DESCRIPTION
해당 PR은 Jerry(2se2)의 프론트 작업 내용을 rebase받아서 테스트하고 올려졌습니다.

- #247 

## 🔗 관련 이슈

- close: #245 

---

## ✅ 작업 내용

### 0) 전체 개요

**목표**: 광고주가 등록한 캠페인의 키워드(Tag)별 성과 통계를 조회하는 API 구현

**변경 규모**:

- 2개 파일 신규 생성 (DTO)
- 2개 파일 수정 (Service, Controller)

**핵심 변경사항**:

- `GET /api/advertiser/keywords/stats` 엔드포인트 추가
- 태그별 노출수/클릭수/CTR 집계 로직 구현
- 정렬 및 페이지네이션 지원

---

## 📋 변경사항 상세

### 1) DTO 생성

**신규 파일**:

- `src/advertiser/dto/keyword-stats-query.dto.ts`
- `src/advertiser/dto/keyword-stats-response.dto.ts`

#### 1-1. 요청 쿼리 파라미터 DTO

```typescript
// keyword-stats-query.dto.ts
export class KeywordStatsQueryDto {
  limit?: number = 20; // 1~100
  offset?: number = 0;
  sortBy?: 'avgCtr' | 'totalImpressions' | 'totalClicks' = 'avgCtr';
  order?: 'asc' | 'desc' = 'desc';
}
```

#### 1-2. 응답 타입 DTO

```typescript
// keyword-stats-response.dto.ts
export interface KeywordStatItem {
  id: number;
  name: string;
  totalImpressions: number;
  totalClicks: number;
  avgCtr: number;
}

export interface KeywordStatsResponse {
  total: number;
  hasMore: boolean;
  keywords: KeywordStatItem[];
}
```

---

### 2) Service 로직 구현

**수정 파일**: `src/advertiser/advertiser.service.ts`

**구현 내용**:

```typescript
// advertiser.service.ts
async getKeywordStats(
  userId: number,
  limit: number = 20,
  offset: number = 0,
  sortBy: 'avgCtr' | 'totalImpressions' | 'totalClicks' = 'avgCtr',
  order: 'asc' | 'desc' = 'desc'
) {
  // 1. userId로 캠페인 목록 조회 (tags relation 포함)
  const campaigns = await this.campaignRepository.listByUserId(userId);

  // 2. 캠페인별 ViewLog, ClickLog 집계 (기존 Repository 메서드 활용)
  const viewCounts = await this.campaignRepository.getViewCountsByCampaignIds(campaignIds);
  const clickCounts = await this.campaignRepository.getClickCountsByCampaignIds(campaignIds);

  // 3. Tag별로 노출/클릭 합산
  // 같은 태그가 여러 캠페인에 있으면 합산됨

  // 4. avgCtr 계산 (clicks / impressions * 100)

  // 5. 정렬 (sortBy, order 적용)

  // 6. 페이지네이션 (limit, offset 적용)

  return { total, hasMore, keywords };
}
```

**데이터 흐름**:

```
Campaign (userId) → CampaignTag → Tag
                 ↓
         ViewLog (노출수)
         ClickLog (클릭수)
                 ↓
      Tag별 집계 → 정렬 → 페이지네이션
```

---

### 3) Controller 엔드포인트 추가

**수정 파일**: `src/advertiser/advertiser.controller.ts`

**구현 내용**:

```typescript
// advertiser.controller.ts
@Get('keywords/stats')
async getKeywordStats(
  @Req() req: AuthenticatedRequest,
  @Query() query: KeywordStatsQueryDto
) {
  const userId = req.user.userId;
  const { limit, offset, sortBy, order } = query;

  const result = await this.advertiserService.getKeywordStats(
    userId, limit, offset, sortBy, order
  );
  return successResponse(result, '키워드 성과 통계 목록입니다.');
}
```

---

## 📊 API 명세

### Request

| Key    | 설명                | 타입   | 필수 | 기본값 | 예시                                  |
| ------ | ------------------- | ------ | ---- | ------ | ------------------------------------- |
| limit  | 조회 개수           | number | X    | 20     | 1~100                                 |
| offset | 페이지네이션 오프셋 | number | X    | 0      | 0, 20, 40...                          |
| sortBy | 정렬 기준           | string | X    | avgCtr | avgCtr, totalImpressions, totalClicks |
| order  | 정렬 순서           | string | X    | desc   | asc, desc                             |

### Response

```json
{
  "status": "success",
  "message": "키워드 성과 통계 목록입니다.",
  "data": {
    "total": 47,
    "hasMore": true,
    "keywords": [
      {
        "id": 1,
        "name": "Python",
        "totalImpressions": 521,
        "totalClicks": 98,
        "avgCtr": 18.5
      },
      {
        "id": 2,
        "name": "Django",
        "totalImpressions": 411,
        "totalClicks": 60,
        "avgCtr": 14.6
      }
    ]
  },
  "timestamp": "2026-01-29T23:20:00.000Z"
}
```

---

## 🧪 테스트 방법

### 빌드 테스트

```bash
npm run build
# Exit code: 0 ✅
```
https://github.com/user-attachments/assets/032304b8-4fbb-458a-b4d8-d7226d15485e

### API 테스트

```bash
# 대시보드 진입 시 (기본 CTR 내림차순)
GET /api/advertiser/keywords/stats?limit=6&offset=0

# 전체보기 클릭 시
GET /api/advertiser/keywords/stats?limit=50&offset=0

# 노출수 기준 내림차순 정렬
GET /api/advertiser/keywords/stats?limit=20&offset=0&sortBy=totalImpressions&order=desc
```

---

## 💬 To Reviewers

### 주요 확인사항

1. **기존 Repository 메서드 재활용**: `CampaignRepository.getViewCountsByCampaignIds`, `getClickCountsByCampaignIds` 활용
2. **Tag 전용 Repository 없음**: CampaignRepository의 tags relation으로 조회
3. **페이지네이션**: `typeorm-bid-log.repository.ts` 패턴 참고

### 설계 결정

- **Tag 조회 방식**: Tag 전용 Repository를 만들지 않고 `CampaignRepository.listByUserId`에서 tags relation으로 함께 조회
  - 이유: 어차피 캠페인 데이터가 필요하고, 추가 쿼리 없이 한 번에 조회 가능

### 비고

로그 데이터는 잘 불러오는게 중요하고 이걸 불러오는 속도는 중요하지 않다고 판단을 해서 적절한 쿼리로 불러오도록 구성했습니다.

---