### PR TITLE
[Feat] 모니터링 아키텍처 구축

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -33,6 +33,7 @@
         "jose": "^6.1.3",
         "mysql2": "^3.16.0",
         "p-limit": "^7.2.0",
+        "prom-client": "^15.1.3",
         "redis": "^4.7.1",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
@@ -243,7 +244,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -744,6 +744,7 @@
       "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.3.3.tgz",
       "integrity": "sha512-JsXDL70gQ+1Vc2W/KUFfkAJzgb4puKwwKehNLuB+HrNKWf91O736kGfxn4KujXCCSuh6mRRL4XEB0PkAFjWS0A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "hashery": "^1.3.0",
         "keyv": "^5.5.5"
@@ -2123,7 +2124,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
       "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
@@ -2316,7 +2318,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.9.tgz",
       "integrity": "sha512-zDntUTReRbAThIfSp3dQZ9kKqI+LjgLp5YZN5c1bgNRDuoeLySAoZg46Bg1a+uV8TMgIRziHocglKGNzr6l+bQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "21.1.0",
         "iterare": "1.2.1",
@@ -2364,7 +2365,6 @@
       "integrity": "sha512-a00B0BM4X+9z+t3UxJqIZlemIwCQdYoPKrMcM+ky4z3pkqqG1eTWexjs+YXpGObnLnjtMPVKWlcZHp3adDYvUw==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -2418,7 +2418,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.12.tgz",
       "integrity": "sha512-GYK/vHI0SGz5m8mxr7v3Urx8b9t78Cf/dj5aJMZlGd9/1D9OI1hAl00BaphjEXINUJ/BQLxIlF2zUjrYsd6enQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cors": "2.8.5",
         "express": "5.2.1",
@@ -2625,6 +2624,15 @@
       "engines": {
         "node": "^14.18.0 || >=16.10.0",
         "npm": ">=5.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@paralleldrive/cuid2": {
@@ -2944,7 +2952,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -2974,7 +2981,6 @@
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -3089,7 +3095,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.3.tgz",
       "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3228,7 +3233,6 @@
       "integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.49.0",
         "@typescript-eslint/types": "8.49.0",
@@ -3924,7 +3928,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3974,7 +3977,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4511,6 +4513,12 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -4590,7 +4598,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4663,7 +4670,6 @@
       "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-5.67.1.tgz",
       "integrity": "sha512-ELJEAzwzesgFxk29emvnAakqrwdBEhEyfZREPQ8pbG4ALVz/mk/AhfuChzxkFpJ7SfL2qclPHbiUGBZzaqcLvg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cron-parser": "4.9.0",
         "ioredis": "5.9.2",
@@ -4880,7 +4886,6 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -4934,15 +4939,13 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/class-validator": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.3.tgz",
       "integrity": "sha512-rXXekcjofVN1LTOSw+u4u9WXVEUvNBVjORW154q/IdmYWy1nMbOU9aNtZB0t8m+FJQ9q91jlr2f9CwwUFdFMRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -5736,7 +5739,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5797,7 +5799,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -6803,6 +6804,7 @@
       "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.4.0.tgz",
       "integrity": "sha512-Wn2i1In6XFxl8Az55kkgnFRiAlIAushzh26PTjL2AKtQcEfXrcLa7Hn5QOWGZEf3LU057P9TwwZjFyxfS1VuvQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "hookified": "^1.14.0"
       },
@@ -7315,7 +7317,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -9499,7 +9500,6 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9549,6 +9549,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
       }
     },
     "node_modules/protobufjs": {
@@ -9802,7 +9815,6 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
       "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2",
         "generic-pool": "3.9.0",
@@ -10698,6 +10710,15 @@
         "streamx": "^2.15.0"
       }
     },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
+      }
+    },
     "node_modules/terser": {
       "version": "5.44.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.44.1.tgz",
@@ -10758,7 +10779,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -11109,7 +11129,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -11282,7 +11301,6 @@
       "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.28.tgz",
       "integrity": "sha512-6GH7wXhtfq2D33ZuRXYwIsl/qM5685WZcODZb7noOOcRMteM9KF2x2ap3H0EBjnSV0VO4gNAfJT5Ukp0PkOlvg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^4.2.0",
@@ -11488,7 +11506,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11788,7 +11805,6 @@
       "integrity": "sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -11858,7 +11874,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -44,6 +44,7 @@
     "jose": "^6.1.3",
     "mysql2": "^3.16.0",
     "p-limit": "^7.2.0",
+    "prom-client": "^15.1.3",
     "redis": "^4.7.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -21,6 +21,7 @@ import { ImageModule } from './image/image.module';
 import { RedisModule } from './redis/redis.module';
 import { QueueModule } from './queue/queue.module';
 import { PaymentModule } from './payment/payment.module';
+import { MetricsModule } from './metrics/metrics.module';
 
 @Module({
   imports: [
@@ -55,6 +56,7 @@ import { PaymentModule } from './payment/payment.module';
     RedisModule,
     QueueModule,
     PaymentModule,
+    MetricsModule,
     // QueueModule,
   ],
   controllers: [],

--- a/backend/src/bid-log/bid-log.module.ts
+++ b/backend/src/bid-log/bid-log.module.ts
@@ -8,6 +8,7 @@ import { TypeOrmBidLogRepository } from './repositories/typeorm-bid-log.reposito
 import { BidLogEntity } from './entities/bid-log.entity';
 import { CampaignModule } from 'src/campaign/campaign.module';
 import { BlogModule } from 'src/blog/blog.module';
+import { MetricsModule } from 'src/metrics/metrics.module';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { BlogModule } from 'src/blog/blog.module';
     // EventEmitterModule은 AppModule에서 전역 등록됨
     CampaignModule,
     BlogModule,
+    MetricsModule,
   ],
   controllers: [BidLogController],
   providers: [

--- a/backend/src/bid-log/bid-log.service.ts
+++ b/backend/src/bid-log/bid-log.service.ts
@@ -6,6 +6,7 @@ import { BidLogRepository } from './repositories/bid-log.repository.interface';
 import { BidLogDataDto, BidLogItemDto } from './dto/bid-log-response.dto';
 import { CampaignRepository } from 'src/campaign/repository/campaign.repository.interface';
 import { BlogRepository } from 'src/blog/repository/blog.repository.interface';
+import { MetricsService } from 'src/metrics/metrics.service';
 
 @Injectable()
 export class BidLogService {
@@ -13,7 +14,8 @@ export class BidLogService {
     private readonly bidLogRepository: BidLogRepository,
     private readonly campaignRepository: CampaignRepository,
     private readonly blogRepository: BlogRepository,
-    private readonly eventEmitter: EventEmitter2
+    private readonly eventEmitter: EventEmitter2,
+    private readonly metricsService: MetricsService
   ) {}
 
   async getRealtimeBidLogs(
@@ -91,9 +93,10 @@ export class BidLogService {
       };
 
       this.eventEmitter.on(`bid.created.${userId}`, listener);
-
+      this.metricsService.incSseConnections('bidlog');
       return () => {
         this.eventEmitter.off(`bid.created.${userId}`, listener);
+        this.metricsService.decSseConnections('bidlog');
       };
     });
   }

--- a/backend/src/metrics/http-metrics.interceptor.ts
+++ b/backend/src/metrics/http-metrics.interceptor.ts
@@ -1,15 +1,19 @@
 import {
   CallHandler,
   ExecutionContext,
+  HttpException,
   Injectable,
   NestInterceptor,
 } from '@nestjs/common';
 import { type Request, type Response } from 'express';
-import { Observable } from 'rxjs';
+import { Observable, tap } from 'rxjs';
+import { MetricsService } from './metrics.service';
 
 type RouteLike = { path?: unknown };
 @Injectable()
 export class HttpMetricsInterceptor implements NestInterceptor {
+  constructor(private readonly metricsService: MetricsService) {}
+
   intercept(
     context: ExecutionContext,
     next: CallHandler<any>
@@ -17,8 +21,37 @@ export class HttpMetricsInterceptor implements NestInterceptor {
     const req = context.switchToHttp().getRequest<Request>();
     const res = context.switchToHttp().getResponse<Response>();
     const startedAt = process.hrtime.bigint();
+
+    const path = this.getRoutePath(req);
+
+    if (path === '/api/metrics' || path === '/healthz') return next.handle();
+
+    return next.handle().pipe(
+      tap({
+        next: () => this.record(req.method, path, res.statusCode, startedAt),
+        error: (error) => {
+          const statusCode =
+            error instanceof HttpException ? error.getStatus() : 500;
+          this.record(req.method, path, statusCode, startedAt);
+        },
+      })
+    );
   }
 
+  private record(
+    method: string,
+    route: string,
+    statusCode: number,
+    startedAt: bigint
+  ) {
+    const durationMs = Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+    this.metricsService.recordHttpRequest(
+      method,
+      route,
+      statusCode,
+      durationMs
+    );
+  }
   private getRoutePath(req: Request): string {
     const route = req.route as RouteLike | undefined;
     const routePath = route?.path;

--- a/backend/src/metrics/http-metrics.interceptor.ts
+++ b/backend/src/metrics/http-metrics.interceptor.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class HttpMetricsInterceptor {}

--- a/backend/src/metrics/http-metrics.interceptor.ts
+++ b/backend/src/metrics/http-metrics.interceptor.ts
@@ -4,14 +4,29 @@ import {
   Injectable,
   NestInterceptor,
 } from '@nestjs/common';
+import { type Request, type Response } from 'express';
 import { Observable } from 'rxjs';
 
+type RouteLike = { path?: unknown };
 @Injectable()
 export class HttpMetricsInterceptor implements NestInterceptor {
   intercept(
     context: ExecutionContext,
     next: CallHandler<any>
   ): Observable<any> | Promise<Observable<any>> {
-    throw new Error('Method not implemented.');
+    const req = context.switchToHttp().getRequest<Request>();
+    const res = context.switchToHttp().getResponse<Response>();
+    const startedAt = process.hrtime.bigint();
+  }
+
+  private getRoutePath(req: Request): string {
+    const route = req.route as RouteLike | undefined;
+    const routePath = route?.path;
+
+    if (typeof routePath === 'string') {
+      return `${req.baseUrl ?? ''}${routePath}`;
+    }
+
+    return req.path ?? 'unknown';
   }
 }

--- a/backend/src/metrics/http-metrics.interceptor.ts
+++ b/backend/src/metrics/http-metrics.interceptor.ts
@@ -1,4 +1,17 @@
-import { Injectable } from '@nestjs/common';
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
 
 @Injectable()
-export class HttpMetricsInterceptor {}
+export class HttpMetricsInterceptor implements NestInterceptor {
+  intercept(
+    context: ExecutionContext,
+    next: CallHandler<any>
+  ): Observable<any> | Promise<Observable<any>> {
+    throw new Error('Method not implemented.');
+  }
+}

--- a/backend/src/metrics/http-metrics.interceptor.ts
+++ b/backend/src/metrics/http-metrics.interceptor.ts
@@ -24,7 +24,12 @@ export class HttpMetricsInterceptor implements NestInterceptor {
 
     const path = this.getRoutePath(req);
 
-    if (path === '/api/metrics' || path === '/healthz') return next.handle();
+    if (
+      path === '/api/metrics' ||
+      path === '/healthz' ||
+      path === '/api/advertiser/bids/stream'
+    )
+      return next.handle();
 
     return next.handle().pipe(
       tap({

--- a/backend/src/metrics/metrics.controller.ts
+++ b/backend/src/metrics/metrics.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('metrics')
+export class MetricsController {}

--- a/backend/src/metrics/metrics.controller.ts
+++ b/backend/src/metrics/metrics.controller.ts
@@ -1,7 +1,8 @@
 import { Controller, Get, Res } from '@nestjs/common';
 import { MetricsService } from './metrics.service';
 import { type Response } from 'express';
-
+import { Public } from 'src/auth/decorators/public.decorator';
+@Public()
 @Controller('metrics')
 export class MetricsController {
   constructor(private readonly metricsService: MetricsService) {}

--- a/backend/src/metrics/metrics.controller.ts
+++ b/backend/src/metrics/metrics.controller.ts
@@ -8,6 +8,7 @@ export class MetricsController {
 
   @Get()
   async getMetrics(@Res({ passthrough: true }) res: Response) {
+    res.setHeader('Content-Type', this.metricsService.getContentType());
     return await this.metricsService.getMetrics();
   }
 }

--- a/backend/src/metrics/metrics.controller.ts
+++ b/backend/src/metrics/metrics.controller.ts
@@ -1,4 +1,13 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, Res } from '@nestjs/common';
+import { MetricsService } from './metrics.service';
+import { type Response } from 'express';
 
 @Controller('metrics')
-export class MetricsController {}
+export class MetricsController {
+  constructor(private readonly metricsService: MetricsService) {}
+
+  @Get()
+  async getMetrics(@Res({ passthrough: true }) res: Response) {
+    return await this.metricsService.getMetrics();
+  }
+}

--- a/backend/src/metrics/metrics.module.ts
+++ b/backend/src/metrics/metrics.module.ts
@@ -1,0 +1,4 @@
+import { Module } from '@nestjs/common';
+
+@Module({})
+export class MetricsModule {}

--- a/backend/src/metrics/metrics.module.ts
+++ b/backend/src/metrics/metrics.module.ts
@@ -4,6 +4,6 @@ import { MetricsService } from './metrics.service';
 
 @Module({
   controllers: [MetricsController],
-  providers: [MetricsService]
+  providers: [MetricsService],
 })
 export class MetricsModule {}

--- a/backend/src/metrics/metrics.module.ts
+++ b/backend/src/metrics/metrics.module.ts
@@ -1,4 +1,7 @@
 import { Module } from '@nestjs/common';
+import { MetricsController } from './metrics.controller';
 
-@Module({})
+@Module({
+  controllers: [MetricsController]
+})
 export class MetricsModule {}

--- a/backend/src/metrics/metrics.module.ts
+++ b/backend/src/metrics/metrics.module.ts
@@ -10,5 +10,6 @@ import { HttpMetricsInterceptor } from './http-metrics.interceptor';
     MetricsService,
     { provide: APP_INTERCEPTOR, useClass: HttpMetricsInterceptor },
   ],
+  exports: [MetricsService],
 })
 export class MetricsModule {}

--- a/backend/src/metrics/metrics.module.ts
+++ b/backend/src/metrics/metrics.module.ts
@@ -1,9 +1,14 @@
 import { Module } from '@nestjs/common';
 import { MetricsController } from './metrics.controller';
 import { MetricsService } from './metrics.service';
+import { APP_INTERCEPTOR } from '@nestjs/core';
+import { HttpMetricsInterceptor } from './http-metrics.interceptor';
 
 @Module({
   controllers: [MetricsController],
-  providers: [MetricsService],
+  providers: [
+    MetricsService,
+    { provide: APP_INTERCEPTOR, useClass: HttpMetricsInterceptor },
+  ],
 })
 export class MetricsModule {}

--- a/backend/src/metrics/metrics.module.ts
+++ b/backend/src/metrics/metrics.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
 import { MetricsController } from './metrics.controller';
+import { MetricsService } from './metrics.service';
 
 @Module({
-  controllers: [MetricsController]
+  controllers: [MetricsController],
+  providers: [MetricsService]
 })
 export class MetricsModule {}

--- a/backend/src/metrics/metrics.service.ts
+++ b/backend/src/metrics/metrics.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class MetricsService {}

--- a/backend/src/metrics/metrics.service.ts
+++ b/backend/src/metrics/metrics.service.ts
@@ -4,6 +4,7 @@ import {
   Registry,
   Histogram,
   collectDefaultMetrics,
+  Gauge,
 } from 'prom-client';
 
 type HttpLabel = 'method' | 'route' | 'status_code';
@@ -25,6 +26,12 @@ export class MetricsService {
     labelNames: ['method', 'route', 'status_code'],
     buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5],
     registers: [this.registry],
+  });
+
+  private readonly sseConnections = new Gauge<'endpoint'>({
+    name: 'boostad_sse_connections',
+    help: 'Current SSE connections',
+    labelNames: ['endpoint'],
   });
 
   constructor() {

--- a/backend/src/metrics/metrics.service.ts
+++ b/backend/src/metrics/metrics.service.ts
@@ -68,6 +68,13 @@ export class MetricsService {
     this.sseConnections.dec({ stream });
   }
 
+  incInFlightHttpRequest() {
+    this.inFlightHttpRequests.inc();
+  }
+  decInFlightHttpRequest() {
+    this.inFlightHttpRequests.dec();
+  }
+
   getContentType(): string {
     return this.registry.contentType;
   }

--- a/backend/src/metrics/metrics.service.ts
+++ b/backend/src/metrics/metrics.service.ts
@@ -46,6 +46,10 @@ export class MetricsService {
     this.httpRequestDurationSeconds.observe(labels, durationMs / 1000);
   }
 
+  getContentType(): string {
+    return this.registry.contentType;
+  }
+
   async getMetrics(): Promise<string> {
     return await this.registry.metrics(); // 레지스트리에 등록된 모든 메트릭 텍스트로 직렬화해서 리턴
   }

--- a/backend/src/metrics/metrics.service.ts
+++ b/backend/src/metrics/metrics.service.ts
@@ -1,18 +1,20 @@
 import { Injectable } from '@nestjs/common';
 import { Counter, Registry, Histogram } from 'prom-client';
 
+type HttpLabel = 'method' | 'route' | 'status_code';
+
 @Injectable()
 export class MetricsService {
   private readonly registry = new Registry();
 
-  private readonly httpRequestsTotal = new Counter({
+  private readonly httpRequestsTotal = new Counter<HttpLabel>({
     name: 'boostad_http_requests_total',
     help: 'Total number of HTTP requests',
     labelNames: ['method', 'route', 'status_code'],
     registers: [this.registry],
   });
 
-  private readonly httpRequestDurationSeconds = new Histogram({
+  private readonly httpRequestDurationSeconds = new Histogram<HttpLabel>({
     name: 'boostad_http_request_duration_seconds',
     help: 'HTTP request duration in seconds',
     labelNames: ['method', 'route', 'status_code'],

--- a/backend/src/metrics/metrics.service.ts
+++ b/backend/src/metrics/metrics.service.ts
@@ -15,14 +15,14 @@ export class MetricsService {
 
   private readonly httpRequestsTotal = new Counter<HttpLabel>({
     name: 'boostad_http_requests_total',
-    help: 'Total number of HTTP requests',
+    help: 'Http 요청 수 총합',
     labelNames: ['method', 'route', 'status_code'],
     registers: [this.registry],
   });
 
   private readonly httpRequestDurationSeconds = new Histogram<HttpLabel>({
     name: 'boostad_http_request_duration_seconds',
-    help: 'HTTP request duration in seconds',
+    help: 'HTTP 요청 처리 시간',
     labelNames: ['method', 'route', 'status_code'],
     buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5],
     registers: [this.registry],
@@ -30,8 +30,14 @@ export class MetricsService {
 
   private readonly sseConnections = new Gauge<'stream'>({
     name: 'boostad_sse_connections',
-    help: 'Current SSE connections',
+    help: '현재 SSE 커넥션 개수',
     labelNames: ['stream'],
+    registers: [this.registry],
+  });
+
+  private readonly inFlightHttpRequests = new Gauge({
+    name: 'boostad_http_in_flight_requests',
+    help: '현재 처리중인 Http 요청 수',
     registers: [this.registry],
   });
 

--- a/backend/src/metrics/metrics.service.ts
+++ b/backend/src/metrics/metrics.service.ts
@@ -32,6 +32,7 @@ export class MetricsService {
     name: 'boostad_sse_connections',
     help: 'Current SSE connections',
     labelNames: ['endpoint'],
+    registers: [this.registry],
   });
 
   constructor() {

--- a/backend/src/metrics/metrics.service.ts
+++ b/backend/src/metrics/metrics.service.ts
@@ -40,9 +40,13 @@ export class MetricsService {
     route: string,
     status_code: number,
     durationMs: number
-  ) {
+  ): void {
     const labels = { method, route, status_code };
     this.httpRequestsTotal.inc(labels);
     this.httpRequestDurationSeconds.observe(labels, durationMs / 1000);
+  }
+
+  async getMetrics(): Promise<string> {
+    return await this.registry.metrics(); // 레지스트리에 등록된 모든 메트릭 텍스트로 직렬화해서 리턴
   }
 }

--- a/backend/src/metrics/metrics.service.ts
+++ b/backend/src/metrics/metrics.service.ts
@@ -1,4 +1,22 @@
 import { Injectable } from '@nestjs/common';
+import { Counter, Registry, Histogram } from 'prom-client';
 
 @Injectable()
-export class MetricsService {}
+export class MetricsService {
+  private readonly registry = new Registry();
+
+  private readonly httpRequestsTotal = new Counter({
+    name: 'boostad_http_requests_total',
+    help: 'Total number of HTTP requests',
+    labelNames: ['method', 'route', 'status_code'],
+    registers: [this.registry],
+  });
+
+  private readonly httpRequestDurationSeconds = new Histogram({
+    name: 'boostad_http_request_duration_seconds',
+    help: 'HTTP request duration in seconds',
+    labelNames: ['method', 'route', 'status_code'],
+    buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5],
+    registers: [this.registry],
+  });
+}

--- a/backend/src/metrics/metrics.service.ts
+++ b/backend/src/metrics/metrics.service.ts
@@ -34,4 +34,15 @@ export class MetricsService {
       labels: { service: 'backend' },
     });
   }
+
+  recordHttpRequest(
+    method: string,
+    route: string,
+    status_code: number,
+    durationMs: number
+  ) {
+    const labels = { method, route, status_code };
+    this.httpRequestsTotal.inc(labels);
+    this.httpRequestDurationSeconds.observe(labels, durationMs / 1000);
+  }
 }

--- a/backend/src/metrics/metrics.service.ts
+++ b/backend/src/metrics/metrics.service.ts
@@ -53,6 +53,14 @@ export class MetricsService {
     this.httpRequestDurationSeconds.observe(labels, durationMs / 1000);
   }
 
+  incSseConnections(endpoint: string) {
+    this.sseConnections.inc({ endpoint });
+  }
+
+  decSseConnections(endpoint: string) {
+    this.sseConnections.dec({ endpoint });
+  }
+
   getContentType(): string {
     return this.registry.contentType;
   }

--- a/backend/src/metrics/metrics.service.ts
+++ b/backend/src/metrics/metrics.service.ts
@@ -28,10 +28,10 @@ export class MetricsService {
     registers: [this.registry],
   });
 
-  private readonly sseConnections = new Gauge<'endpoint'>({
+  private readonly sseConnections = new Gauge<'stream'>({
     name: 'boostad_sse_connections',
     help: 'Current SSE connections',
-    labelNames: ['endpoint'],
+    labelNames: ['stream'],
     registers: [this.registry],
   });
 
@@ -54,12 +54,12 @@ export class MetricsService {
     this.httpRequestDurationSeconds.observe(labels, durationMs / 1000);
   }
 
-  incSseConnections(endpoint: string) {
-    this.sseConnections.inc({ endpoint });
+  incSseConnections(stream: string) {
+    this.sseConnections.inc({ stream });
   }
 
-  decSseConnections(endpoint: string) {
-    this.sseConnections.dec({ endpoint });
+  decSseConnections(stream: string) {
+    this.sseConnections.dec({ stream });
   }
 
   getContentType(): string {

--- a/backend/src/metrics/metrics.service.ts
+++ b/backend/src/metrics/metrics.service.ts
@@ -1,5 +1,10 @@
 import { Injectable } from '@nestjs/common';
-import { Counter, Registry, Histogram } from 'prom-client';
+import {
+  Counter,
+  Registry,
+  Histogram,
+  collectDefaultMetrics,
+} from 'prom-client';
 
 type HttpLabel = 'method' | 'route' | 'status_code';
 
@@ -21,4 +26,12 @@ export class MetricsService {
     buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5],
     registers: [this.registry],
   });
+
+  constructor() {
+    collectDefaultMetrics({
+      register: this.registry,
+      prefix: 'boostad_backend_',
+      labels: { service: 'backend' },
+    });
+  }
 }

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -6,6 +6,8 @@ services:
       dockerfile: nginx/Dockerfile.prod
     ports:
       - '80:80'
+    expose:
+      - '8080'
     depends_on:
       - backend
     restart: unless-stopped
@@ -58,3 +60,13 @@ services:
       - --path.sysfs=/host/sys
       - --path.rootfs=/rootfs
       - --collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)
+
+  nginx-exporter:
+    image: nginx/nginx-prometheus-exporter:0.11.0
+    restart: unless-stopped
+    depends_on:
+      - nginx
+    command:
+      - -nginx.scrape-uri=http://nginx:8080/stub_status
+    ports:
+      - '9113:9113'

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -19,3 +19,9 @@ scrape_configs:
           - '10.0.0.6:9100'
           - '10.0.3.6:9100'
           - '10.0.3.7:9100'
+          
+  - job_name: backend-app
+    metrics_path: /api/metrics
+    static_configs:
+      - targets:
+          - '10.0.0.6:80'

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -25,3 +25,8 @@ scrape_configs:
     static_configs:
       - targets:
           - '10.0.0.6:80'
+
+  - job_name: nginx-exporter
+    static_configs:
+      - targets:
+          - '10.0.0.6:9113'

--- a/nginx/nginx.prod.conf
+++ b/nginx/nginx.prod.conf
@@ -81,3 +81,18 @@ server {
     return 444;
   }
 }
+
+server {
+  listen 8080;
+  server_name localhost;
+
+  location /stub_status {
+    stub_status;
+    access_log off;
+    allow 127.0.0.1;
+    allow 10.0.0.0/8;
+    allow 172.16.0.0/12;
+    allow 192.168.0.0/16;
+    deny all;
+  }
+}


### PR DESCRIPTION
<!-- PR 제목 예시 : [Feat] 로그인 기능 구현 -->
<!-- PR 제목은 위 형식을 참고하여 작성해주세요. -->
<!-- 필요 없는 내용은 지우고 작성해주세요 -->

## 🔗 관련 이슈

- close: #274 

---

## ✅ 작업 내용

### 📌 주요 검토 파일

- `backend/src/metrics/metrics.service.ts` Prometheus 지표 정의(HTTP/SSE/inflight) + default metrics 수집 초기화
- `backend/src/metrics/http-metrics.interceptor.ts` 전역 HTTP 지표 수집 + inflight gauge 증감, SSE/metrics/health 스킵
- `backend/src/metrics/metrics.controller.ts` `/api/metrics` 응답 헤더(Content-Type) 설정 + `@Public()` 적용
- `backend/src/metrics/metrics.module.ts` `APP_INTERCEPTOR` 등록 + `MetricsService` export
- `backend/src/app.module.ts` `MetricsModule` import로 모듈 활성화
- `backend/src/bid-log/bid-log.service.ts` SSE subscribe/teardown 시 `boostad_sse_connections` 증감
- `backend/src/bid-log/bid-log.module.ts` `MetricsModule` import (BidLogService에서 MetricsService 주입)
- `backend/package.json` / `backend/package-lock.json` `prom-client` 추가
- `nginx/nginx.prod.conf` exporter 입력용 `:8080/stub_status` 노출(내부 접근만 허용)
- `docker-compose.prod.yml` `nginx-exporter` 서비스 추가(호스트 `:9113` → 컨테이너 `:9113`)
- `monitoring/prometheus/prometheus.yml` `backend-app`, `nginx-exporter` scrape 타겟 설정

### 1) `/api/metrics` 엔드포인트 추가 (prom-client Registry 기반)

Prometheus가 주기적으로 scrape할 수 있도록 백엔드에 `/api/metrics` 엔드포인트를 추가했습니다. 
`prom-client`의 custom `Registry`를 사용해 애플리케이션 지표를 한 곳에 모으고, 응답은 Prometheus가 파싱할 수 있도록 registry의 `contentType`으로 헤더를 설정해 내려줍니다. 
또한 전역 인증/레이트리밋 등의 영향으로 수집이 막히지 않도록 `@Public()`을 적용해 “모니터링 수집 경로”를 안정적으로 확보했습니다.

### 2) HTTP 요청 지표 수집 (전역 인터셉터 + inflight gauge)

HTTP 지표는 “모든 요청”을 대상으로 해야 하므로 전역 인터셉터(`APP_INTERCEPTOR`) 방식으로 수집하도록 구성했습니다. 요청 수(`boostad_http_requests_total`)와 지연시간(`boostad_http_request_duration_seconds`)을 기록하고, 동시에 처리중인 요청 수를 보기 위해 inflight gauge(`boostad_http_in_flight_requests`)를 추가했습니다. inflight는 요청 시작 시 `inc`, 종료 시점은 성공/에러 여부와 무관하게 `finalize`에서 `dec`되도록 구현해 누락/중복 감소를 줄였습니다.

### 3) SSE 연결수 지표 수집 (bidlog stream)

SSE는 요청이 오래 열려 있고 “종료 타이밍”이 구독 해제(unsubscribe)에 의해 결정되기 때문에, HTTP 인터셉터 방식으로는 현재 연결 수를 정확히 표현하기 어렵습니다. 따라서 bidlog SSE 구독을 생성하는 시점에 `inc`, teardown 시점에 `dec`를 수행하는 방식으로 `boostad_sse_connections{stream="bidlog"}` 지표를 추가했습니다.

### 4) SSE/수집 엔드포인트 스킵 처리

SSE 스트림은 메시지 전송마다 Observable이 `next`될 수 있어 HTTP 지표가 과집계될 가능성이 있습니다. 이를 방지하기 위해 `/api/advertiser/bids/stream` 경로는 HTTP 인터셉터에서 스킵했고, 지표 수집 엔드포인트(`/api/metrics`) 및 헬스체크(`/healthz`)도 동일하게 스킵 처리했습니다.

### 5) Nginx exporter 추가 + Prometheus scrape 타겟 연결

프록시 레벨에서도 연결/트래픽 상태를 확인할 수 있도록 Nginx exporter를 추가했습니다. Nginx에는 exporter가 읽을 `stub_status`를 내부 포트(`:8080`)로만 노출하고(외부 공개 X), exporter 컨테이너가 이를 읽어 Prometheus 포맷(`:9113/metrics`)으로 변환해 노출합니다. Prometheus 설정에는 backend-app(`/api/metrics`)과 nginx-exporter(`:9113`) 타겟을 추가해 수집 경로를 연결했습니다.

---

## 📸 스크린샷 / 데모 (옵션)

- N/A

---

## 🧪 테스트 방법 (옵션)

1. (Backend) `curl -sS http://localhost/api/metrics | rg \"boostad_\"` 로 지표 노출 확인
2. (SSE) 프론트에서 실시간 입찰 페이지 진입 후 `/api/metrics`에서 `boostad_sse_connections{stream=\"bidlog\"}` 값 증가 확인
3. (Prometheus) `http://<prometheus-host>:9090/targets`에서 `backend-app`, `nginx-exporter`가 `UP`인지 확인

---

## 💬 To Reviewers

- `nginx-exporter`는 호스트 `:9113` 포트를 사용하므로, 모니터링 서버에서만 접근 가능하도록 보안그룹/방화벽 제한이 필요합니다.
