### PR TITLE
[Deploy] 그라파나 대시보드 json 작성

### DIFF
--- a/monitoring/grafana/dashboards/boostad-backend-overview.json
+++ b/monitoring/grafana/dashboards/boostad-backend-overview.json
@@ -1,0 +1,453 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "panels": [],
+      "title": "상태",
+      "type": "row"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 1 },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "max(up{job=\"backend-app\",instance=~\"$backend\"})",
+          "legendFormat": "backend-app",
+          "refId": "A"
+        }
+      ],
+      "title": "백엔드 UP",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 1 },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(up{job=\"node-exporter\",instance=~\"$node\"})",
+          "legendFormat": "node-exporter",
+          "refId": "A"
+        }
+      ],
+      "title": "노드 Exporter UP (개수)",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 1 },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "max(up{job=\"nginx-exporter\",instance=~\"$nginx\"})",
+          "legendFormat": "nginx-exporter",
+          "refId": "A"
+        }
+      ],
+      "title": "Nginx Exporter UP",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "id": 10,
+      "panels": [],
+      "title": "백엔드 HTTP",
+      "type": "row"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": { "unit": "ops" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "id": 11,
+      "targets": [
+        {
+          "expr": "sum(rate(boostad_http_requests_total{job=\"backend-app\",instance=~\"$backend\"}[1m]))",
+          "legendFormat": "RPS",
+          "refId": "A"
+        }
+      ],
+      "title": "초당 요청 수 (RPS)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": { "unit": "s" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "id": 12,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(boostad_http_request_duration_seconds_bucket{job=\"backend-app\",instance=~\"$backend\"}[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP 지연시간 p95 (초)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": { "unit": "percentunit", "min": 0, "max": 1 },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 14 },
+      "id": 13,
+      "targets": [
+        {
+          "expr": "sum(rate(boostad_http_requests_total{job=\"backend-app\",status_code=~\"5..\",instance=~\"$backend\"}[5m])) / sum(rate(boostad_http_requests_total{job=\"backend-app\",instance=~\"$backend\"}[5m]))",
+          "legendFormat": "5xx 비율",
+          "refId": "A"
+        }
+      ],
+      "title": "5xx 비율",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": { "unit": "none", "min": 0 },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 14 },
+      "id": 14,
+      "targets": [
+        {
+          "expr": "boostad_http_in_flight_requests{job=\"backend-app\",instance=~\"$backend\"}",
+          "legendFormat": "inflight",
+          "refId": "A"
+        }
+      ],
+      "title": "처리 중 HTTP 요청 (inflight)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] },
+      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 14 },
+      "id": 15,
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "expr": "topk(10, sum by (route) (rate(boostad_http_requests_total{job=\"backend-app\",instance=~\"$backend\"}[5m])))",
+          "format": "table",
+          "legendFormat": "{{route}}",
+          "refId": "A"
+        }
+      ],
+      "title": "라우트별 RPS Top10 (5m)",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Time": true },
+            "indexByName": {},
+            "renameByName": { "Value": "RPS", "route": "라우트" }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 20 },
+      "id": 20,
+      "panels": [],
+      "title": "SSE",
+      "type": "row"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "unit": "none", "min": 0 }, "overrides": [] },
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 21 },
+      "id": 21,
+      "targets": [
+        {
+          "expr": "boostad_sse_connections{job=\"backend-app\",stream=\"bidlog\",instance=~\"$backend\"}",
+          "legendFormat": "bidlog",
+          "refId": "A"
+        }
+      ],
+      "title": "실시간 연결 수 (bidlog SSE)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "min": 0,
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 21 },
+      "id": 22,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "boostad_sse_connections{job=\"backend-app\",stream=\"bidlog\",instance=~\"$backend\"}",
+          "legendFormat": "현재",
+          "refId": "A"
+        }
+      ],
+      "title": "실시간 연결 수 (현재값)",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 27 },
+      "id": 30,
+      "panels": [],
+      "title": "Nginx",
+      "type": "row"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "unit": "none", "min": 0 }, "overrides": [] },
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 28 },
+      "id": 31,
+      "targets": [
+        {
+          "expr": "nginx_connections_active{job=\"nginx-exporter\",instance=~\"$nginx\"}",
+          "legendFormat": "active",
+          "refId": "A"
+        }
+      ],
+      "title": "활성 연결 (active)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] },
+      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 28 },
+      "id": 32,
+      "targets": [
+        {
+          "expr": "sum(rate(nginx_http_requests_total{job=\"nginx-exporter\",instance=~\"$nginx\"}[1m]))",
+          "legendFormat": "req/s",
+          "refId": "A"
+        }
+      ],
+      "title": "요청 처리량 (req/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "unit": "none", "min": 0 }, "overrides": [] },
+      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 28 },
+      "id": 33,
+      "targets": [
+        {
+          "expr": "nginx_connections_reading{job=\"nginx-exporter\",instance=~\"$nginx\"}",
+          "legendFormat": "reading",
+          "refId": "A"
+        },
+        {
+          "expr": "nginx_connections_writing{job=\"nginx-exporter\",instance=~\"$nginx\"}",
+          "legendFormat": "writing",
+          "refId": "B"
+        },
+        {
+          "expr": "nginx_connections_waiting{job=\"nginx-exporter\",instance=~\"$nginx\"}",
+          "legendFormat": "waiting",
+          "refId": "C"
+        }
+      ],
+      "title": "연결 상태 (reading/writing/waiting)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 34 },
+      "id": 40,
+      "panels": [],
+      "title": "서버 리소스 (node_exporter)",
+      "type": "row"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100 }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 35 },
+      "id": 41,
+      "targets": [
+        {
+          "expr": "100 - (avg by (instance) (rate(node_cpu_seconds_total{job=\"node-exporter\",mode=\"idle\",instance=~\"$node\"}[5m])) * 100)",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU 사용률(%)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100 }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 35 },
+      "id": 42,
+      "targets": [
+        {
+          "expr": "100 - (node_memory_MemAvailable_bytes{job=\"node-exporter\",instance=~\"$node\"} / node_memory_MemTotal_bytes{job=\"node-exporter\",instance=~\"$node\"} * 100)",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "메모리 사용률(%)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100 }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 35 },
+      "id": 43,
+      "targets": [
+        {
+          "expr": "100 - (node_filesystem_avail_bytes{job=\"node-exporter\",mountpoint=\"/\",fstype!~\"tmpfs|overlay\",instance=~\"$node\"} / node_filesystem_size_bytes{job=\"node-exporter\",mountpoint=\"/\",fstype!~\"tmpfs|overlay\",instance=~\"$node\"} * 100)",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "디스크 사용률(/)(%)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["boostad", "monitoring"],
+  "templating": {
+    "list": [
+      {
+        "datasource": "Prometheus",
+        "definition": "label_values(up{job=\"backend-app\"}, instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "백엔드 인스턴스",
+        "multi": true,
+        "name": "backend",
+        "query": { "query": "label_values(up{job=\"backend-app\"}, instance)", "refId": "StandardVariableQuery" },
+        "refresh": 1,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "datasource": "Prometheus",
+        "definition": "label_values(up{job=\"node-exporter\"}, instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "노드 인스턴스",
+        "multi": true,
+        "name": "node",
+        "query": { "query": "label_values(up{job=\"node-exporter\"}, instance)", "refId": "StandardVariableQuery" },
+        "refresh": 1,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "datasource": "Prometheus",
+        "definition": "label_values(up{job=\"nginx-exporter\"}, instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Nginx Exporter 인스턴스",
+        "multi": true,
+        "name": "nginx",
+        "query": { "query": "label_values(up{job=\"nginx-exporter\"}, instance)", "refId": "StandardVariableQuery" },
+        "refresh": 1,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "BoostAD 백엔드/프록시 모니터링",
+  "uid": "boostad-backend",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
<!-- PR 제목 예시 : [Feat] 로그인 기능 구현 -->
<!-- PR 제목은 위 형식을 참고하여 작성해주세요. -->
<!-- 필요 없는 내용은 지우고 작성해주세요 -->

## 🔗 관련 이슈

- close: #

---

## ✅ 작업 내용

### 📌 주요 검토 파일

- `monitoring/grafana/dashboards/boostad-backend-overview.json` Grafana 프로비저닝 대시보드(JSON, 한글 패널명)

## Grafana 대시보드 추가 (프로비저닝 / 한글 패널명)

### 1) 대시보드 JSON 추가
Grafana file provisioning 방식으로 자동 로드되는 대시보드 JSON을 추가했습니다. 패널/섹션명을 한글로 구성해 팀원이 대시보드 목적을 빠르게 파악할 수 있도록 했습니다.

### 2) 포함된 섹션/패널
대시보드(`BoostAD 백엔드/프록시 모니터링`)는 아래를 한 화면에서 확인할 수 있게 구성했습니다.

- 상태(UP): backend-app / node-exporter / nginx-exporter
- 백엔드 HTTP: RPS, p95 지연시간, 5xx 비율, inflight 요청 수, 라우트별 RPS Top10
- SSE: bidlog SSE 연결 수(현재값 + 시계열)
- Nginx: active connections, req/s, reading/writing/waiting
- 서버 리소스(node_exporter): CPU/메모리/디스크 사용률

또한 변수(`백엔드 인스턴스`, `노드 인스턴스`, `Nginx Exporter 인스턴스`)를 제공해 환경별로 인스턴스 선택이 가능하도록 했습니다.

### 3) 사용/전제 조건
대시보드는 아래 전제를 기준으로 쿼리가 구성되어 있습니다.

- Grafana 데이터소스 이름이 `Prometheus`로 등록되어 있을 것
- Prometheus에 `job="backend-app"`, `job="node-exporter"`, `job="nginx-exporter"` 타겟이 `UP`일 것
- 백엔드 HTTP/SSE 지표가 `boostad_*` 네이밍을 사용한다는 전제(예: `boostad_http_requests_total`, `boostad_http_request_duration_seconds_*`, `boostad_http_in_flight_requests`, `boostad_sse_connections`)

---

## 📸 스크린샷 / 데모 (옵션)

- N/A

---

## 🧪 테스트 방법 (옵션)

1. (Grafana) 대시보드 목록에서 `BoostAD 백엔드/프록시 모니터링` 로드 확인
2. (Grafana) 변수에서 `백엔드 인스턴스` / `노드 인스턴스` / `Nginx Exporter 인스턴스` 선택 후 패널에 데이터가 표시되는지 확인

---

## 💬 To Reviewers

- 대시보드는 `job`/메트릭 이름(특히 `boostad_*`)에 의존하므로, 환경에 따라 라벨/메트릭명이 다르면 JSON의 PromQL만 조정하면 됩니다.
