### PR TITLE
[Feat] sdk 모바일 유의사항 추가

### DIFF
--- a/frontend/src/3_features/sdkInstallation/ui/SdkInfoBox.tsx
+++ b/frontend/src/3_features/sdkInstallation/ui/SdkInfoBox.tsx
@@ -42,20 +42,49 @@ export function SdkInfoBox({ mode }: SdkInfoBoxProps) {
   }
 
   return (
-    <div className="flex flex-col w-150 p-4 gap-4 bg-blue-100 border border-blue-300 rounded-xl">
-      <div className="flex flex-row gap-2 items-center">
-        <Icon.Info className="w-5 h-5 text-blue-500" />
-        <h3 className="font-semibold text-sm text-gray-900">SDK가 하는 일</h3>
+    <div className="flex flex-col w-150 gap-4">
+      <div className="flex flex-col p-4 gap-4 bg-blue-100 border border-blue-300 rounded-xl">
+        <div className="flex flex-row gap-2 items-center">
+          <Icon.Info className="w-5 h-5 text-blue-500" />
+          <h3 className="font-semibold text-sm text-gray-900">SDK가 하는 일</h3>
+        </div>
+
+        <ul className="grid grid-cols-2 gap-2 px-7">
+          {autoFeatures.map((feature, index) => (
+            <li key={index} className="flex flex-row gap-2 items-center">
+              <Icon.Circle className="w-1.5 h-1.5 text-blue-500" />
+              <span className="text-xs font-base text-gray-600">{feature}</span>
+            </li>
+          ))}
+        </ul>
       </div>
 
-      <ul className="grid grid-cols-2 gap-2 px-7">
-        {autoFeatures.map((feature, index) => (
-          <li key={index} className="flex flex-row gap-2 items-center">
-            <Icon.Circle className="w-1.5 h-1.5 text-blue-500" />
-            <span className="text-xs font-base text-gray-600">{feature}</span>
-          </li>
-        ))}
-      </ul>
+      <div className="flex flex-col p-4 gap-2 bg-yellow-50 border border-yellow-300 rounded-xl">
+        <div className="flex flex-row gap-2 items-center">
+          <Icon.Info className="w-5 h-5 text-yellow-600" />
+          <h3 className="font-semibold text-sm text-gray-900">
+            티스토리 모바일 환경 유의사항
+          </h3>
+        </div>
+        <p className="text-xs text-gray-600 pl-7">
+          티스토리 기본 설정에서는 모바일 접속 시 별도의 모바일 스킨이 적용되어
+          SDK 스크립트가 로드되지 않습니다.
+          <br />
+          <br />
+          <strong>모바일에서도 광고를 노출하려면:</strong>
+          <br />
+          티스토리 관리자 → 꾸미기 → 스킨 편집 → 모바일 설정에서
+          <br />
+          <span className="font-semibold text-yellow-700">
+            "모바일 웹 지원 안 함"
+          </span>
+          을 체크해주세요.
+          <br />
+          <br />
+          이렇게 설정하면 PC와 모바일 모두 동일한 스킨을 사용하여 SDK가 정상
+          작동합니다.
+        </p>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
<!-- PR 제목 예시 : [Feat] 로그인 기능 구현 -->
<!-- PR 제목은 위 형식을 참고하여 작성해주세요. -->
<!-- 필요 없는 내용은 지우고 작성해주세요 -->

## 🔗 관련 이슈

- close: #

---

## ✅ 작업 내용

- 티스토리 모바일 환경에서 SDK가 정상 작동하기 위한 설정 안내 추가
- 자동모드 SDK 설치 가이드 페이지에 "티스토리 모바일 환경 유의사항" 안내 박스 추가


## 📸 스크린샷 / 데모 (옵션)

<!-- UI 변경사항이나 새로운 기능의 동작을 시각적으로 보여주세요. -->
<img width="720" height="885" alt="스크린샷 2026-02-03 오전 8 12 54" src="https://github.com/user-attachments/assets/558c5634-6d3a-417d-8258-421961d31c2c" />

---

## 🧪 테스트 방법 (옵션)

<!-- 리뷰어가 기능을 테스트할 수 있도록 구체적인 테스트 방법을 설명해주세요. -->

1. 퍼블리셔 온보딩 → SDK 설치 가이드 페이지 진입
2. 자동모드 선택 상태에서 "티스토리 모바일 환경 유의사항" 안내 박스 노출 확인

---

## 💬 To Reviewers

티스토리 기본 설정에서는 모바일 접속 시 별도 모바일 스킨이 적용되어 사용자가 삽입한 SDK 스크립트가 로드되지 않는 문제가 있기때문에,
현재 저희 프로젝트 상에서는 퍼블리셔가 "모바일 웹 지원 안 함" 설정을 체크해야 PC/모바일 모두 동일한 스킨을 사용하여 SDK가 정상 작동하도록 해줘야하던 문제가 있습니다!
그래서 관련 안내사항을 자동모드(티스토리 전용)에서만 노출되도록 했습니다.
