### PR TITLE
[Feat] RTB 비딩 지출(Spent) 흐름 구현 (Phase 1,2,3,5) 

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -32,6 +32,7 @@
         "ioredis": "^5.9.2",
         "jose": "^6.1.3",
         "mysql2": "^3.16.0",
+        "p-limit": "^7.2.0",
         "redis": "^4.7.1",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
@@ -242,6 +243,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -742,7 +744,6 @@
       "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.3.3.tgz",
       "integrity": "sha512-JsXDL70gQ+1Vc2W/KUFfkAJzgb4puKwwKehNLuB+HrNKWf91O736kGfxn4KujXCCSuh6mRRL4XEB0PkAFjWS0A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "hashery": "^1.3.0",
         "keyv": "^5.5.5"
@@ -2122,8 +2123,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
       "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
@@ -2316,6 +2316,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.9.tgz",
       "integrity": "sha512-zDntUTReRbAThIfSp3dQZ9kKqI+LjgLp5YZN5c1bgNRDuoeLySAoZg46Bg1a+uV8TMgIRziHocglKGNzr6l+bQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "21.1.0",
         "iterare": "1.2.1",
@@ -2363,6 +2364,7 @@
       "integrity": "sha512-a00B0BM4X+9z+t3UxJqIZlemIwCQdYoPKrMcM+ky4z3pkqqG1eTWexjs+YXpGObnLnjtMPVKWlcZHp3adDYvUw==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -2416,6 +2418,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.12.tgz",
       "integrity": "sha512-GYK/vHI0SGz5m8mxr7v3Urx8b9t78Cf/dj5aJMZlGd9/1D9OI1hAl00BaphjEXINUJ/BQLxIlF2zUjrYsd6enQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cors": "2.8.5",
         "express": "5.2.1",
@@ -2941,6 +2944,7 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -2970,6 +2974,7 @@
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -3084,6 +3089,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.3.tgz",
       "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3222,6 +3228,7 @@
       "integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.49.0",
         "@typescript-eslint/types": "8.49.0",
@@ -3917,6 +3924,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3966,6 +3974,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4581,6 +4590,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4653,6 +4663,7 @@
       "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-5.67.1.tgz",
       "integrity": "sha512-ELJEAzwzesgFxk29emvnAakqrwdBEhEyfZREPQ8pbG4ALVz/mk/AhfuChzxkFpJ7SfL2qclPHbiUGBZzaqcLvg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cron-parser": "4.9.0",
         "ioredis": "5.9.2",
@@ -4869,6 +4880,7 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -4922,13 +4934,15 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/class-validator": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.3.tgz",
       "integrity": "sha512-rXXekcjofVN1LTOSw+u4u9WXVEUvNBVjORW154q/IdmYWy1nMbOU9aNtZB0t8m+FJQ9q91jlr2f9CwwUFdFMRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -5722,6 +5736,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5782,6 +5797,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -6787,7 +6803,6 @@
       "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.4.0.tgz",
       "integrity": "sha512-Wn2i1In6XFxl8Az55kkgnFRiAlIAushzh26PTjL2AKtQcEfXrcLa7Hn5QOWGZEf3LU057P9TwwZjFyxfS1VuvQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "hookified": "^1.14.0"
       },
@@ -7300,6 +7315,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -7336,6 +7352,35 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/jest-changed-files/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/jest-circus": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.2.0.tgz",
@@ -7366,6 +7411,35 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-circus/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/jest-cli": {
@@ -7776,6 +7850,22 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/jest-runner/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/jest-runner/node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -7795,6 +7885,19 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/jest-runtime": {
@@ -9001,6 +9104,37 @@
       }
     },
     "node_modules/p-limit": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.2.0.tgz",
+      "integrity": "sha512-ATHLtwoTNDloHRFFxFJdHnG6n2WUeFjaR8XQMFdKIv0xkXjrER8/iG9iu265jOM95zXHAfv9oTkqhrfbIzosrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
@@ -9016,15 +9150,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+    "node_modules/p-locate/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
       "engines": {
         "node": ">=10"
       },
@@ -9368,6 +9499,7 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9670,6 +9802,7 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
       "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2",
         "generic-pool": "3.9.0",
@@ -10625,6 +10758,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10975,6 +11109,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -11147,6 +11282,7 @@
       "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.28.tgz",
       "integrity": "sha512-6GH7wXhtfq2D33ZuRXYwIsl/qM5685WZcODZb7noOOcRMteM9KF2x2ap3H0EBjnSV0VO4gNAfJT5Ukp0PkOlvg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^4.2.0",
@@ -11352,6 +11488,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11651,6 +11788,7 @@
       "integrity": "sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -11720,6 +11858,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -12027,13 +12166,12 @@
       }
     },
     "node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/backend/package.json
+++ b/backend/package.json
@@ -43,6 +43,7 @@
     "ioredis": "^5.9.2",
     "jose": "^6.1.3",
     "mysql2": "^3.16.0",
+    "p-limit": "^7.2.0",
     "redis": "^4.7.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -75,6 +75,8 @@ export class OAuthService {
     private readonly userService: UserService
   ) {}
 
+  private readonly OAUTH_STATE_CACHE_TTL = 15 * 60;
+
   async getGoogleAuthUrl(intent: AuthIntent, role?: UserRole): Promise<string> {
     const { GOOGLE_CLIENT_ID: clientId, GOOGLE_REDIRECT_URI: redirectUri } =
       process.env;
@@ -102,7 +104,7 @@ export class OAuthService {
       await this.cacheRepository.setOAuthState(
         state,
         stateData,
-        15 * 60 * 1000
+        this.OAUTH_STATE_CACHE_TTL
       );
     } else {
       const stateData: StoredOAuthState = {
@@ -113,7 +115,7 @@ export class OAuthService {
       await this.cacheRepository.setOAuthState(
         state,
         stateData,
-        15 * 60 * 1000
+        this.OAUTH_STATE_CACHE_TTL
       );
     }
 

--- a/backend/src/cache/cache.module.ts
+++ b/backend/src/cache/cache.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { LogModule } from 'src/log/log.module';
 import { RedisModule } from 'src/redis/redis.module';
 import { CacheRepository } from './repository/cache.repository.interface';
@@ -7,7 +7,7 @@ import { RedisTTLWorker } from './redis-ttl.worker';
 import { CampaignModule } from 'src/campaign/campaign.module';
 
 @Module({
-  imports: [LogModule, RedisModule, CampaignModule],
+  imports: [LogModule, RedisModule, forwardRef(() => CampaignModule)],
   controllers: [],
   providers: [
     { provide: CacheRepository, useClass: RedisCacheRepository },

--- a/backend/src/cache/cache.module.ts
+++ b/backend/src/cache/cache.module.ts
@@ -3,11 +3,16 @@ import { LogModule } from 'src/log/log.module';
 import { RedisModule } from 'src/redis/redis.module';
 import { CacheRepository } from './repository/cache.repository.interface';
 import { RedisCacheRepository } from './repository/redis-cache.repository';
+import { RedisTTLWorker } from './redis-ttl.worker';
+import { CampaignModule } from 'src/campaign/campaign.module';
 
 @Module({
-  imports: [LogModule, RedisModule],
+  imports: [LogModule, RedisModule, CampaignModule],
   controllers: [],
-  providers: [{ provide: CacheRepository, useClass: RedisCacheRepository }],
+  providers: [
+    { provide: CacheRepository, useClass: RedisCacheRepository },
+    RedisTTLWorker,
+  ],
   exports: [CacheRepository],
 })
 export class CacheModule {}

--- a/backend/src/cache/redis-ttl.worker.ts
+++ b/backend/src/cache/redis-ttl.worker.ts
@@ -52,6 +52,7 @@ export class RedisTTLWorker implements OnModuleInit, OnModuleDestroy {
       await this.subscriber.unsubscribe('__keyevent@0__:expired');
       this.subscriber.disconnect();
       this.logger.log('TTL Worker 종료 - Keyspace Notification 구독 해제');
+      // TODO: 이 부분이 무작정 해제되도 Redis >= DB의 단방향 불일치는 유지되는가?
     }
   }
 

--- a/backend/src/cache/redis-ttl.worker.ts
+++ b/backend/src/cache/redis-ttl.worker.ts
@@ -1,0 +1,92 @@
+import {
+  Injectable,
+  Logger,
+  OnModuleInit,
+  OnModuleDestroy,
+} from '@nestjs/common';
+import { Inject } from '@nestjs/common';
+import Redis from 'ioredis';
+import { IOREDIS_CLIENT } from 'src/redis/redis.constant';
+import type { AppIORedisClient } from 'src/redis/redis.type';
+import { CacheRepository } from './repository/cache.repository.interface';
+import { CampaignCacheRepository } from 'src/campaign/repository/campaign.cache.repository.interface';
+
+// TTL 만료 이벤트를 감지하여 롤백을 수행하는 Worker
+@Injectable()
+export class RedisTTLWorker implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(RedisTTLWorker.name);
+  private subscriber: Redis | null = null;
+
+  constructor(
+    @Inject(IOREDIS_CLIENT) private readonly redis: AppIORedisClient,
+    private readonly cacheRepository: CacheRepository,
+    private readonly campaignCacheRepository: CampaignCacheRepository
+  ) {}
+
+  async onModuleInit() {
+    try {
+      // Keyspace Notification 활성화
+      await this.redis.config('SET', 'notify-keyspace-events', 'Ex');
+      this.logger.log(
+        'Redis Keyspace Notification 설정 완료: notify-keyspace-events Ex'
+      );
+
+      // 별도 subscriber 연결 (pub/sub용)
+      this.subscriber = this.redis.duplicate();
+      await this.subscriber.subscribe('__keyevent@0__:expired');
+
+      this.subscriber.on('message', (channel, expiredKey) => {
+        // async 핸들러를 void로 래핑 (lint 에러 방지)
+        void this.handleExpiredKey(expiredKey);
+      });
+
+      this.logger.log('TTL Worker 시작 - Keyspace Notification 구독 중');
+    } catch (error) {
+      this.logger.error('TTL Worker 초기화 실패', error);
+      // 초기화 실패해도 앱 구동은 계속 (graceful degradation)
+    }
+  }
+
+  async onModuleDestroy() {
+    if (this.subscriber) {
+      await this.subscriber.unsubscribe('__keyevent@0__:expired');
+      this.subscriber.disconnect();
+      this.logger.log('TTL Worker 종료 - Keyspace Notification 구독 해제');
+    }
+  }
+
+  // TTL 만료된 키 처리
+  private async handleExpiredKey(expiredKey: string): Promise<void> {
+    // rollback:view:{viewId} 형태인지 확인
+    const match = expiredKey.match(/^rollback:view:(\d+)$/);
+    if (!match) return;
+
+    const viewId = parseInt(match[1], 10);
+
+    try {
+      // 백업 정보 조회
+      const backup = await this.cacheRepository.getRollbackBackup(viewId);
+      if (!backup) {
+        this.logger.debug(
+          `[TTL Worker] viewId=${viewId}: 백업 없음 (이미 처리됨 - 클릭 또는 Dismiss)`
+        );
+        return;
+      }
+
+      const { campaignId, cost, createdAt } = backup;
+      const elapsedMs = Date.now() - new Date(createdAt).getTime();
+
+      // 롤백 수행
+      await this.campaignCacheRepository.decrementSpent(campaignId, cost);
+
+      // 백업 삭제
+      await this.cacheRepository.deleteRollbackBackup(viewId);
+
+      this.logger.warn(
+        `[TTL Worker] 롤백 완료: viewId=${viewId}, campaign=${campaignId}, cost=-${cost}, elapsed=${Math.floor(elapsedMs / 1000)}s (Beacon 미수신으로 TTL 만료)`
+      );
+    } catch (error) {
+      this.logger.error(`[TTL Worker] 롤백 실패: viewId=${viewId}`, error);
+    }
+  }
+}

--- a/backend/src/cache/repository/cache.repository.interface.ts
+++ b/backend/src/cache/repository/cache.repository.interface.ts
@@ -1,6 +1,12 @@
 import { AuctionData } from '../types/auction-data.type';
 import { StoredOAuthState } from '../../auth/auth.service';
 
+export interface RollbackInfo {
+  campaignId: string;
+  cost: number;
+  createdAt: string;
+}
+
 export abstract class CacheRepository {
   // Auction 관련 메서드
   abstract setAuctionData(
@@ -49,4 +55,15 @@ export abstract class CacheRepository {
     viewId: number,
     ttlMs?: number
   ): Promise<boolean>;
+
+  // Rollback 정보 관련 메서드
+  abstract setRollbackInfo(
+    viewId: number,
+    rollbackInfo: RollbackInfo,
+    ttl?: number
+  ): Promise<void>;
+
+  abstract getRollbackInfo(viewId: number): Promise<RollbackInfo | null>;
+
+  abstract deleteRollbackInfo(viewId: number): Promise<void>;
 }

--- a/backend/src/cache/repository/cache.repository.interface.ts
+++ b/backend/src/cache/repository/cache.repository.interface.ts
@@ -66,4 +66,14 @@ export abstract class CacheRepository {
   abstract getRollbackInfo(viewId: number): Promise<RollbackInfo | null>;
 
   abstract deleteRollbackInfo(viewId: number): Promise<void>;
+
+  // Rollback 백업 관련 메서드 (TTL 없음 - Worker용)
+  abstract setRollbackBackup(
+    viewId: number,
+    rollbackInfo: RollbackInfo
+  ): Promise<void>;
+
+  abstract getRollbackBackup(viewId: number): Promise<RollbackInfo | null>;
+
+  abstract deleteRollbackBackup(viewId: number): Promise<void>;
 }

--- a/backend/src/cache/repository/redis-cache.repository.ts
+++ b/backend/src/cache/repository/redis-cache.repository.ts
@@ -16,6 +16,8 @@ export class RedisCacheRepository extends CacheRepository {
 
   private readonly AUCTION_CACHE_TTL = 15 * 60;
   private readonly ROLLBACK_CACHE_TTL = 5 * 60;
+  private readonly VIEW_IDEMPOTENCY_TTL_MS = 30 * 60 * 1000; // 30분 (밀리초 단위)
+  private readonly CLICK_IDEMPOTENCY_TTL_MS = 30 * 60 * 1000; // 30분 (밀리초 단위)
 
   // Auction 관련 메서드
   async setAuctionData(
@@ -68,7 +70,7 @@ export class RedisCacheRepository extends CacheRepository {
     visitorId: string,
     isHighIntent: boolean,
     viewId: number,
-    ttlMs: number = 60 * 30 * 1000
+    ttlMs: number = this.VIEW_IDEMPOTENCY_TTL_MS
   ): Promise<void> {
     const hashedUrl = this.hashUrl(postUrl);
     const intent = isHighIntent ? 'high' : 'normal';
@@ -80,7 +82,7 @@ export class RedisCacheRepository extends CacheRepository {
     postUrl: string,
     visitorId: string,
     isHighIntent: boolean,
-    ttlMs: number = 60 * 30 * 1000
+    ttlMs: number = this.VIEW_IDEMPOTENCY_TTL_MS
   ): Promise<
     | { status: 'acquired' }
     | { status: 'exists'; viewId: number }
@@ -127,7 +129,7 @@ export class RedisCacheRepository extends CacheRepository {
   // 이미 있는 값이면 true, 최초면 false return
   async setClickIdempotencyKey(
     viewId: number,
-    ttlMs: number = 60 * 30 * 1000
+    ttlMs: number = this.CLICK_IDEMPOTENCY_TTL_MS
   ): Promise<boolean> {
     const key = `dedup:click:view:${viewId}`;
 

--- a/backend/src/cache/repository/redis-cache.repository.ts
+++ b/backend/src/cache/repository/redis-cache.repository.ts
@@ -164,6 +164,26 @@ export class RedisCacheRepository extends CacheRepository {
     await this.redis.del(key);
   }
 
+  // Rollback 백업 관련 메서드 (TTL 없음 - Worker용)
+  async setRollbackBackup(
+    viewId: number,
+    rollbackInfo: RollbackInfo
+  ): Promise<void> {
+    const key = `backup:rollback:view:${viewId}`;
+    await this.redis.set(key, JSON.stringify(rollbackInfo)); // TTL 없음
+  }
+
+  async getRollbackBackup(viewId: number): Promise<RollbackInfo | null> {
+    const key = `backup:rollback:view:${viewId}`;
+    const data = await this.redis.get(key);
+    return data ? (JSON.parse(data) as RollbackInfo) : null;
+  }
+
+  async deleteRollbackBackup(viewId: number): Promise<void> {
+    const key = `backup:rollback:view:${viewId}`;
+    await this.redis.del(key);
+  }
+
   private getAuctionKey(auctionId: string): string {
     return `auction:${auctionId}`;
   }

--- a/backend/src/cache/repository/redis-cache.repository.ts
+++ b/backend/src/cache/repository/redis-cache.repository.ts
@@ -15,7 +15,7 @@ export class RedisCacheRepository extends CacheRepository {
   }
 
   private readonly AUCTION_CACHE_TTL = 15 * 60;
-  private readonly ROLLBACK_CACHE_TTL = 5 * 60;
+  private readonly ROLLBACK_CACHE_TTL = 5 * 60; // 1 * 30 테스트 용으로 추천
   private readonly VIEW_IDEMPOTENCY_TTL_MS = 30 * 60 * 1000; // 30분 (밀리초 단위)
   private readonly CLICK_IDEMPOTENCY_TTL_MS = 30 * 60 * 1000; // 30분 (밀리초 단위)
 

--- a/backend/src/cache/repository/redis-cache.repository.ts
+++ b/backend/src/cache/repository/redis-cache.repository.ts
@@ -14,16 +14,18 @@ export class RedisCacheRepository extends CacheRepository {
     super();
   }
 
+  private readonly AUCTION_CACHE_TTL = 15 * 60;
+  private readonly ROLLBACK_CACHE_TTL = 5 * 60;
+
   // Auction 관련 메서드
   async setAuctionData(
     auctionId: string,
     auctionData: AuctionData,
-    ttl: number = 24 * 60 * 60 * 1000 // TTL: 24시간 (밀리초 단위)
+    ttl: number = this.AUCTION_CACHE_TTL // TTL: 15분 (초 단위)
   ): Promise<void> {
     const key = this.getAuctionKey(auctionId);
     const value = JSON.stringify(auctionData);
-    const ttlSeconds = Math.floor(ttl / 1000);
-    await this.redis.setex(key, ttlSeconds, value);
+    await this.redis.setex(key, ttl, value);
   }
 
   async getAuctionData(auctionId: string): Promise<AuctionData | undefined> {
@@ -46,8 +48,7 @@ export class RedisCacheRepository extends CacheRepository {
   ): Promise<void> {
     const key = this.getOAuthStateKey(state);
     const value = JSON.stringify(data);
-    const ttlSeconds = Math.floor(ttl / 1000);
-    await this.redis.setex(key, ttlSeconds, value);
+    await this.redis.setex(key, ttl, value);
   }
 
   async getOAuthState(state: string): Promise<StoredOAuthState | undefined> {
@@ -147,7 +148,7 @@ export class RedisCacheRepository extends CacheRepository {
   async setRollbackInfo(
     viewId: number,
     rollbackInfo: RollbackInfo,
-    ttl: number = 300 // 5분 (초 단위)
+    ttl: number = this.ROLLBACK_CACHE_TTL // 5분 (초 단위)
   ): Promise<void> {
     const key = `rollback:view:${viewId}`;
     await this.redis.setex(key, ttl, JSON.stringify(rollbackInfo));

--- a/backend/src/campaign/repository/campaign.cache.repository.interface.ts
+++ b/backend/src/campaign/repository/campaign.cache.repository.interface.ts
@@ -22,6 +22,20 @@ export abstract class CampaignCacheRepository {
 
   abstract updateDailySpentCacheById(id: string, amount: number): Promise<void>;
 
+  // 선제적 Spent 증가 (원자적 예산 검증 + 증가)
+  // 예산 검증 통과 시 dailySpent += cpc, totalSpent += cpc 후 true 반환
+  // 예산 초과 시 증가 없이 false 반환
+  abstract incrementSpent(
+    campaignId: string,
+    cpc: number,
+    dailyBudget: number,
+    totalBudget: number | null
+  ): Promise<boolean>;
+
+  // Spent 롤백 (비딩 패배 시)
+  // dailySpent -= cpc, totalSpent -= cpc
+  abstract decrementSpent(campaignId: string, cpc: number): Promise<void>;
+
   // 태그 변경 시 임베딩 비우기
   abstract deleteCampaignEmbeddingById(id: string): Promise<void>;
 

--- a/backend/src/campaign/repository/redis-campaign.cache.repository.ts
+++ b/backend/src/campaign/repository/redis-campaign.cache.repository.ts
@@ -15,6 +15,7 @@ import {
 export class RedisCampaignCacheRepository implements CampaignCacheRepository {
   private readonly logger = new Logger(RedisCampaignCacheRepository.name);
   private readonly KEY_PREFIX = 'campaign:';
+  private readonly CAMPAIGN_CACHE_TTL = 60 * 60 * 24;
 
   constructor(
     @Inject(IOREDIS_CLIENT) private readonly ioredisClient: AppIORedisClient
@@ -23,7 +24,7 @@ export class RedisCampaignCacheRepository implements CampaignCacheRepository {
   async saveCampaignCacheById(
     id: string,
     data: CachedCampaign,
-    ttl = 60 * 60 * 24
+    ttl = this.CAMPAIGN_CACHE_TTL
   ): Promise<void> {
     const key = this.getCampaignCacheKey(id);
 

--- a/backend/src/campaign/scripts/lua-script.ts
+++ b/backend/src/campaign/scripts/lua-script.ts
@@ -1,0 +1,48 @@
+// Lua Script: 원자적 예산 검증 + Spent 증가 (by Claude)
+// KEYS[1] = campaign:{id}
+// ARGV[1] = cpc
+// ARGV[2] = dailyBudget
+// ARGV[3] = totalBudget (null이면 "null" 문자열)
+//
+// 반환값:
+// 1 = 성공 (Spent 증가됨)
+// 0 = 일일 예산 초과
+// -1 = 총 예산 초과
+// -99 = 캠페인 없음
+export const REDIS_INCREMENT_SPENT_SCRIPT = `
+    local campaignKey = KEYS[1]
+    local cpc = tonumber(ARGV[1])
+    local dailyBudget = tonumber(ARGV[2])
+    local totalBudgetStr = ARGV[3]
+    
+    -- 현재 spent 값 조회 (JSON 경로에서)
+    local dailySpentRaw = redis.call('JSON.GET', campaignKey, '$.dailySpent')
+    local totalSpentRaw = redis.call('JSON.GET', campaignKey, '$.totalSpent')
+    
+    if not dailySpentRaw or not totalSpentRaw then
+      return -99  -- 캠페인 없음
+    end
+    
+    -- JSON 배열 형태로 반환되므로 파싱 필요 (예: "[50000]")
+    local dailySpent = tonumber(string.match(dailySpentRaw, '%[(%d+)%]')) or 0
+    local totalSpent = tonumber(string.match(totalSpentRaw, '%[(%d+)%]')) or 0
+    
+    -- 일일 예산 검증
+    if dailySpent + cpc >= dailyBudget then
+      return 0  -- 일일 예산 초과
+    end
+    
+    -- 총 예산 검증 (totalBudget이 "null"이 아닌 경우만)
+    if totalBudgetStr ~= "null" then
+      local totalBudget = tonumber(totalBudgetStr)
+      if totalSpent + cpc >= totalBudget then
+        return -1  -- 총 예산 초과
+      end
+    end
+    
+    -- 원자적으로 Spent 증가
+    redis.call('JSON.NUMINCRBY', campaignKey, '$.dailySpent', cpc)
+    redis.call('JSON.NUMINCRBY', campaignKey, '$.totalSpent', cpc)
+    
+    return 1  -- 성공
+  `;

--- a/backend/src/campaign/scripts/lua-script.ts
+++ b/backend/src/campaign/scripts/lua-script.ts
@@ -46,3 +46,45 @@ export const REDIS_INCREMENT_SPENT_SCRIPT = `
     
     return 1  -- 성공
   `;
+
+// Lua Script: 원자적 Spent 감소 (롤백용)
+// KEYS[1] = campaign:{id}
+// ARGV[1] = cpc (감소할 금액, 양수로 전달)
+//
+// 반환값:
+// 1 = 성공 (Spent 감소됨)
+// 0 = 음수 방지 (dailySpent가 음수가 될 뻔함)
+// -1 = 음수 방지 (totalSpent가 음수가 될 뻔함)
+// -99 = 캠페인 없음
+export const REDIS_DECREMENT_SPENT_SCRIPT = `
+  local campaignKey = KEYS[1]
+  local cpc = tonumber(ARGV[1])
+  
+  -- 현재 spent 값 조회
+  local dailySpentRaw = redis.call('JSON.GET', campaignKey, '$.dailySpent')
+  local totalSpentRaw = redis.call('JSON.GET', campaignKey, '$.totalSpent')
+  
+  if not dailySpentRaw or not totalSpentRaw then
+    return -99  -- 캠페인 없음
+  end
+  
+  -- JSON 배열 파싱
+  local dailySpent = tonumber(string.match(dailySpentRaw, '%[(%d+)%]')) or 0
+  local totalSpent = tonumber(string.match(totalSpentRaw, '%[(%d+)%]')) or 0
+  
+  -- 음수 방지 검증 (일일)
+  if dailySpent - cpc < 0 then
+    return 0  -- 일일 Spent가 음수가 될 수 없음
+  end
+  
+  -- 음수 방지 검증 (총)
+  if totalSpent - cpc < 0 then
+    return -1  -- 총 Spent가 음수가 될 수 없음
+  end
+  
+  -- 원자적으로 Spent 감소
+  redis.call('JSON.NUMINCRBY', campaignKey, '$.dailySpent', -cpc)
+  redis.call('JSON.NUMINCRBY', campaignKey, '$.totalSpent', -cpc)
+  
+  return 1  -- 성공
+`;

--- a/backend/src/rtb/rtb.service.ts
+++ b/backend/src/rtb/rtb.service.ts
@@ -212,10 +212,7 @@ export class RTBService {
               );
             }
           } catch (error) {
-            this.logger.error(
-              `캠페인 ${campaign.id} 예산 확보 중 오류 발생 - 후보에서 제외`,
-              error
-            );
+            this.logger.warn(`캠페인 ${campaign.id} 후보에서 제외`, error);
           }
         })
       )

--- a/backend/src/rtb/rtb.service.ts
+++ b/backend/src/rtb/rtb.service.ts
@@ -94,6 +94,7 @@ export class RTBService {
       });
 
       // 7. BidLog 저장 (모든 참여 캠페인의 입찰 기록)
+      // --------------------------------------------------------------------------------------------------------------------------------------
       // TODO(추후 고려 사항): 속성값 고민 및 reason 필드에 대한 고민 그리고 로그 데이터는 RedisStream으로 큐를 통한 배치처리가 고려되면 좋을 거 같음
       const bidLogs: BidLog[] = result.candidates.map((candidate) => ({
         auctionId,
@@ -121,6 +122,7 @@ export class RTBService {
           await this.bidLogService.emitBidCreated(savedBid.id);
         }
       }
+      // --------------------------------------------------------------------------------------------------------------------------------------
 
       // TODO: 7. explain(reason) 생성 로직 필요 -> 일단 보류
 

--- a/backend/src/sdk/dto/create-dismiss-log.dto.ts
+++ b/backend/src/sdk/dto/create-dismiss-log.dto.ts
@@ -1,0 +1,15 @@
+import { IsInt, IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateDismissLogDto {
+  @IsInt()
+  @IsNotEmpty()
+  viewId: number;
+
+  @IsString()
+  @IsNotEmpty()
+  blogKey: string;
+
+  @IsString()
+  @IsNotEmpty()
+  postUrl: string;
+}

--- a/backend/src/sdk/sdk.controller.ts
+++ b/backend/src/sdk/sdk.controller.ts
@@ -5,11 +5,13 @@ import {
   UseGuards,
   Req,
   BadRequestException,
+  HttpCode,
 } from '@nestjs/common';
 import { SdkService } from './sdk.service';
 import { CreateViewLogDto } from './dto/create-view-log.dto';
 import { successResponse } from 'src/common/response/success-response';
 import { CreateClickLogDto } from './dto/create-click-log.dto';
+import { CreateDismissLogDto } from './dto/create-dismiss-log.dto';
 import { Public } from 'src/auth/decorators/public.decorator';
 import {
   type BlogKeyValidatedRequest,
@@ -59,5 +61,12 @@ export class SdkController {
       { clickId },
       '캠페인 클릭 로그가 성공적으로 저장되었습니다.'
     );
+  }
+
+  @Public()
+  @Post('campaign-dismiss')
+  @HttpCode(204)
+  async recordDismiss(@Body() createDismissLogDto: CreateDismissLogDto) {
+    await this.sdkService.recordDismiss(createDismissLogDto);
   }
 }

--- a/backend/src/sdk/sdk.module.ts
+++ b/backend/src/sdk/sdk.module.ts
@@ -4,9 +4,10 @@ import { SdkService } from './sdk.service';
 import { LogModule } from 'src/log/log.module';
 import { CacheModule } from 'src/cache/cache.module';
 import { BlogModule } from 'src/blog/blog.module';
+import { CampaignModule } from 'src/campaign/campaign.module';
 
 @Module({
-  imports: [LogModule, CacheModule, BlogModule],
+  imports: [LogModule, CacheModule, BlogModule, CampaignModule],
   controllers: [SdkController],
   providers: [SdkService],
 })

--- a/backend/src/sdk/sdk.service.ts
+++ b/backend/src/sdk/sdk.service.ts
@@ -86,6 +86,10 @@ export class SdkService {
       createdAt: new Date().toISOString(),
     });
 
+    this.logger.debug(
+      `[SDK ViewLog] Rollback 정보 저장: viewId=${viewId}, campaign=${campaignId}, cost=${cost} (TTL 5분)`
+    );
+
     return viewId;
   }
 
@@ -95,27 +99,48 @@ export class SdkService {
     const isDup = await this.cacheRepository.setClickIdempotencyKey(viewId);
 
     if (isDup) {
+      this.logger.debug(`[SDK ClickLog] 중복 클릭: viewId=${viewId}`);
       return null;
     }
+
     const exists = await this.logRepository.existsByViewId(viewId);
     if (!exists) {
       throw new BadRequestException('잘못된 요청입니다.');
     }
-    return await this.logRepository.saveClickLog({ viewId });
+
+    const clickId = await this.logRepository.saveClickLog({ viewId });
+
+    // 클릭 시 Rollback 정보 삭제 (Dismiss Beacon이 와도 무시되도록)
+    await this.cacheRepository.deleteRollbackInfo(viewId);
+
+    this.logger.log(
+      `[SDK ClickLog] 클릭 기록 완료: viewId=${viewId}, clickId=${clickId} (Rollback 정보 삭제 → Spent 유지)`
+    );
+
+    return clickId;
   }
 
   async recordDismiss(dto: CreateDismissLogDto): Promise<void> {
     const { viewId } = dto;
 
+    this.logger.debug(`[SDK Dismiss] 시작: viewId=${viewId}`);
+
     // 1. Redis에서 Rollback 정보 조회
     const rollbackInfo = await this.cacheRepository.getRollbackInfo(viewId);
     if (!rollbackInfo) {
       // TTL 만료 또는 이미 처리됨 → 무시
-      this.logger.warn(`[SDK] RollbackInfo not found for viewId=${viewId}`);
+      this.logger.warn(
+        `[SDK Dismiss] RollbackInfo not found for viewId=${viewId} (TTL 만료 또는 이미 처리됨)`
+      );
       return;
     }
 
-    const { campaignId, cost } = rollbackInfo;
+    const { campaignId, cost, createdAt } = rollbackInfo;
+    const elapsedMs = Date.now() - new Date(createdAt).getTime();
+
+    this.logger.debug(
+      `[SDK Dismiss] RollbackInfo 조회 성공: viewId=${viewId}, campaign=${campaignId}, cost=${cost}, elapsed=${Math.floor(elapsedMs / 1000)}s`
+    );
 
     // 2. Spent 롤백 (Phase 2에서 구현된 메서드 사용)
     await this.campaignCacheRepository.decrementSpent(campaignId, cost);
@@ -124,7 +149,7 @@ export class SdkService {
     await this.cacheRepository.deleteRollbackInfo(viewId);
 
     this.logger.log(
-      `[SDK] Rollback 처리 완료: campaign=${campaignId}, cost=${cost}`
+      `[SDK Dismiss] 롤백 완료: viewId=${viewId}, campaign=${campaignId}, cost=-${cost} (일일/총), elapsed=${Math.floor(elapsedMs / 1000)}s`
     );
   }
 }

--- a/backend/src/sdk/sdk.service.ts
+++ b/backend/src/sdk/sdk.service.ts
@@ -2,18 +2,24 @@ import {
   BadRequestException,
   ConflictException,
   Injectable,
+  Logger,
   NotFoundException,
 } from '@nestjs/common';
 import { CreateViewLogDto } from './dto/create-view-log.dto';
 import { LogRepository } from 'src/log/repository/log.repository.interface';
 import { CacheRepository } from 'src/cache/repository/cache.repository.interface';
 import { CreateClickLogDto } from './dto/create-click-log.dto';
+import { CreateDismissLogDto } from './dto/create-dismiss-log.dto';
+import { CampaignCacheRepository } from 'src/campaign/repository/campaign.cache.repository.interface';
 
 @Injectable()
 export class SdkService {
+  private readonly logger = new Logger(SdkService.name);
+
   constructor(
     private readonly logRepository: LogRepository,
-    private readonly cacheRepository: CacheRepository
+    private readonly cacheRepository: CacheRepository,
+    private readonly campaignCacheRepository: CampaignCacheRepository
   ) {}
 
   async recordView(dto: CreateViewLogDto, visitorId: string) {
@@ -73,6 +79,13 @@ export class SdkService {
       viewId
     );
 
+    // Rollback 정보 Redis 저장 (TTL 5분)
+    await this.cacheRepository.setRollbackInfo(viewId, {
+      campaignId,
+      cost,
+      createdAt: new Date().toISOString(),
+    });
+
     return viewId;
   }
 
@@ -89,5 +102,29 @@ export class SdkService {
       throw new BadRequestException('잘못된 요청입니다.');
     }
     return await this.logRepository.saveClickLog({ viewId });
+  }
+
+  async recordDismiss(dto: CreateDismissLogDto): Promise<void> {
+    const { viewId } = dto;
+
+    // 1. Redis에서 Rollback 정보 조회
+    const rollbackInfo = await this.cacheRepository.getRollbackInfo(viewId);
+    if (!rollbackInfo) {
+      // TTL 만료 또는 이미 처리됨 → 무시
+      this.logger.warn(`[SDK] RollbackInfo not found for viewId=${viewId}`);
+      return;
+    }
+
+    const { campaignId, cost } = rollbackInfo;
+
+    // 2. Spent 롤백 (Phase 2에서 구현된 메서드 사용)
+    await this.campaignCacheRepository.decrementSpent(campaignId, cost);
+
+    // 3. Redis에서 Rollback 정보 삭제 (중복 방지)
+    await this.cacheRepository.deleteRollbackInfo(viewId);
+
+    this.logger.log(
+      `[SDK] Rollback 처리 완료: campaign=${campaignId}, cost=${cost}`
+    );
   }
 }

--- a/backend/src/sdk/sdk.service.ts
+++ b/backend/src/sdk/sdk.service.ts
@@ -59,6 +59,13 @@ export class SdkService {
           cost,
           createdAt: new Date().toISOString(),
         });
+
+        // Rollback 백업 정보 저장 (TTL 없음 - Worker용) - TTL 만료로 인한 삭제시 이벤트 명만 발생하면서 삭제 -> 그 이벤트 명에 맞는 RollBack 백업 정보 필요
+        await this.cacheRepository.setRollbackBackup(existingViewId, {
+          campaignId,
+          cost,
+          createdAt: new Date().toISOString(),
+        });
       }
 
       return existingViewId;

--- a/sdk/src/features/BannerAdRenderer.ts
+++ b/sdk/src/features/BannerAdRenderer.ts
@@ -573,7 +573,20 @@ export class BannerAdRenderer implements AdRenderer {
   // Dismiss Beacon 전송
   private sendDismissBeacon(): void {
     // 클릭했거나 이미 전송했으면 무시
-    if (this.hasClicked || this.hasSentDismiss || this.currentViewId === null) {
+    if (this.hasClicked) {
+      console.log(
+        '[BoostAD SDK] Beacon 전송 스킵: 광고 클릭됨 (Spent 유지)'
+      );
+      return;
+    }
+
+    if (this.hasSentDismiss) {
+      console.log('[BoostAD SDK] Beacon 전송 스킵: 이미 전송됨 (중복 방지)');
+      return;
+    }
+
+    if (this.currentViewId === null) {
+      console.log('[BoostAD SDK] Beacon 전송 스킵: viewId 없음 (광고 미렌더링)');
       return;
     }
 
@@ -585,6 +598,10 @@ export class BannerAdRenderer implements AdRenderer {
       postUrl: window.location.href,
     };
 
+    console.log(
+      `[BoostAD SDK] Beacon 전송 시도: viewId=${this.currentViewId}, url=${window.location.href}`
+    );
+
     const blob = new Blob([JSON.stringify(payload)], {
       type: 'application/json',
     });
@@ -592,9 +609,12 @@ export class BannerAdRenderer implements AdRenderer {
 
     if (navigator.sendBeacon) {
       const sent = navigator.sendBeacon(url, blob);
-      console.log('[BoostAD SDK] Beacon 전송:', sent ? '성공' : '실패');
+      console.log(
+        `[BoostAD SDK] Beacon 전송 결과: ${sent ? '성공' : '실패'} (viewId=${this.currentViewId})`
+      );
     } else {
       // Fallback: fetch with keepalive (구형 브라우저)
+      console.log('[BoostAD SDK] Beacon fallback 사용 (구형 브라우저)');
       fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/sdk/src/features/BannerAdRenderer.ts
+++ b/sdk/src/features/BannerAdRenderer.ts
@@ -34,7 +34,11 @@ export class BannerAdRenderer implements AdRenderer {
     );
 
     // 🔧 새 광고 렌더링 전에 이전 광고 Dismiss 처리
-    if (this.currentViewId !== null && !this.hasClicked && !this.hasSentDismiss) {
+    if (
+      this.currentViewId !== null &&
+      !this.hasClicked &&
+      !this.hasSentDismiss
+    ) {
       console.log(
         `[BoostAD SDK] 새 광고 렌더링 전 이전 광고 Dismiss: viewId=${this.currentViewId}`
       );
@@ -568,19 +572,14 @@ export class BannerAdRenderer implements AdRenderer {
 
   // Beacon 이벤트 리스너 등록
   private registerBeaconListeners(): void {
-    // beforeunload: 페이지 닫기, 새로고침, 뒤로가기
-    window.addEventListener('beforeunload', () => {
-      this.sendDismissBeacon();
-    });
-
-    // visibilitychange: 탭 전환, 백그라운드 전환
+    // visibilitychange: 탭 닫기, 새로고침, 뒤로가기, 탭 전환 (메인 이벤트)
     document.addEventListener('visibilitychange', () => {
       if (document.visibilityState === 'hidden') {
         this.sendDismissBeacon();
       }
     });
 
-    // pagehide: iOS Safari 호환성
+    // pagehide: iOS Safari 호환성 (백업 레이어)
     window.addEventListener('pagehide', () => {
       this.sendDismissBeacon();
     });
@@ -590,9 +589,7 @@ export class BannerAdRenderer implements AdRenderer {
   private sendDismissBeacon(): void {
     // 클릭했거나 이미 전송했으면 무시
     if (this.hasClicked) {
-      console.log(
-        '[BoostAD SDK] Beacon 전송 스킵: 광고 클릭됨 (Spent 유지)'
-      );
+      console.log('[BoostAD SDK] Beacon 전송 스킵: 광고 클릭됨 (Spent 유지)');
       return;
     }
 
@@ -602,7 +599,9 @@ export class BannerAdRenderer implements AdRenderer {
     }
 
     if (this.currentViewId === null) {
-      console.log('[BoostAD SDK] Beacon 전송 스킵: viewId 없음 (광고 미렌더링)');
+      console.log(
+        '[BoostAD SDK] Beacon 전송 스킵: viewId 없음 (광고 미렌더링)'
+      );
       return;
     }
 

--- a/sdk/src/features/BannerAdRenderer.ts
+++ b/sdk/src/features/BannerAdRenderer.ts
@@ -164,6 +164,18 @@ export class BannerAdRenderer implements AdRenderer {
     const safeImage = this.escapeHtml(campaign.image);
 
     const containerHeight = container.offsetHeight || container.clientHeight;
+    const screenWidth = window.innerWidth;
+    const isMobile = screenWidth <= 768;
+
+    // 모바일: 화면 너비가 768px 이하일 때
+    if (isMobile) {
+      return this.renderMobileWidget(
+        safeTitle,
+        safeContent,
+        safeUrl,
+        safeImage
+      );
+    }
 
     // S: 높이가 120px 이하일 때
     if (containerHeight > 0 && containerHeight <= 120) {
@@ -187,6 +199,89 @@ export class BannerAdRenderer implements AdRenderer {
 
     // 기본
     return this.renderFullWidget(safeTitle, safeContent, safeUrl, safeImage);
+  }
+
+  // Mobile (화면 너비 <= 768px)
+  private renderMobileWidget(
+    title: string,
+    content: string,
+    url: string,
+    image: string
+  ): string {
+    return /*html*/ `
+      <a href="${url}" class="boostad-link" target="_blank" rel="noopener noreferrer" style="
+        display: block;
+        width: 100%;
+        padding: 16px;
+        border: 1px solid #e0e0e0;
+        border-radius: 10px;
+        background: #ffffff;
+        text-decoration: none;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+        transition: box-shadow 0.2s;
+        box-sizing: border-box;
+        margin: 16px 0;
+      " onmouseover="this.style.boxShadow='0 4px 12px rgba(0,0,0,0.12)';" onmouseout="this.style.boxShadow='0 2px 6px rgba(0,0,0,0.08)';">
+        <div style="
+          display: flex;
+          gap: 12px;
+          margin-bottom: 12px;
+        ">
+          <img src="${image}" alt="${title}" style="
+            width: 80px;
+            height: 80px;
+            border-radius: 8px;
+            object-fit: cover;
+            flex-shrink: 0;
+          " onerror="this.style.display='none';" />
+          <div style="flex: 1; min-width: 0; overflow: hidden;">
+            <div style="font-size: 10px; color: #999; margin-bottom: 6px;">Sponsored</div>
+            <div style="
+              font-size: 15px;
+              font-weight: 500;
+              color: #333;
+              line-height: 1.4;
+              margin-bottom: 6px;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              display: -webkit-box;
+              -webkit-line-clamp: 2;
+              -webkit-box-orient: vertical;
+            ">${title}</div>
+          </div>
+        </div>
+        <div style="
+          font-size: 13px;
+          color: #666;
+          line-height: 1.5;
+          margin-bottom: 12px;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          display: -webkit-box;
+          -webkit-line-clamp: 2;
+          -webkit-box-orient: vertical;
+        ">${content}</div>
+        <div style="
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+        ">
+          <span style="
+            color: #155dfc;
+            font-size: 13px;
+            font-weight: 500;
+            text-decoration: underline;
+            text-decoration-color: transparent;
+            text-underline-offset: 3px;
+            transition: text-decoration-color 0.2s;
+          " class="boostad-cta">더 알아보기 →</span>
+          <span style="font-size: 10px; color: #99a1af; white-space: nowrap;">
+            by <strong>BoostAD</strong>
+          </span>
+        </div>
+      </a>
+    `;
   }
 
   // S (h-20 ~ 120px)

--- a/sdk/src/features/BannerAdRenderer.ts
+++ b/sdk/src/features/BannerAdRenderer.ts
@@ -29,6 +29,20 @@ export class BannerAdRenderer implements AdRenderer {
     behaviorScore?: number,
     isHighIntent?: boolean
   ): void {
+    console.log(
+      `[BoostAD SDK] render() 호출: campaign=${campaign ? campaign.id : 'null'}, 이전 viewId=${this.currentViewId}`
+    );
+
+    // 🔧 새 광고 렌더링 전에 이전 광고 Dismiss 처리
+    if (this.currentViewId !== null && !this.hasClicked && !this.hasSentDismiss) {
+      console.log(
+        `[BoostAD SDK] 새 광고 렌더링 전 이전 광고 Dismiss: viewId=${this.currentViewId}`
+      );
+      this.sendDismissBeacon();
+    }
+
+    // 새 광고 렌더링 시 상태 초기화
+    this.currentViewId = null;
     this.hasClicked = false;
     this.hasSentDismiss = false;
 
@@ -54,6 +68,8 @@ export class BannerAdRenderer implements AdRenderer {
         behaviorScore || 0,
         isHighIntent || false
       );
+    } else {
+      console.log('[BoostAD SDK] 광고 없음 → viewId null 유지');
     }
   }
 

--- a/sdk/src/features/BannerAdRenderer.ts
+++ b/sdk/src/features/BannerAdRenderer.ts
@@ -156,6 +156,37 @@ export class BannerAdRenderer implements AdRenderer {
     `;
   }
 
+  private isMobileDevice(): boolean {
+    // 1. User-Agent 체크
+    const userAgent = navigator.userAgent.toLowerCase();
+    const mobilePatterns = [
+      /android/i,
+      /webos/i,
+      /iphone/i,
+      /ipad/i,
+      /ipod/i,
+      /blackberry/i,
+      /windows phone/i,
+    ];
+    const isMobileUA = mobilePatterns.some((pattern) =>
+      pattern.test(userAgent)
+    );
+
+    // 2. Touch 지원 체크
+    const isTouchDevice =
+      'ontouchstart' in window ||
+      navigator.maxTouchPoints > 0 ||
+      ('msMaxTouchPoints' in navigator &&
+        (navigator as { msMaxTouchPoints: number }).msMaxTouchPoints > 0);
+
+    // 3. 화면 크기 체크
+    const screenWidth = window.innerWidth;
+    const isSmallScreen = screenWidth <= 768;
+
+    // 복합 판단: (모바일 UA || 터치 지원) && 작은 화면
+    return (isMobileUA || isTouchDevice) && isSmallScreen;
+  }
+
   private renderAdWidget(campaign: Campaign, container: HTMLElement): string {
     // XSS 방지: 모든 사용자 입력 데이터 이스케이프
     const safeTitle = this.escapeHtml(campaign.title);
@@ -164,11 +195,9 @@ export class BannerAdRenderer implements AdRenderer {
     const safeImage = this.escapeHtml(campaign.image);
 
     const containerHeight = container.offsetHeight || container.clientHeight;
-    const screenWidth = window.innerWidth;
-    const isMobile = screenWidth <= 768;
 
-    // 모바일: 화면 너비가 768px 이하일 때
-    if (isMobile) {
+    // 모바일 디바이스 감지 (User-Agent + Touch + 화면 크기)
+    if (this.isMobileDevice()) {
       return this.renderMobileWidget(
         safeTitle,
         safeContent,


### PR DESCRIPTION
## 🔗 이슈

### 대표 이슈

- #256 

### 연관 이슈

- close: #287
- close: #288 

---

## 📋 작업 개요

RTB(Real-Time Bidding) 시스템에서 **동시 비딩 시 예산 초과 방지**를 위한 선제적 Spent 증가 및 롤백 메커니즘을 구현했습니다.

### 핵심 원리

```

비딩 참여 → 선제적 Spent 증가 → 비딩 결과 확인 → 패배/미클릭 시 롤백

```

### 안전성 보장

- **Redis >= DB (단방향 불일치)**: 선제적 증가로 인해 Redis가 항상 크거나 같음

- **보수적 차단**: Redis 기준 검증으로 예산 초과 원천 차단

- **일일 정산**: ClickLog 기반 최종 보정으로 정합성 유지

---

## ✅ 작업 내용

### Phase 1: 예산 필터링 구현

**변경 파일:**
- `backend/src/rtb/matchers/xenova.matcher.ts`

**변경 배경:**
- 기존: 비딩 시 예산 검증 없이 모든 ACTIVE 캠페인 참여

- 문제점: 동시 비딩 시 예산 초과 위험

- 해결: `filterEligibleCampaigns()`에서 `dailySpent + cpc < dailyBudget` 검증

**구현 내용:**
```typescript

// xenova.matcher.ts - filterEligibleCampaigns()

private filterEligibleCampaigns(

  campaigns: CachedCampaign[],

  isHighIntent: boolean

): CachedCampaign[] {

  const now = new Date();

  

  return campaigns.filter((campaign) => {

    // 삭제된 캠페인 제외

    if (campaign.deletedAt) return false;

  

    // ACTIVE 상태만 허용

    if (campaign.status !== 'ACTIVE') return false;

  

    // 날짜 범위 검증

    const startDate = new Date(campaign.startDate);

    const endDate = new Date(campaign.endDate);

    if (now < startDate || now >= endDate) return false;

  

    // embeddingTags 존재 여부

    if (!campaign.embeddingTags || Object.keys(campaign.embeddingTags).length === 0) {

      return false;

    }

  

    // isHighIntent 일치 여부

    if (isHighIntent !== campaign.isHighIntent) return false;

  

    return true;

  });

}

```

**핵심 포인트:**

- Redis 캐시(`CachedCampaign`)에서 `dailySpent`, `totalSpent` 값 활용

- Matcher 단계에서 1차 필터링 (예산 여유 있는 캠페인만 후보로)

- 동시성 문제는 Phase 2에서 원자적 연산으로 해결

---
### Phase 2: 선제적 Spent 증가 (Atomic Operation)

**변경 파일:**

- `backend/src/campaign/repository/redis-campaign.cache.repository.ts`

- `backend/src/campaign/scripts/lua-script.ts` (NEW)

- `backend/src/rtb/rtb.service.ts`

**변경 배경:**

- 기존: 비딩 승리 후 클릭 시점에 Spent 증가

- 문제점: 동시 비딩 시 모두 예산 검증 통과 → 예산 초과

- 해결: 비딩 **참여 시점**에 선제적으로 Spent 증가 (예산 확보)


**구현 내용:**

#### 1) Lua Script를 통한 원자적 연산

```typescript

// lua-script.ts - REDIS_INCREMENT_SPENT_SCRIPT

export const REDIS_INCREMENT_SPENT_SCRIPT = `

  local key = KEYS[1]
  local cpc = tonumber(ARGV[1])
  local dailyBudget = tonumber(ARGV[2])
  local totalBudget = ARGV[3]

  -- 캠페인 데이터 조회
  local data = redis.call('JSON.GET', key, '.')
  if not data then return -99 end

  local campaign = cjson.decode(data)
  local dailySpent = tonumber(campaign.dailySpent) or 0
  local totalSpent = tonumber(campaign.totalSpent) or 0

  -- 일일 예산 검증
  if dailySpent + cpc > dailyBudget then
    return 0  -- 일일 예산 초과
  end

  -- 총 예산 검증 (null이 아닌 경우)
  if totalBudget ~= 'null' then
    local totalBudgetNum = tonumber(totalBudget)
    if totalSpent + cpc > totalBudgetNum then
      return -1  -- 총 예산 초과
    end
  end

  -- 원자적 증가
  redis.call('JSON.NUMINCRBY', key, '$.dailySpent', cpc)
  redis.call('JSON.NUMINCRBY', key, '$.totalSpent', cpc)
  return 1  -- 성공
`;

```

#### 2) RedisCampaignCacheRepository 구현

```typescript
// redis-campaign.cache.repository.ts
async incrementSpent(
  campaignId: string,
  cpc: number,
  dailyBudget: number,
  totalBudget: number | null

): Promise<boolean> {

  const key = this.getCampaignCacheKey(campaignId);

  const result = await this.ioredisClient.eval(
    REDIS_INCREMENT_SPENT_SCRIPT,
    1,
    key,
    cpc.toString(),
    dailyBudget.toString(),
    totalBudget !== null ? totalBudget.toString() : 'null'
  ) as number;

  if (result === 1) {
    this.logger.debug(`캠페인 ${campaignId} Spent 증가 성공: +${cpc}`);
    return true;
  }

  return false;  // 예산 초과로 실패
}

async decrementSpent(campaignId: string, cpc: number): Promise<void> {

  const key = this.getCampaignCacheKey(campaignId);

  await this.ioredisClient.eval(
    REDIS_DECREMENT_SPENT_SCRIPT,
    1,
    key,
    cpc.toString()
  );

  this.logger.debug(`캠페인 ${campaignId} Spent 롤백 완료: -${cpc}`);
}
```

#### 3) RTBService 통합

```typescript

// rtb.service.ts

async runAuction(context: DecisionContext) {

  const auctionId = randomUUID();

  // 1. 후보 불러오기

  let candidates = await this.matcher.findCandidatesByTags(context);

  // 2. 선제적 Spent 증가 (예산 확보)

  candidates = await this.increaseSpentCandidates(candidates);

  // ... 점수 계산 및 우승자 선정 ...

  // 5. 패배한 캠페인들의 Spent 롤백

  await this.rollbackLosersSpent(auctionId, result);

  // ... 나머지 로직 ...
} 

private async increaseSpentCandidates(candidates: Candidate[]) {

  const eligibleCandidates: Candidate[] = [];

  await Promise.allSettled(
    candidates.map((candidate) =>
      this.limit(async () => {

        const { campaign } = candidate;

        const reserved = await this.campaignCacheRepository.incrementSpent(
          campaign.id,
          campaign.maxCpc,
          campaign.dailyBudget,
          campaign.totalBudget
        );

        if (reserved) {
          eligibleCandidates.push(candidate);
        }
      })
    )
  );
  return eligibleCandidates;
}
```

**핵심 포인트:**

- Lua Script로 **예산 검증 + 증가를 단일 원자적 연산**으로 수행

- 동시 비딩 시에도 **한 캠페인당 하나의 비딩만 통과**

- `p-limit`으로 동시 처리량 제한 (Redis 부하 방지)

---

### Phase 3: 비딩 패배 롤백

**변경 파일:**

- `backend/src/rtb/rtb.service.ts`

- `backend/src/campaign/repository/redis-campaign.cache.repository.ts`

**변경 배경:**

- 선제적 증가 후 비딩 패배 시 Spent 복원 필요

- 해결: 우승자 제외 모든 캠페인의 Spent 롤백

**구현 내용:**

```typescript

// rtb.service.ts
private async rollbackLosersSpent(
  auctionId: string,
  result: SelectionResult
) {

  const losers = result.candidates.filter(
    (candidate) => candidate.id !== result.winner.id
  );

  // 병렬 처리 - p-limit 사용

  await Promise.allSettled(
    losers.map((loser) =>
      this.limit(async () => {
        await this.campaignCacheRepository.decrementSpent(
          loser.id,
          loser.maxCpc
        );
        this.logger.debug(
          `Auction ${auctionId}: 패배 캠페인 ${loser.id} Spent 롤백 완료`
        );
      })
    )
  );
}
```

  

**Decrement Lua Script:**

```typescript

export const REDIS_DECREMENT_SPENT_SCRIPT = `

  local key = KEYS[1]

  local cpc = tonumber(ARGV[1])

  

  local data = redis.call('JSON.GET', key, '.')

  if not data then return -99 end

  

  local campaign = cjson.decode(data)

  local dailySpent = tonumber(campaign.dailySpent) or 0

  local totalSpent = tonumber(campaign.totalSpent) or 0

  

  -- 음수 방지

  if dailySpent < cpc then return 0 end

  if totalSpent < cpc then return -1 end

  

  redis.call('JSON.NUMINCRBY', key, '$.dailySpent', -cpc)

  redis.call('JSON.NUMINCRBY', key, '$.totalSpent', -cpc)

  

  return 1

`;

```

**핵심 포인트:**
- **HINCRBY 방식**이 아닌 **증감 연산**으로 다른 비딩과 독립적 롤백
- 음수 방지 로직으로 데이터 정합성 보장
- 롤백 실패는 치명적이지 않음 (과다 차감 방향은 안전)

---

### Phase 5: TTL 백업 (Failsafe)

**변경 파일:**

- `backend/src/cache/repository/cache.repository.interface.ts`

- `backend/src/cache/repository/redis-cache.repository.ts`

- `backend/src/cache/redis-ttl.worker.ts` (NEW)

- `backend/src/sdk/sdk.service.ts`

- `frontend/src/ad-renderer/BannerAdRenderer.ts` (SDK)

  

**변경 배경:**

- 비딩 승리 후 클릭 없이 페이지 이탈 시 Spent 복원 필요

- SDK Beacon 방식의 한계: 브라우저 강제 종료 시 미전송

- 해결: **SDK Beacon + TTL 백업** 이중 안전장치

**구현 내용:**

#### 1) CacheRepository 인터페이스 확장

```typescript

// cache.repository.interface.ts

export interface RollbackInfo {
  campaignId: string;
  cost: number;
  createdAt: string;
}

abstract class CacheRepository {

  // ... 기존 메서드 ...

  // Rollback 정보 (TTL 5분)
  abstract setRollbackInfo(viewId: number, info: RollbackInfo): Promise<void>;
  abstract getRollbackInfo(viewId: number): Promise<RollbackInfo | null>;
  abstract deleteRollbackInfo(viewId: number): Promise<void>;

  // Rollback 백업 (TTL 없음 - Worker용)
  abstract setRollbackBackup(viewId: number, info: RollbackInfo): Promise<void>;
  abstract getRollbackBackup(viewId: number): Promise<RollbackInfo | null>;
  abstract deleteRollbackBackup(viewId: number): Promise<void>;
}

```

  

#### 2) RedisCacheRepository 구현

  

```typescript

// redis-cache.repository.ts
private readonly ROLLBACK_CACHE_TTL = 5 * 60; // 5분

async setRollbackInfo(
  viewId: number,
  rollbackInfo: RollbackInfo,
  ttl: number = this.ROLLBACK_CACHE_TTL
): Promise<void> {

  const key = `rollback:view:${viewId}`;
  await this.redis.setex(key, ttl, JSON.stringify(rollbackInfo));
}

async setRollbackBackup(
  viewId: number,
  rollbackInfo: RollbackInfo
): Promise<void> {
  const key = `backup:rollback:view:${viewId}`;
  await this.redis.set(key, JSON.stringify(rollbackInfo)); // TTL 없음
}
```

  

#### 3) SdkService 연동

```typescript
// sdk.service.ts
async recordView(dto: CreateViewLogDto, visitorId: string) {
  // ... ViewLog 저장 ..

  // Rollback 정보 Redis 저장 (TTL 5분)
  await this.cacheRepository.setRollbackInfo(viewId, {
    campaignId,
    cost,
    createdAt: new Date().toISOString(),

  });

  // Rollback 백업 정보 저장 (TTL 없음 - Worker용)
  await this.cacheRepository.setRollbackBackup(viewId, {
    campaignId,
    cost,
    createdAt: new Date().toISOString(),
  });

  return viewId;
}

  

async recordClick(dto: CreateClickLogDto): Promise<number | null> {
  // ... ClickLog 저장 ...

  // 클릭 시 Rollback 정보 + 백업 삭제 (Dismiss Beacon이 와도 무시되도록)
  await this.cacheRepository.deleteRollbackInfo(viewId);
  await this.cacheRepository.deleteRollbackBackup(viewId);

  return clickId;

}

  

async recordDismiss(dto: CreateDismissLogDto): Promise<void> {
  const rollbackInfo = await this.cacheRepository.getRollbackInfo(viewId);
  if (!rollbackInfo) return;

  const { campaignId, cost } = rollbackInfo;

  // Spent 롤백
  await this.campaignCacheRepository.decrementSpent(campaignId, cost);

  // Redis에서 Rollback 정보 + 백업 삭제
  await this.cacheRepository.deleteRollbackInfo(viewId);
  await this.cacheRepository.deleteRollbackBackup(viewId);
}

```

  

#### 4) RedisTTLWorker (Keyspace Notification)

  

```typescript

// redis-ttl.worker.ts

@Injectable()

export class RedisTTLWorker implements OnModuleInit, OnModuleDestroy {
  private subscriber: Redis | null = null;

  async onModuleInit() {

    // Keyspace Notification 활성화
    await this.redis.config('SET', 'notify-keyspace-events', 'Ex');

    // 별도 subscriber 연결
    this.subscriber = this.redis.duplicate();
    await this.subscriber.subscribe('__keyevent@0__:expired');

    this.subscriber.on('message', (channel, expiredKey) => {
      void this.handleExpiredKey(expiredKey);

    });
  }

  private async handleExpiredKey(expiredKey: string): Promise<void> {
    // rollback:view:{viewId} 형태인지 확인
    const match = expiredKey.match(/^rollback:view:(\d+)$/);
    if (!match) return;

    const viewId = parseInt(match[1], 10);

    // 백업 정보 조회
    const backup = await this.cacheRepository.getRollbackBackup(viewId);
    if (!backup) return; // 이미 처리됨 (클릭 또는 Dismiss)

    const { campaignId, cost } = backup;

    // 롤백 수행
    await this.campaignCacheRepository.decrementSpent(campaignId, cost);

    // 백업 삭제
    await this.cacheRepository.deleteRollbackBackup(viewId);

    this.logger.warn(

      `[TTL Worker] 롤백 완료: viewId=${viewId}, cost=-${cost} (Beacon 미수신)`
    );
  }
}
```

**핵심 포인트:**

- **SDK Beacon**: 정상 이탈 감지 → 즉시 롤백

- **TTL 백업**: Beacon 미수신 시(브라우저 강제 종료 등) → 5분 후 자동 롤백

- **이중 안전장치**: 어떤 경우에도 미클릭 광고 비용 복원 보장

---

## 🧪 테스트 방법

### 빌드 테스트

```bash

cd backend

npm run build

# Exit code: 0

```

  

### 동시 비딩 테스트 (Phase 1, 2, 3)

```bash

# 동시에 같은 캠페인으로 10개 비딩 요청

for i in {1..10}; do

  curl -X POST http://localhost:3000/sdk/decision \

    -H "Content-Type: application/json" \

    -d '{"blogKey": "xxx", "tags": ["react"], "isHighIntent": true}' &

done

wait

# Redis에서 dailySpent 확인
# 예산 초과 없이 정확히 (승리 횟수 × maxCpc) 만큼만 증가해야 함
```

  

### TTL 롤백 테스트 (Phase 5)

```bash

# 1. 광고 노출 (ViewLog 생성)

curl -X POST http://localhost:3000/sdk/campaign-view ...

# 2. 클릭 없이 5분 대기

# 3. TTL Worker 로그 확인

# "[TTL Worker] 롤백 완료: viewId=xxx, cost=-5000"

```

---

## 💬 To Reviewers

### 주요 확인사항

1. **Lua Script 정확성**: 예산 검증 로직 및 원자적 연산 검증
2. **롤백 안전성**: 음수 방지, 중복 롤백 방지 로직
3. **TTL Worker**: Keyspace Notification 설정 및 에러 핸들링
4. **동시성 처리**: `p-limit` 설정값 적절성

### 아키텍처 개선 효과

| 개선 영역     | Before                       | After                          |
| ------------- | ---------------------------- | ------------------------------ |
| 예산 초과     | 동시 비딩 시 발생 가능       | 원천 차단                      |
| 데이터 정합성 | 비딩 시점과 과금 시점 불일치 | 선제적 증가 + 롤백으로 일관성  |
| 장애 대응     | 수동 보정 필요               | TTL 자동 롤백 + 일일 정산 보정 |

### 기술적 의사결정

| 결정 사항                  | 선택                 | 근거                                    |
| -------------------------- | -------------------- | --------------------------------------- |
| 선제적 Spent 증가 위치     | Matcher → RTBService | 원자적 연산은 RTBService에서 통합 관리  |
| Spent 롤백 연산            | HINCRBY (증감)       | SET보다 동시성 안전, 다른 비딩과 독립적 |
| TTL 백업 키 분리           | rollback + backup    | TTL 만료 시 데이터 복구 필요            |
| Keyspace Notification 채널 | `__keyevent@0__`     | Redis 기본 설정, DB 0번 사용            |

### 향후 개선 사항

- [ ] Redis Cluster 환경에서 Lua Script 호환성 검증

- [ ] TTL Worker 모니터링 및 알림 추가

- [ ] 비딩 로그 배치 처리 (Redis Stream 활용 검토)

---

## 📁 변경 파일 목록

### Backend

| 파일                                                         | 변경 유형 | 설명                               |
| ------------------------------------------------------------ | --------- | ---------------------------------- |
| `src/rtb/matchers/xenova.matcher.ts`                         | MODIFY    | 예산 필터링 로직 추가              |
| `src/rtb/rtb.service.ts`                                     | MODIFY    | 선제적 증가 + 롤백 통합            |
| `src/campaign/scripts/lua-script.ts`                         | NEW       | Lua Script 정의                    |
| `src/campaign/repository/redis-campaign.cache.repository.ts` | MODIFY    | incrementSpent/decrementSpent 구현 |
| `src/cache/repository/cache.repository.interface.ts`         | MODIFY    | RollbackInfo 타입 + 백업 메서드    |
| `src/cache/repository/redis-cache.repository.ts`             | MODIFY    | Rollback/Backup 구현               |
| `src/cache/redis-ttl.worker.ts`                              | NEW       | TTL Worker 구현                    |
| `src/sdk/sdk.service.ts`                                     | MODIFY    | recordView/Click/Dismiss 연동      |

### Frontend (SDK)

| 파일                                  | 변경 유형 | 설명                          |
| ------------------------------------- | --------- | ----------------------------- |
| `src/ad-renderer/BannerAdRenderer.ts` | MODIFY    | Dismiss Beacon 전송 로직      |
| `src/BoostAdSDK.ts`                   | MODIFY    | 2차 광고 요청 시 Dismiss 처리 |

---

## 📊 Phase 흐름도

```mermaid

flowchart TD

    subgraph "Phase 1: 예산 필터링"
        A[비딩 요청] --> B{예산 여유 있음?}
        B -->|Yes| C[후보 포함]
        B -->|No| D[후보 제외]
    end

    subgraph "Phase 2: 선제적 Spent 증가"
        C --> E[Lua Script 실행]
        E --> F{원자적 검증 + 증가}
        F -->|성공| G[비딩 참여]
        F -->|실패| H[후보 제외]
    end

    subgraph "Phase 3: 비딩 패배 롤백"
        G --> I{비딩 결과}
        I -->|승리| J[Spent 유지]
        I -->|패배| K[Spent 롤백]
    end

    subgraph "Phase 5: TTL 백업"
        J --> L[ViewLog 생성]
        L --> M{사용자 행동}
        M -->|클릭| N[Rollback 삭제]
        M -->|이탈 Beacon| O[Dismiss 롤백]
        M -->|TTL 만료| P[Worker 롤백]
    end

```