### PR TITLE
[Refactor] 캠페인 폼 수정

### DIFF
--- a/frontend/src/4_shared/ui/CampaignForm/ui/CampaignForm.tsx
+++ b/frontend/src/4_shared/ui/CampaignForm/ui/CampaignForm.tsx
@@ -24,16 +24,25 @@ export function CampaignForm({
   const { currentStep, setStep, formData, balance, mode, initialTotalBudget } =
     useCampaignFormStore();
 
+  const isEditMode = mode === 'edit';
+
   const isNextDisabled = () => {
     if (isSubmitting) return true;
     if (currentStep === 1) {
-      return !isStep1Valid(formData.campaignContent);
+      const isContentValid = isStep1Valid(formData.campaignContent);
+      if (isEditMode) {
+        const { startDate, endDate } = formData.budgetSettings;
+        const isDateValid =
+          startDate !== '' && endDate !== '' && endDate >= startDate;
+        return !isContentValid || !isDateValid;
+      }
+      return !isContentValid;
     }
     if (currentStep === 2) {
       return !isStep2Valid({
         ...formData.budgetSettings,
         balance,
-        isEditMode: mode === 'edit',
+        isEditMode,
         initialTotalBudget: initialTotalBudget ?? undefined,
       });
     }
@@ -44,13 +53,13 @@ export function CampaignForm({
     if (currentStep === 2) {
       setStep(1);
     } else if (currentStep === 3) {
-      setStep(2);
+      setStep(isEditMode ? 1 : 2);
     }
   };
 
   const handleNext = () => {
     if (currentStep === 1) {
-      setStep(2);
+      setStep(isEditMode ? 3 : 2);
     } else if (currentStep === 2) {
       setStep(3);
     } else if (currentStep === 3 && onSubmit) {

--- a/frontend/src/4_shared/ui/CampaignForm/ui/ConfirmCard.tsx
+++ b/frontend/src/4_shared/ui/CampaignForm/ui/ConfirmCard.tsx
@@ -3,7 +3,7 @@ import { Icon } from '@shared/ui/Icon';
 
 interface ConfirmCardProps {
   title: string;
-  onEdit: () => void;
+  onEdit?: () => void;
   children: ReactNode;
 }
 
@@ -12,14 +12,16 @@ export function ConfirmCard({ title, onEdit, children }: ConfirmCardProps) {
     <div className="flex flex-col gap-4 border-b border-gray-200 pb-5">
       <div className="flex items-center justify-between">
         <h3 className="text-base font-bold text-gray-900">{title}</h3>
-        <button
-          type="button"
-          onClick={onEdit}
-          className="flex cursor-pointer items-center gap-1 text-sm text-blue-500"
-        >
-          <Icon.Pen className="h-4 w-4" />
-          <span>수정</span>
-        </button>
+        {onEdit && (
+          <button
+            type="button"
+            onClick={onEdit}
+            className="flex cursor-pointer items-center gap-1 text-sm text-blue-500"
+          >
+            <Icon.Pen className="h-4 w-4" />
+            <span>수정</span>
+          </button>
+        )}
       </div>
       {children}
     </div>

--- a/frontend/src/4_shared/ui/CampaignForm/ui/DateField.tsx
+++ b/frontend/src/4_shared/ui/CampaignForm/ui/DateField.tsx
@@ -8,6 +8,7 @@ interface DateFieldProps {
   hint?: string;
   error?: string;
   min?: string;
+  disabled?: boolean;
 }
 
 export function DateField({
@@ -18,6 +19,7 @@ export function DateField({
   hint,
   error,
   min,
+  disabled = false,
 }: DateFieldProps) {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     onChange(e.target.value);
@@ -41,6 +43,7 @@ export function DateField({
         onChange={handleChange}
         onBlur={handleBlur}
         min={minDate}
+        disabled={disabled}
         className={`h-11 rounded-lg border px-3 outline-none focus:ring-2 [&::-webkit-calendar-picker-indicator]:cursor-pointer ${
           value
             ? 'text-gray-900'
@@ -49,6 +52,10 @@ export function DateField({
           error
             ? 'border-red-300 focus:ring-red-200'
             : 'border-gray-200 focus:ring-blue-200'
+        } ${
+          disabled
+            ? 'bg-gray-100 cursor-not-allowed opacity-60'
+            : ''
         }`}
       />
 

--- a/frontend/src/4_shared/ui/CampaignForm/ui/Step3Content.tsx
+++ b/frontend/src/4_shared/ui/CampaignForm/ui/Step3Content.tsx
@@ -60,6 +60,8 @@ export function Step3Content() {
     setStep(2);
   };
 
+  const isEditMode = mode === 'edit';
+
   const headerTitle = mode === 'edit' ? '캠페인 수정 확인' : '광고 캠페인 확인';
   const headerDescription = mode === 'edit'
     ? '수정된 내용을 확인하고 저장하세요'
@@ -112,7 +114,10 @@ export function Step3Content() {
       </ConfirmCard>
 
       {/* 예산 및 기간 */}
-      <ConfirmCard title="예산 및 기간" onEdit={handleEditBudget}>
+      <ConfirmCard
+        title="예산 및 기간"
+        onEdit={isEditMode ? undefined : handleEditBudget}
+      >
         <div className="flex flex-col gap-4">
           <div className="grid grid-cols-2 gap-4">
             {budgetGridItems.map((item) => (
@@ -136,6 +141,11 @@ export function Step3Content() {
               />
             ))}
           </div>
+          {isEditMode && (
+            <p className="text-xs text-gray-500 bg-gray-50 p-3 rounded-lg">
+              💡 예산 수정은 캠페인 상세 페이지의 예산 수정 버튼을 이용해주세요.
+            </p>
+          )}
         </div>
       </ConfirmCard>
 

--- a/frontend/src/4_shared/ui/CampaignForm/ui/StepIndicator.tsx
+++ b/frontend/src/4_shared/ui/CampaignForm/ui/StepIndicator.tsx
@@ -10,13 +10,25 @@ interface StepIndicatorProps {
 
 export function StepIndicator({
   currentStep,
-  totalSteps = 3,
+  totalSteps: totalStepsProp = 3,
   mode = 'create',
   onBack,
 }: StepIndicatorProps) {
-  const progressPercentage = (currentStep / totalSteps) * 100;
+  const isEditMode = mode === 'edit';
+  const totalSteps = isEditMode ? 2 : totalStepsProp;
+
+  // 수정 모드에서는 step 1 → step 3으로 가도록 step 계산
+  const displayStep = isEditMode && currentStep === 3 ? 2 : currentStep;
+  const progressPercentage = (displayStep / totalSteps) * 100;
 
   const getStepTitle = (step: FormStep) => {
+    if (isEditMode) {
+      const editTitles: Record<number, string> = {
+        1: '광고 내용 및 기간',
+        3: '확인',
+      };
+      return editTitles[step] || '';
+    }
     const titles = {
       1: '광고 내용',
       2: '예산 설정',
@@ -39,7 +51,7 @@ export function StepIndicator({
               <Icon.ArrowLeft className="w-5 h-5 text-gray-600" />
             </button>
             <span className="text-sm font-medium text-gray-900">
-              STEP {currentStep} OF {totalSteps}
+              STEP {displayStep} OF {totalSteps}
               <span className="pl-2 text-gray-500">
                 {getStepTitle(currentStep)}
               </span>
@@ -47,7 +59,7 @@ export function StepIndicator({
           </div>
         ) : (
           <span className="text-sm font-medium text-gray-900">
-            STEP {currentStep} OF {totalSteps}
+            STEP {displayStep} OF {totalSteps}
             <span className="pl-2 text-gray-500">
               {getStepTitle(currentStep)}
             </span>


### PR DESCRIPTION
## 🔗 관련 이슈
- close: #

---

## ✅ 작업 내용

캠페인 수정 모달의 플로우를 개선하고, 수정 모드에서 예산 설정 단계를 제거했습니다.

### 1️⃣ 캠페인 수정 플로우를 3단계에서 2단계로 변경

**기존 구조 (3단계)**
- Step 1: 광고 내용
- Step 2: 예산 설정
- Step 3: 확인

**개선된 구조 (2단계)**
- Step 1: 광고 내용 및 기간
- Step 2: 확인

**주요 변경사항**
- 수정 모드에서 Step 2 (예산 설정) 단계 제거
- Step 1 → Step 3 (확인)으로 바로 이동
- StepIndicator에서 수정 모드일 때 `totalSteps=2`로 표시
- 내비게이션 로직 개선: 뒤로가기 시 `Step 3 → Step 1` 이동

### 2️⃣ 기간 설정을 Step 1으로 이동

**Step1Content 개선**
- 수정 모드에서만 "기간 설정" 영역이 Step 1에 표시
- 시작일/종료일 입력 필드 추가
- DateField 컴포넌트에 `disabled` prop 추가하여 비활성화 지원

**캠페인 상태별 제약사항**
- **이미 시작된 캠페인**: 시작일 수정 불가 (disabled), 종료일만 수정 가능
- **종료된 캠페인**: 기간 수정 전체 불가, 안내 문구 표시
- **예정된 캠페인**: 시작일/종료일 모두 수정 가능

**Validation 추가**
- Step 1에서 기간 필드 유효성 검사 추가
- 시작일 > 종료일 체크
- 빈 값 체크

### 3️⃣ Step 3 예산 카드 수정 버튼 제거 및 안내 추가

**ConfirmCard 컴포넌트 개선**
- `onEdit` prop을 optional로 변경
- `onEdit`이 없으면 "수정" 버튼 미표시

**Step3Content 개선**
- 수정 모드에서 "예산 및 기간" 카드의 수정 버튼 제거
- 예산 수정은 캠페인 상세 페이지에서만 가능하도록 안내 문구 추가
  ```
  💡 예산 수정은 캠페인 상세 페이지의 예산 수정 버튼을 이용해주세요.
  ```

### 4️⃣ DateField 컴포넌트 기능 추가

**disabled 상태 지원**
- `disabled` prop 추가
- disabled 상태일 때 회색 배경, 커서 변경, 투명도 조정
- 이미 시작된 캠페인의 시작일 필드에 적용

---

## 📸 스크린샷 / 데모

**수정 모달 - Step 1 (광고 내용 및 기간)**
- 광고 내용 수정 + 기간 설정이 한 화면에
- 이미 시작된 캠페인은 시작일 수정 불가

**수정 모달 - Step 2 (확인)**
- Step 2 (예산 설정) 건너뛰고 바로 확인 화면
- 예산 카드에 수정 버튼 없음, 안내 문구 추가
- STEP 2 OF 2로 표시

**종료된 캠페인**
- 기간 수정 불가 안내 문구 표시

![화면 기록 2026-01-30 오전 7 35 35](https://github.com/user-attachments/assets/56cf5a96-7950-4dbe-a11c-97f7cf061cde)


---

## 🧪 테스트 방법

### 2. 진행 중인 캠페인 (시작됨)
1. 진행 중 캠페인의 수정 버튼 클릭
2. Step 1에서 시작일 필드가 disabled 상태인지 확인
3. 종료일만 수정 가능한지 확인
4. 시작일보다 이른 종료일 입력 시 에러 표시되는지 확인

### 4. Step 3 확인 화면
1. 수정 모달에서 Step 3 확인 화면 진입
2. "예산 및 기간" 카드에 수정 버튼이 없는지 확인
3. 예산 수정 안내 문구가 표시되는지 확인
4. "뒤로" 버튼 클릭 시 Step 1로 이동하는지 확인

---

## 💬 To Reviewers
