### PR TITLE
[Hotfix] 키워드목록 제거권장 기준 CTR 3으로 수정

### DIFF
--- a/frontend/src/3_features/keywordStats/lib/constants.ts
+++ b/frontend/src/3_features/keywordStats/lib/constants.ts
@@ -1,1 +1,1 @@
-export const LOW_CTR_THRESHOLD = 10;
+export const LOW_CTR_THRESHOLD = 3;


### PR DESCRIPTION
<!-- PR 제목 예시 : [Feat] 로그인 기능 구현 -->
<!-- PR 제목은 위 형식을 참고하여 작성해주세요. -->
<!-- 필요 없는 내용은 지우고 작성해주세요 -->

## 🔗 관련 이슈

- close: #

---

## ✅ 작업 내용

### 키워드 통계 목록의 제거권장 태그가 달리는 기준인 CTR값을 10->3으로 수정

## 📸 스크린샷 / 데모 (옵션)

<!-- UI 변경사항이나 새로운 기능의 동작을 시각적으로 보여주세요. -->

---

## 🧪 테스트 방법 (옵션)

<!-- 리뷰어가 기능을 테스트할 수 있도록 구체적인 테스트 방법을 설명해주세요. -->

1.
2.

---

## 💬 To Reviewers

<!-- 리뷰어에게 전달하고 싶은 내용이나 특별히 확인이 필요한 부분을 작성해주세요. -->
