### PR TITLE
[Refactor/Perf] 누락된 Redis 캐싱 마이그레이션(update/delete/matcher) 및 환불 로직 추가

### DIFF
--- a/backend/src/campaign/campaign.service.ts
+++ b/backend/src/campaign/campaign.service.ts
@@ -410,7 +410,6 @@ export class CampaignService {
       );
 
       // 4. 태그 변경과 상관 없이 임베딩 재생성
-      // TODO: (임베딩은 정상 동작) dto.tags 변경 없을 시 임베딩 재적용 안 하도록 수정되면 성능 개선의 의미가 존재할 듯 -> 전용 메서드 만들어야되어서 추후 적용 고려
       if (
         dto.tags &&
         cachedCampaign.tags &&

--- a/backend/src/campaign/campaign.service.ts
+++ b/backend/src/campaign/campaign.service.ts
@@ -409,6 +409,22 @@ export class CampaignService {
         }
       );
 
+      // 4. 태그 변경과 상관 없이 임베딩 재생성
+      // TODO: (임베딩은 정상 동작) dto.tags 변경 없을 시 임베딩 재적용 안 하도록 수정되면 성능 개선의 의미가 존재할 듯 -> 전용 메서드 만들어야되어서 추후 적용 고려
+      if (
+        dto.tags &&
+        cachedCampaign.tags &&
+        !this.areTagsEqual(dto.tags, cachedCampaign.tags)
+      ) {
+        await this.campaignCacheRepository.deleteCampaignEmbeddingById(
+          campaignId
+        );
+        await this.embeddingQueue.add('generate-campaign-embedding', {
+          campaignId,
+        });
+        this.logger.log(`캠페인 ${campaignId} 임베딩 재생성 큐 추가`);
+      }
+
       // 3. Redis 전체 동기화 (DB 결과 반영, 요청한 상태로 복원)
       await this.campaignCacheRepository.updateCampaignCacheWithoutSpentById(
         updatedCampaign.id,
@@ -417,19 +433,6 @@ export class CampaignService {
       this.logger.log(
         `캠페인 ${campaignId} Redis 최종 동기화 완료 (상태: ${updatedCampaign.status})`
       );
-
-      // 4. 태그 변경과 상관 없이 임베딩 재생성
-      // TODO: (임베딩은 정상 동작) dto.tags 변경 없을 시 임베딩 재적용 안 하도록 수정되면 성능 개선의 의미가 존재할 듯 -> 전용 메서드 만들어야되어서 추후 적용 고려
-      if (
-        dto.tags &&
-        cachedCampaign.tags &&
-        !this.areTagsEqual(dto.tags, cachedCampaign.tags)
-      ) {
-        await this.embeddingQueue.add('generate-campaign-embedding', {
-          campaignId,
-        });
-        this.logger.log(`캠페인 ${campaignId} 임베딩 재생성 큐 추가`);
-      }
 
       return updatedCampaign;
     } catch (error) {

--- a/backend/src/campaign/campaign.service.ts
+++ b/backend/src/campaign/campaign.service.ts
@@ -440,15 +440,9 @@ export class CampaignService {
         ? dto.status === 'ACTIVE'
           ? CampaignStatus.ACTIVE
           : CampaignStatus.PAUSED
-        : cachedCampaign.status; // A/B campaign
+        : (cachedCampaign.status as CampaignStatus); // A/B campaign
 
-      await this.campaignCacheRepository.updateCampaignStatus(
-        campaignId,
-        restoreStatus
-      );
-      this.logger.log(
-        `캠페인 ${campaignId} Redis 상태 복원 → ${restoreStatus}`
-      );
+      await this.updateCampaignStatus(campaignId, restoreStatus);
 
       throw error;
     }

--- a/backend/src/campaign/repository/campaign.cache.repository.interface.ts
+++ b/backend/src/campaign/repository/campaign.cache.repository.interface.ts
@@ -1,4 +1,7 @@
-import { CachedCampaign } from '../types/campaign.types';
+import {
+  CachedCampaign,
+  CachedCampaignWithoutSpent,
+} from '../types/campaign.types';
 
 export abstract class CampaignCacheRepository {
   abstract saveCampaignCacheById(
@@ -6,6 +9,12 @@ export abstract class CampaignCacheRepository {
     data: CachedCampaign,
     ttl?: number
   ): Promise<void>;
+
+  abstract updateCampaignCacheWithoutSpentById(
+    id: string,
+    data: CachedCampaignWithoutSpent
+  ): Promise<void>;
+
   abstract findCampaignCacheById(id: string): Promise<CachedCampaign | null>;
 
   // 상태만 업데이트 (embeddingTags 보존)

--- a/backend/src/campaign/repository/campaign.cache.repository.interface.ts
+++ b/backend/src/campaign/repository/campaign.cache.repository.interface.ts
@@ -22,6 +22,9 @@ export abstract class CampaignCacheRepository {
 
   abstract updateDailySpentCacheById(id: string, amount: number): Promise<void>;
 
+  // 태그 변경 시 임베딩 비우기
+  abstract deleteCampaignEmbeddingById(id: string): Promise<void>;
+
   // 태그별 임베딩 업데이트
   abstract updateCampaignEmbeddingTags(
     id: string,

--- a/backend/src/campaign/repository/redis-campaign.cache.repository.ts
+++ b/backend/src/campaign/repository/redis-campaign.cache.repository.ts
@@ -91,6 +91,22 @@ export class RedisCampaignCacheRepository implements CampaignCacheRepository {
     }
   }
 
+  // 태그 변경 시 임베딩 비우기
+  async deleteCampaignEmbeddingById(id: string): Promise<void> {
+    const key = this.getCampaignCacheKey(id);
+    try {
+      await this.ioredisClient.call(
+        'JSON.SET',
+        key,
+        '$.embeddingTags',
+        JSON.stringify({})
+      );
+    } catch (error) {
+      this.logger.error(`임베딩 삭제 실패: ${id}`, error);
+      throw error;
+    }
+  }
+
   async updateDailySpentCacheById(id: string, amount: number): Promise<void> {
     const key = this.getCampaignCacheKey(id);
 

--- a/backend/src/campaign/types/campaign.types.ts
+++ b/backend/src/campaign/types/campaign.types.ts
@@ -57,7 +57,7 @@ export type CachedCampaign = {
   totalSpent: number;
   lastResetDate: string;
   isHighIntent: boolean;
-  status: string;
+  status: CampaignStatus;
   startDate: string;
   endDate: string;
   createdAt: string;

--- a/backend/src/campaign/types/campaign.types.ts
+++ b/backend/src/campaign/types/campaign.types.ts
@@ -69,3 +69,8 @@ export type CachedCampaign = {
   // 태그별 임베딩 (Worker가 추가)
   embeddingTags?: { [tagName: string]: number[] };
 };
+
+export type CachedCampaignWithoutSpent = Omit<
+  CachedCampaign,
+  'dailySpent' | 'totalSpent'
+>;

--- a/backend/src/rtb/matchers/xenova.matcher.backup
+++ b/backend/src/rtb/matchers/xenova.matcher.backup
@@ -240,20 +240,7 @@ export class TransformerMatcher extends Matcher {
       }
 
       try {
-        // Redis에 이미 캐싱된 임베딩을 우선 사용 (Worker가 생성)
-        let tagEmbedding: number[];
-
-        if (campaign.embeddingTags && campaign.embeddingTags[tagName]) {
-          // Redis에 이미 임베딩이 있으면 바로 사용
-          tagEmbedding = campaign.embeddingTags[tagName];
-        } else {
-          // 없으면 새로 생성 (fallback)
-          tagEmbedding = await this.getEmbeddingCached(tagName);
-          this.logger.debug(
-            `Redis 캐시 미스 - 태그 임베딩 새로 생성: "${tagName}" (campaign=${campaign.id})`
-          );
-        }
-
+        const tagEmbedding = await this.getEmbeddingCached(tagName);
         sims.push(
           this.mlEngine.calculateSimilarity(requestEmbedding, tagEmbedding)
         );

--- a/backend/src/rtb/rtb.controller.ts
+++ b/backend/src/rtb/rtb.controller.ts
@@ -30,7 +30,6 @@ export class RTBController {
     @Res({ passthrough: true }) res: Response
   ) {
     const visitorId = req.visitorId;
-    // console.log(`현재 방문자의 visitorId:${visitorId}`); // todo: 제거
 
     if (!visitorId) {
       res.cookie('visitor_id', randomUUID(), {
@@ -40,7 +39,6 @@ export class RTBController {
         maxAge: 1000 * 60 * 60 * 24 * 365, // 1년
         path: '/',
       });
-      // console.log(`visitorId가 생성되었습니다: ${visitorId}`); // todo: 제거
     }
 
     const context: DecisionContext = {


### PR DESCRIPTION
## **🔗 관련 이슈**

### 대표 이슈

- close: #261

### 연관 이슈

- close: #263  (Campaign Service Redis 캐싱 전환)
- close: #264  (Xenova Matcher 임베딩 캐시 최적화)

---

## **📋 개요**

RTB 시스템의 실시간성 향상을 위해 Campaign Service의 DB 조회 로직을 Redis 캐싱으로 전환하고, Xenova Matcher에서 기존 캐싱된 임베딩을 활용하도록 최적화.

> 광고 로딩 시, 로딩 성능이 상딩히 개선이 되었습니다.

**아키텍처 변경:**

- Before: `CampaignService → CampaignRepository (DB) → Response`
- After: `CampaignService → CampaignCacheRepository (Redis) → Response (DB는 Write-Through)`

**주요 목표:**

- RTB 비딩 응답 속도 향상 (Redis First 전략)
- 데이터 정합성 유지 (보상 트랜잭션)
- 캠페인 삭제 시 예산 환불 로직 추가
- 임베딩 캐시 활용으로 ML 모델 호출 최소화

---

## **✅ 작업 내용**

### **1) Campaign Service - Redis First 전략 적용**

**변경 파일:**

- `campaign.service.ts`
- `campaign.cache.repository.interface.ts`
- `redis-campaign.cache.repository.ts`
- `campaign.types.ts`

**변경 배경:**

- 기존: 모든 캠페인 조회를 DB에서 직접 수행
- 문제점:
  - RTB 요청 시 DB 조회 지연
  - 동시성 이슈로 spent 값 불일치 가능
- 해결: Redis에서 캐싱된 캠페인 정보 우선 조회

**구현 내용:**

**updateCampaign 메서드 리팩토링:**

```typescript
// Before: DB에서 캠페인 조회
const campaign = await this.campaignRepository.findOne(campaignId, userId);

// After: Redis에서 캠페인 조회
const cachedCampaign =
  await this.campaignCacheRepository.findCampaignCacheById(campaignId);
```

**Redis 상태 먼저 PAUSED로 변경 (비딩 즉시 중단):**

```typescript
// 1. Redis 상태만 PAUSED로 빠르게 변경
await this.updateCampaignStatus(campaignId, CampaignStatus.PAUSED);

// 2. 검증 로직 수행
if (!cachedCampaign) throw new NotFoundException(...);
if (cachedCampaign.userId !== userId) throw new ForbiddenException(...);

// 3. DB 업데이트 (트랜잭션)
// 4. Redis 동기화 (Write-Through)
// 5. 실패 시 Redis 상태 복원 (보상 트랜잭션)
```

---

### **2) CachedCampaignWithoutSpent 타입 추가**

**변경 배경:**

- 동시성 이슈가 있을 수 있는 `dailySpent`, `totalSpent` 필드는 제외하고 업데이트
- TypeScript의 `Omit` 유틸리티 타입 활용

**구현 내용:**

```typescript
export type CachedCampaignWithoutSpent = Omit<
  CachedCampaign,
  'dailySpent' | 'totalSpent'
>;
```

**Redis에서 Spent 제외 필드만 업데이트:**

```typescript
async updateCampaignCacheWithoutSpentById(
  id: string,
  data: CachedCampaignWithoutSpent
): Promise<void> {
  const key = this.getCampaignCacheKey(id);

  // data에 포함된 필드만 개별 업데이트 (dailySpent, totalSpent는 건드리지 않음)
  const updatePromises = Object.entries(data).map(([field, value]) =>
    this.ioredisClient.call('JSON.SET', key, `$.${field}`, JSON.stringify(value))
  );

  await Promise.all(updatePromises);
}
```

---

### **3) 캠페인 삭제 시 남은 예산 환불 로직**

**변경 배경:**

- 캠페인 삭제 시 사용하지 않은 예산을 사용자에게 환불해야 함
- 트랜잭션으로 DB 삭제와 환불을 원자적으로 처리

**구현 내용:**

```typescript
async deleteCampaign(campaignId: string, userId: number): Promise<void> {
  // Redis 먼저 삭제 (RTB 비딩 중단)
  await this.campaignCacheRepository.deleteCampaignCacheById(campaignId);

  // 트랜잭션으로 DB 삭제 + 예산 환불 처리
  await this.dataSource.transaction(async (manager) => {
    await this.campaignRepository.delete(campaignId);

    if (cachedCampaign.totalBudget !== null) {
      const remainingBudget = cachedCampaign.totalBudget - cachedCampaign.totalSpent;

      if (remainingBudget > 0) {
        // 잔액 환불
        user.balance = user.balance + remainingBudget;
        await userRepo.save(user);

        // 크레딧 히스토리 기록 (CHARGE 타입)
        await historyRepo.save({
          type: CreditHistoryType.CHARGE,
          amount: remainingBudget,
          description: `'${cachedCampaign.title}' 캠페인 삭제 - 남은 예산 환불`,
        });
      }
    }
  });
}
```

---

### **4) 태그 변경 시만 임베딩 재생성**

**변경 배경:**

- 기존: 캠페인 수정 시 항상 임베딩 재생성
- 문제점: 불필요한 ML 모델 호출로 성능 저하
- 해결: 태그 변경 여부 체크 후 필요한 경우에만 재생성

**구현 내용:**

```typescript
// 태그 변경 여부 체크
if (dto.tags && cachedCampaign.tags && !this.areTagsEqual(dto.tags, cachedCampaign.tags)) {
  await this.campaignCacheRepository.deleteCampaignEmbeddingById(campaignId);
  await this.embeddingQueue.add('generate-campaign-embedding', { campaignId });
}

private areTagsEqual(dtoTags: string[], redisTags: string[]): boolean {
  if (dtoTags.length !== redisTags.length) return false;
  const dtoSet = new Set(dtoTags);
  return redisTags.every((tag) => dtoSet.has(tag));
}
```

---

### **5) Xenova Matcher - Redis 캐싱 임베딩 활용**

**변경 파일:**

- `xenova.matcher.ts`

**변경 배경:**

- 기존: 매번 태그 임베딩을 새로 생성
- 문제점: ML 모델 호출 비용이 높음
- 해결: Redis에 이미 캐싱된 `embeddingTags` 우선 사용

**구현 내용:**

```typescript
// Before: 매번 새로 임베딩 생성
const tagEmbedding = await this.getEmbeddingCached(tagName);

// After: Redis 캐시 우선 사용
let tagEmbedding: number[];

if (campaign.embeddingTags && campaign.embeddingTags[tagName]) {
  // Redis에 이미 임베딩이 있으면 바로 사용
  tagEmbedding = campaign.embeddingTags[tagName];
} else {
  // 없으면 새로 생성 (fallback)
  tagEmbedding = await this.getEmbeddingCached(tagName);
  this.logger.debug(`Redis 캐시 미스 - 태그 임베딩 새로 생성: "${tagName}"`);
}
```

---

## **📁 변경 파일 목록**

| 파일                                     | 변경 내용                                                                 |
| ---------------------------------------- | ------------------------------------------------------------------------- |
| `campaign.service.ts`                    | Redis First 전략, 환불 로직, 태그 비교 로직 추가                          |
| `campaign.cache.repository.interface.ts` | `updateCampaignCacheWithoutSpentById`, `deleteCampaignEmbeddingById` 추가 |
| `redis-campaign.cache.repository.ts`     | 위 인터페이스 구현                                                        |
| `campaign.types.ts`                      | `CachedCampaignWithoutSpent` 타입 추가, `status` 타입 강화                |
| `xenova.matcher.ts`                      | Redis 캐싱 임베딩 활용 로직 추가                                          |

---

## **🧪 테스트 방법**

### **빌드 테스트**

```bash
npm run build
# Exit code: 0
```

### **기능 테스트**

1. 캠페인 수정 시 Redis 상태 즉시 PAUSED 확인
2. DB 업데이트 후 Redis 동기화 확인
3. 캠페인 삭제 시 환불 금액 및 CreditHistory 기록 확인
4. 태그 변경 없을 시 임베딩 재생성 스킵 확인

---

## **💬 To Reviewers**

### **주요 확인사항**

1. **Redis First 전략 일관성**: 모든 조회가 Redis 우선으로 변경됨
2. **보상 트랜잭션**: DB 실패 시 Redis 상태 복원 로직
3. **데이터 정합성**: Spent 필드 분리 저장으로 동시성 이슈 방지
4. **성능 개선**: 불필요한 임베딩 재생성 방지

### **아키텍처 개선 효과**

- **RTB 응답 속도**: Redis 조회로 대폭 개선
- **데이터 안정성**: Write-Through + 보상 트랜잭션
- **ML 리소스 절약**: 임베딩 캐시 재활용

### **향후 개선 사항**

- **실시간 지출 vs 확정 지출**: 대시보드에서 Redis/DB 값 구분 표시
- **자정 Cron 보정**: ViewLog 기반 정합성 검증

---

## 💌 비고 – 문제·해결

### Problem 1: Spent 동시성 이슈

- **문제**: `dailySpent`, `totalSpent`를 함께 업데이트하면 RTB 과정의 값과 충돌 가능
- **해결**: `CachedCampaignWithoutSpent` 타입으로 Spent 제외 필드만 업데이트

### Problem 2: 타입 불일치

- **문제**: `dto.endDate` (Date) vs `cachedCampaign.startDate` (string) 비교 시 타입 에러
- **해결**: 양쪽 모두 Date 객체로 변환하여 비교

### Problem 3: 태그 배열 비교

- **문제**: `dto.tags` (string[])와 `cachedCampaign.tags` (string[]) 순서 무관 비교 필요
- **해결**: Set을 활용한 `areTagsEqual` 헬퍼 함수 구현

### Problem 4: 임베딩 불필요한 재생성

- **문제**: 태그 변경 없어도 매번 임베딩 재생성
- **해결**: 태그 비교 후 변경된 경우에만 임베딩 큐 추가