### PR TITLE
[Feat] 상세 캠페인 spent 히스토리 구현

### DIFF
--- a/backend/src/campaign/campaign.controller.ts
+++ b/backend/src/campaign/campaign.controller.ts
@@ -64,18 +64,6 @@ export class CampaignController {
     return successResponse(campaign, '캠페인을 조회했습니다.');
   }
 
-  @Get(':id/stats')
-  async getCampaignStats(
-    @Req() req: AuthenticatedRequest,
-    @Param('id') id: string
-  ) {
-    const stats = await this.campaignService.getCampaignById(
-      id,
-      req.user.userId
-    );
-    return successResponse(stats, '캠페인 통계를 조회했습니다.');
-  }
-
   @Get(':id/click-history')
   async getClickHistory(
     @Req() req: AuthenticatedRequest,

--- a/backend/src/campaign/campaign.controller.ts
+++ b/backend/src/campaign/campaign.controller.ts
@@ -64,6 +64,34 @@ export class CampaignController {
     return successResponse(campaign, '캠페인을 조회했습니다.');
   }
 
+  @Get(':id/stats')
+  async getCampaignStats(
+    @Req() req: AuthenticatedRequest,
+    @Param('id') id: string
+  ) {
+    const stats = await this.campaignService.getCampaignById(
+      id,
+      req.user.userId
+    );
+    return successResponse(stats, '캠페인 통계를 조회했습니다.');
+  }
+
+  @Get(':id/click-history')
+  async getClickHistory(
+    @Req() req: AuthenticatedRequest,
+    @Param('id') id: string,
+    @Query('limit') limit?: number,
+    @Query('offset') offset?: number
+  ) {
+    const history = await this.campaignService.getClickHistory(
+      id,
+      req.user.userId,
+      limit ? Number(limit) : 5,
+      offset ? Number(offset) : 0
+    );
+    return successResponse(history, '클릭 히스토리를 조회했습니다.');
+  }
+
   @Put(':id')
   async updateCampaign(
     @Req() req: AuthenticatedRequest,

--- a/backend/src/log/repository/log.repository.interface.ts
+++ b/backend/src/log/repository/log.repository.interface.ts
@@ -34,7 +34,7 @@ export abstract class LogRepository {
   ): Promise<{
     logs: Array<{
       id: number;
-      createdAt: Date;
+      createdAt: Date | null;
       postUrl: string | null;
       blogName: string;
       cost: number;

--- a/backend/src/log/repository/log.repository.interface.ts
+++ b/backend/src/log/repository/log.repository.interface.ts
@@ -26,5 +26,23 @@ export abstract class LogRepository {
     campaignIds: string[]
   ): Promise<Map<string, number>>;
 
+  // 클릭 히스토리 조회 (캠페인 상세 페이지용)
+  abstract getClickHistoryByCampaignId(
+    campaignId: string,
+    limit: number,
+    offset: number
+  ): Promise<{
+    logs: Array<{
+      id: number;
+      createdAt: Date;
+      postUrl: string | null;
+      blogName: string;
+      cost: number;
+      behaviorScore: number | null;
+      isHighIntent: boolean;
+    }>;
+    total: number;
+  }>;
+
   abstract existsByViewId(viewId: number): Promise<boolean>;
 }

--- a/backend/src/log/repository/typeorm-log.repository.ts
+++ b/backend/src/log/repository/typeorm-log.repository.ts
@@ -134,13 +134,14 @@ export class TypeOrmLogRepository extends LogRepository {
       .where('view_log.campaign_id = :campaignId', { campaignId })
       .orderBy('click_log.created_at', 'DESC');
 
-    // Total count
     const total = await queryBuilder.getCount();
 
-    // Paginated logs
-    const results = await queryBuilder
-      .skip(offset)
-      .take(limit)
+    const results = await this.clickLogRepository
+      .createQueryBuilder('click_log')
+      .innerJoin('click_log.viewLog', 'view_log')
+      .innerJoin('Blog', 'blog', 'blog.id = view_log.blog_id')
+      .where('view_log.campaign_id = :campaignId', { campaignId })
+      .orderBy('click_log.created_at', 'DESC')
       .select('click_log.id', 'id')
       .addSelect('click_log.created_at', 'createdAt')
       .addSelect('view_log.post_url', 'postUrl')
@@ -148,6 +149,8 @@ export class TypeOrmLogRepository extends LogRepository {
       .addSelect('view_log.behavior_score', 'behaviorScore')
       .addSelect('view_log.is_high_intent', 'isHighIntent')
       .addSelect('blog.name', 'blogName')
+      .offset(offset)
+      .limit(limit)
       .getRawMany<{
         id: number;
         createdAt: Date | string;

--- a/backend/src/log/repository/typeorm-log.repository.ts
+++ b/backend/src/log/repository/typeorm-log.repository.ts
@@ -117,7 +117,7 @@ export class TypeOrmLogRepository extends LogRepository {
   ): Promise<{
     logs: Array<{
       id: number;
-      createdAt: Date;
+      createdAt: Date | null;
       postUrl: string | null;
       blogName: string;
       cost: number;
@@ -141,33 +141,31 @@ export class TypeOrmLogRepository extends LogRepository {
     const results = await queryBuilder
       .skip(offset)
       .take(limit)
-      .select([
-        'click_log.id',
-        'click_log.created_at',
-        'view_log.post_url',
-        'view_log.cost',
-        'view_log.behavior_score',
-        'view_log.is_high_intent',
-        'blog.name',
-      ])
+      .select('click_log.id', 'id')
+      .addSelect('click_log.created_at', 'createdAt')
+      .addSelect('view_log.post_url', 'postUrl')
+      .addSelect('view_log.cost', 'cost')
+      .addSelect('view_log.behavior_score', 'behaviorScore')
+      .addSelect('view_log.is_high_intent', 'isHighIntent')
+      .addSelect('blog.name', 'blogName')
       .getRawMany<{
-        click_log_id: number;
-        click_log_created_at: Date;
-        view_log_post_url: string | null;
-        view_log_cost: number;
-        view_log_behavior_score: number | null;
-        view_log_is_high_intent: boolean;
-        blog_name: string;
+        id: number;
+        createdAt: Date | string;
+        postUrl: string | null;
+        cost: number;
+        behaviorScore: number | null;
+        isHighIntent: boolean;
+        blogName: string;
       }>();
 
     const logs = results.map((row) => ({
-      id: row.click_log_id,
-      createdAt: new Date(row.click_log_created_at),
-      postUrl: row.view_log_post_url,
-      blogName: row.blog_name,
-      cost: row.view_log_cost,
-      behaviorScore: row.view_log_behavior_score,
-      isHighIntent: row.view_log_is_high_intent,
+      id: row.id,
+      createdAt: row.createdAt ? new Date(row.createdAt) : null,
+      postUrl: row.postUrl,
+      blogName: row.blogName,
+      cost: row.cost,
+      behaviorScore: row.behaviorScore,
+      isHighIntent: Boolean(row.isHighIntent),
     }));
 
     return { logs, total };

--- a/frontend/src/2_pages/campaignDetail/ui/CampaignDetailPage.tsx
+++ b/frontend/src/2_pages/campaignDetail/ui/CampaignDetailPage.tsx
@@ -130,25 +130,30 @@ export function CampaignDetailPage() {
 
   return (
     <div className="flex flex-col gap-6 px-8 py-8 bg-gray-100 min-h-screen">
-      <CampaignDetailHeader
-        title={campaign.title}
-        status={campaign.status}
-        onBack={handleBack}
-        onPause={handlePause}
-        onEdit={handleEdit}
-        isPauseLoading={isPauseLoading}
-      />
-
-      <CampaignInfoCard
-        image={campaign.image}
-        title={campaign.title}
-        content={campaign.content}
-        tags={campaign.tags}
-        url={campaign.url}
-        isHighIntent={campaign.isHighIntent}
-        startDate={campaign.startDate}
-        endDate={campaign.endDate}
-      />
+      {/* 헤더 + 기본정보 카드를 하나의 카드로 묶기 */}
+      <div className="bg-white rounded-2xl shadow-sm">
+        <div className="px-6 py-3 border-b border-gray-100">
+          <CampaignDetailHeader
+            title={campaign.title}
+            status={campaign.status}
+            onBack={handleBack}
+            onPause={handlePause}
+            onEdit={handleEdit}
+            isPauseLoading={isPauseLoading}
+          />
+        </div>
+        <CampaignInfoCard
+          image={campaign.image}
+          title={campaign.title}
+          content={campaign.content}
+          tags={campaign.tags}
+          url={campaign.url}
+          isHighIntent={campaign.isHighIntent}
+          startDate={campaign.startDate}
+          endDate={campaign.endDate}
+          noBorder
+        />
+      </div>
 
       <CampaignMetricsCards
         clicks={campaign.clicks}

--- a/frontend/src/3_features/campaignDetail/ui/CampaignInfoCard.tsx
+++ b/frontend/src/3_features/campaignDetail/ui/CampaignInfoCard.tsx
@@ -11,6 +11,7 @@ interface CampaignInfoCardProps {
   isHighIntent: boolean;
   startDate: string;
   endDate: string;
+  noBorder?: boolean;
 }
 
 function formatDate(dateString: string): string {
@@ -35,9 +36,14 @@ export function CampaignInfoCard({
   isHighIntent,
   startDate,
   endDate,
+  noBorder = false,
 }: CampaignInfoCardProps) {
   return (
-    <div className="p-6 bg-white border border-gray-200 rounded-xl">
+    <div
+      className={
+        noBorder ? 'p-6' : 'p-6 bg-white border border-gray-200 rounded-xl'
+      }
+    >
       <p className="text-sm text-gray-500 mb-4">기본 정보</p>
 
       <div className="flex gap-6">

--- a/frontend/src/3_features/campaignDetail/ui/SpendingLogCard/SpendingLogCard.tsx
+++ b/frontend/src/3_features/campaignDetail/ui/SpendingLogCard/SpendingLogCard.tsx
@@ -1,4 +1,6 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { apiClient } from '@shared/lib/api';
 import { Pagination } from '@shared/ui/Pagination';
 import { SpendingLogTableHeader } from './SpendingLogTableHeader';
 import {
@@ -6,56 +8,65 @@ import {
   type SpendingLogRowData,
 } from './SpendingLogTableRow';
 
-// Mock 데이터 생성
-function generateMockData(): SpendingLogRowData[] {
-  const blogs = [
-    { name: '데브로그', url: 'https://devlog.io/react-hooks-guide' },
-    { name: '코딩하는 플레미', url: 'https://flemi.dev/typescript-tips' },
-    { name: '프론트엔드 마스터', url: 'https://femaster.kr/nextjs-tutorial' },
-    { name: '백엔드 개발 일지', url: 'https://backend-daily.com/nodejs-best' },
-    { name: 'JS 마스터 블로그', url: 'https://jsmaster.blog/es2024-features' },
-    { name: '테크 인사이트', url: 'https://techinsight.io/web-performance' },
-    { name: '개발자 K', url: 'https://dev-k.blog/clean-code-tips' },
-    { name: '코드랩', url: 'https://codelab.kr/docker-kubernetes' },
-  ];
-
-  const cpcValues = [500, 550, 480, 620, 450, 580, 520, 490];
-  const now = new Date();
-  const logs: SpendingLogRowData[] = [];
-
-  for (let i = 0; i < 15; i++) {
-    const date = new Date(now);
-    date.setMinutes(date.getMinutes() - i * 8);
-
-    const isHighIntent = i % 3 !== 1;
-    const blog = blogs[i % blogs.length];
-
-    logs.push({
-      id: i + 1,
-      createdAt: date.toISOString(),
-      postUrl: blog.url,
-      blogName: blog.name,
-      cpc: cpcValues[i % cpcValues.length],
-      behaviorScore: isHighIntent ? Math.floor(Math.random() * 25) + 75 : null,
-      isHighIntent,
-    });
-  }
-
-  return logs;
+interface ClickHistoryResponse {
+  logs: Array<{
+    id: number;
+    createdAt: string;
+    postUrl: string | null;
+    blogName: string;
+    cost: number;
+    behaviorScore: number | null;
+    isHighIntent: boolean;
+  }>;
+  total: number;
+  hasMore: boolean;
 }
 
-const MOCK_DATA = generateMockData();
-
 export function SpendingLogCard() {
+  const { id: campaignId } = useParams<{ id: string }>();
+  const [logs, setLogs] = useState<SpendingLogRowData[]>([]);
+  const [total, setTotal] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
   const [offset, setOffset] = useState(0);
   const limit = 5;
 
-  const total = MOCK_DATA.length;
   const hasMore = offset + limit < total;
   const currentPage = Math.floor(offset / limit) + 1;
   const totalPages = Math.ceil(total / limit);
 
-  const logs = MOCK_DATA.slice(offset, offset + limit);
+  useEffect(() => {
+    const fetchClickHistory = async () => {
+      if (!campaignId) return;
+
+      try {
+        setIsLoading(true);
+        const data = await apiClient<ClickHistoryResponse>(
+          `/api/campaigns/${campaignId}/click-history?limit=${limit}&offset=${offset}`
+        );
+
+        const mappedLogs: SpendingLogRowData[] = data.logs.map((log) => ({
+          id: log.id,
+          createdAt: log.createdAt,
+          postUrl: log.postUrl || '',
+          blogName: log.blogName,
+          cpc: log.cost,
+          behaviorScore: log.behaviorScore,
+          isHighIntent: log.isHighIntent,
+        }));
+
+        setLogs(mappedLogs);
+        setTotal(data.total);
+      } catch (error) {
+        console.error('클릭 히스토리 조회 실패:', error);
+        setLogs([]);
+        setTotal(0);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchClickHistory();
+  }, [campaignId, offset]);
 
   const handlePrevPage = () => {
     if (offset > 0) {
@@ -81,9 +92,21 @@ export function SpendingLogCard() {
       <table className="w-full">
         <SpendingLogTableHeader />
         <tbody>
-          {logs.map((log) => (
-            <SpendingLogTableRow key={log.id} log={log} />
-          ))}
+          {isLoading ? (
+            <tr>
+              <td colSpan={5} className="p-8 text-center text-gray-500">
+                로딩 중...
+              </td>
+            </tr>
+          ) : logs.length === 0 ? (
+            <tr>
+              <td colSpan={5} className="p-8 text-center text-gray-500">
+                클릭 기록이 없습니다
+              </td>
+            </tr>
+          ) : (
+            logs.map((log) => <SpendingLogTableRow key={log.id} log={log} />)
+          )}
         </tbody>
       </table>
 

--- a/frontend/src/3_features/campaignDetail/ui/SpendingLogCard/SpendingLogTableRow.tsx
+++ b/frontend/src/3_features/campaignDetail/ui/SpendingLogCard/SpendingLogTableRow.tsx
@@ -15,8 +15,22 @@ interface SpendingLogTableRowProps {
   log: SpendingLogRowData;
 }
 
-function formatDateTime(timestamp: string): string {
-  const date = new Date(timestamp);
+function formatDateTime(timestamp: string | null): string {
+  if (!timestamp) {
+    return '-';
+  }
+
+  // ISO 8601 형식이 아닌 경우 (MySQL DATETIME) 'T'를 추가하여 파싱
+  const isoString = timestamp.includes('T')
+    ? timestamp
+    : timestamp.replace(' ', 'T');
+  const date = new Date(isoString);
+
+  // Invalid Date 체크
+  if (isNaN(date.getTime())) {
+    return '-';
+  }
+
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, '0');
   const day = String(date.getDate()).padStart(2, '0');


### PR DESCRIPTION
## 🔗 관련 이슈

---

## ✅ 작업 내용

### 주요 검토 파일:

**Backend - 클릭 히스토리 API**

- `backend/src/campaign/campaign.controller.ts` - 클릭 히스토리 엔드포인트 추가
- `backend/src/campaign/campaign.service.ts` - 클릭 히스토리 조회 로직
- `backend/src/log/repository/log.repository.interface.ts` - 클릭 히스토리 쿼리 인터페이스
- `backend/src/log/repository/typeorm-log.repository.ts` - 3 번 JOIN 쿼리 구현

**Backend - Spent 통계 DB 기반 전환**

- `backend/src/campaign/campaign.service.ts` - DB Campaign 테이블 기반 Spent 조회

**Frontend - 캠페인 상세 페이지 UI 개선**

- `frontend/src/3_features/campaignDetail/ui/SpendingLogCard/` - 클릭 히스토리 테이블 컴포넌트
- `frontend/src/3_features/campaignDetail/ui/CampaignInfoCard.tsx` - 헤더 통합 카드
- `frontend/src/3_features/campaignDetail/ui/SpendingLogCard/SpendingLogTableRow.tsx` - 날짜 파싱 수정

---

## 1. 캠페인 상세 페이지 UI 통합

기존 캠페인 상세 페이지는 헤더와 기본 정보 카드가 분리되어 있었습니다. 이를 하나의 통합 카드로 개선해보았습니다!

- 기존
<img width="1428" height="844" alt="image" src="https://github.com/user-attachments/assets/3caa1e80-a75c-4796-995a-e750924fceba" />

- 현재
<img width="1430" height="803" alt="image" src="https://github.com/user-attachments/assets/5ef92b29-f555-450a-86a1-de95db15f207" />


---

## 2. DB Campaign 테이블 기반 Spent 통계 전환

DB Campaign 테이블의 `dailySpent`, `totalSpent` 필드를 직접 사용하도록하여 Cron Job을 통한 db 동기화가 완료되면 바로 적용될 것 같습니다!

- DB Campaign 테이블의 `dailySpent`, `totalSpent` 직접 조회
- Cron Job이 1분마다 Redis → DB 동기화 수행
- 확정된 금액만 표시 (안정적 통계)

---

## 3. 클릭 히스토리 API 구현

광고주가 캠페인별 실제 클릭 내역을 확인할 수 있도록 클릭 히스토리 조회 API를 구현

### 데이터 조회 로직

**3-way JOIN 쿼리**

- `ClickLog` → `ViewLog` → `Blog` 순서로 INNER JOIN
- `campaignId` 기준 필터링 (소유권 검증 포함)
- `created_at` 역순 정렬 (최신 클릭 우선)
- 페이지네이션 적용

---

## 📸 스크린샷 / 데모 (옵션)

<img width="1179" height="551" alt="image" src="https://github.com/user-attachments/assets/a3ab6313-10ba-43e4-82b3-90303372df6e" />

