### PR TITLE
[Feat] 예산 validation 100원단위 증가 및 안내문구(+최종확인)

### DIFF
--- a/frontend/src/4_shared/ui/CampaignForm/lib/step1Validation.ts
+++ b/frontend/src/4_shared/ui/CampaignForm/lib/step1Validation.ts
@@ -11,12 +11,18 @@ export function validateTitle(title: string) {
   if (!title.trim()) {
     return '광고 제목을 입력해주세요.';
   }
+  if (title.length > 30) {
+    return '제목은 최대 30자까지 입력 가능합니다.';
+  }
   return null;
 }
 
 export function validateContent(content: string) {
   if (!content.trim()) {
     return '광고 내용을 입력해주세요.';
+  }
+  if (content.length > 100) {
+    return '내용은 최대 100자까지 입력 가능합니다.';
   }
   return null;
 }

--- a/frontend/src/4_shared/ui/CampaignForm/lib/step2Validation.ts
+++ b/frontend/src/4_shared/ui/CampaignForm/lib/step2Validation.ts
@@ -60,10 +60,18 @@ export function formatDateForDisplay(date: string) {
 
 // 예산 유효성 검사
 export const MIN_DAILY_BUDGET = 3000;
+export const BUDGET_UNIT = 100;
+
+export function isMultipleOf100(value: number): boolean {
+  return value % BUDGET_UNIT === 0;
+}
 
 export function validateMaxCpc(maxCpc: number, dailyBudget: number) {
   if (maxCpc <= 0) {
     return 'CPC를 입력해주세요.';
+  }
+  if (!isMultipleOf100(maxCpc)) {
+    return '100원 단위로 입력해주세요.';
   }
   if (dailyBudget > 0 && maxCpc > dailyBudget) {
     return 'CPC 값은 하루 예산을 초과할 수 없습니다.';
@@ -78,6 +86,9 @@ export function validateDailyBudget(
 ) {
   if (dailyBudget <= 0) {
     return '하루 예산을 입력해주세요.';
+  }
+  if (!isMultipleOf100(dailyBudget)) {
+    return '100원 단위로 입력해주세요.';
   }
   if (dailyBudget < MIN_DAILY_BUDGET) {
     return `최소 ${MIN_DAILY_BUDGET.toLocaleString()}원 이상 입력해주세요`;
@@ -99,6 +110,9 @@ export function validateTotalBudget(
 ) {
   if (totalBudget <= 0) {
     return '총 예산을 입력해주세요.';
+  }
+  if (!isMultipleOf100(totalBudget)) {
+    return '100원 단위로 입력해주세요.';
   }
   if (dailyBudget > 0 && totalBudget < dailyBudget) {
     return '총 예산은 하루 예산 이상이어야 합니다.';

--- a/frontend/src/4_shared/ui/CampaignForm/ui/Step1Content.tsx
+++ b/frontend/src/4_shared/ui/CampaignForm/ui/Step1Content.tsx
@@ -157,6 +157,7 @@ export function Step1Content({ onImageUpload }: Step1ContentProps) {
         onChange={handleTitleChange}
         onBlur={handleTitleBlur}
         error={errors.campaignContent?.title}
+        maxLength={30}
       />
       <TextArea
         label="광고 내용"
@@ -165,7 +166,7 @@ export function Step1Content({ onImageUpload }: Step1ContentProps) {
         onChange={handleContentChange}
         onBlur={handleContentBlur}
         error={errors.campaignContent?.content}
-        maxLength={70}
+        maxLength={100}
       />
       <TextField
         label="광고 URL"

--- a/frontend/src/4_shared/ui/CampaignForm/ui/Step2Content.tsx
+++ b/frontend/src/4_shared/ui/CampaignForm/ui/Step2Content.tsx
@@ -20,8 +20,8 @@ export function Step2Content() {
 
   const totalBudgetHint =
     balance !== null
-      ? `(일 예산 이상 · 잔액: ${balance.toLocaleString()}원)`
-      : '(일 예산 이상)';
+      ? `100원 단위 · 일 예산 이상 · 잔액: ${balance.toLocaleString()}원`
+      : '100원 단위 · 일 예산 이상';
 
   const handleDailyBudgetChange = (value: number) => {
     updateBudgetSettings({ dailyBudget: value });
@@ -110,7 +110,7 @@ export function Step2Content() {
         value={dailyBudget}
         onChange={handleDailyBudgetChange}
         onBlur={handleDailyBudgetBlur}
-        hint={`(최소 ${MIN_DAILY_BUDGET.toLocaleString()}원)`}
+        hint={`100원 단위 · 최소 ${MIN_DAILY_BUDGET.toLocaleString()}원`}
         error={errors.budgetSettings?.dailyBudget}
       />
 
@@ -128,7 +128,7 @@ export function Step2Content() {
         value={maxCpc}
         onChange={handleMaxCpcChange}
         onBlur={handleMaxCpcBlur}
-        hint="(일 예산 이하)"
+        hint="100원 단위 · 일 예산 이하"
         error={errors.budgetSettings?.maxCpc}
       />
 

--- a/frontend/src/4_shared/ui/CurrencyField/CurrencyField.tsx
+++ b/frontend/src/4_shared/ui/CurrencyField/CurrencyField.tsx
@@ -10,6 +10,7 @@ interface CurrencyFieldProps {
   placeholder?: string;
   unit?: string;
   prefix?: string;
+  transparentMessage?: boolean;
 }
 
 export function CurrencyField({
@@ -22,6 +23,7 @@ export function CurrencyField({
   placeholder = '0',
   unit = '원',
   prefix,
+  transparentMessage = false,
 }: CurrencyFieldProps) {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const numberValue = parseNumber(e.target.value);
@@ -39,7 +41,7 @@ export function CurrencyField({
       {label && <label className="text-sm font-bold text-gray-900">{label}</label>}
 
       <div
-        className={`flex h-11 items-center rounded-lg border px-3 focus-within:ring-2 ${
+        className={`flex h-11 items-center rounded-lg border px-3 bg-white focus-within:ring-2 ${
           error
             ? 'border-red-300 focus-within:ring-red-200'
             : 'border-gray-200 focus-within:ring-blue-200'
@@ -58,8 +60,8 @@ export function CurrencyField({
         <span className="ml-2 text-sm text-gray-500">{unit}</span>
       </div>
 
-      {hint && !error && <p className="text-xs text-gray-400">{hint}</p>}
-      {error && <p className="text-xs text-red-500">{error}</p>}
+      {hint && !error && <p className={`text-xs text-gray-400 ${transparentMessage ? 'bg-transparent' : ''}`}>{hint}</p>}
+      {error && <p className={`text-xs text-red-500 ${transparentMessage ? 'bg-transparent' : ''}`}>{error}</p>}
     </div>
   );
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- close: #292 

---

## ✅ 작업 내용

예산 입력을 100원 단위로 통일하고,
생성 / 수정 화면에서 validation 기준과 안내 문구를 정리했습니다!

+ 추가로 캠페인 생성 시 제목 30자 제한, 내용 100자 제한이
프론트에서 일부 누락되어 있던 것 같아 수정해서 반영했습니다.
입력 단계에서는 maxLength로 30자 / 100자를 걸어두었고,
혹시 모를 케이스를 대비해서 validation에서도
각각 30자, 100자 제한을 한 번 더 체크하도록 처리했습니다...!(Step1Content, Step1Validation)

### 📁 변경된 파일 (4개)

#### 1️⃣ `step2Validation.ts`

* 예산 단위를 관리하기 위한 `BUDGET_UNIT = 100` 상수 추가
* **100원 단위 여부를 검사하는 `isMultipleOf100()` 함수 export**
* 아래 validation 함수들에 **100원 단위 검증 로직 추가**

  * `validateMaxCpc`
  * `validateDailyBudget`
  * `validateTotalBudget`

#### 2️⃣ `Step2Content.tsx`

* 예산 입력 **hint 문구에 “100원 단위” 안내 추가**
  → 생성 단계에서 입력 기준을 바로 인지할 수 있도록 개선

#### 3️⃣ `BudgetEditMode.tsx`

* 예산 수정 화면에 `errors` state 및 validation 로직 추가
* `validateAddBudget()` 함수 추가

  * 100원 단위 검증
  * 잔액 초과 여부 검증
* 상단에 안내 문구 추가
  → `* 모든 금액은 100원 단위로 입력해주세요`
* 에러 메시지 노출을 위해 `transparentMessage` prop 적용

#### 4️⃣ `CurrencyField.tsx`

* `transparentMessage` prop 추가
* 입력 필드 배경에 `bg-white` 적용 (가독성 개선)


### ✅ 예산 Validation 최종 정리

#### 캠페인 생성 (Step2Content)

| 필드     | 검증 항목                                              |
| ------ | -------------------------------------------------- |
| 총 예산   | 필수 입력 · **100원 단위** · 일일 예산 이상 · 잔액 이하             |
| 일일 예산  | 필수 입력 · **100원 단위** · 3,000원 이상 · CPC 이상 · 총 예산 이하 |
| 최대 CPC | 필수 입력 · **100원 단위** · 일일 예산 이하                     |

#### 빠른 예산 수정 (BudgetEditMode)

| 필드     | 검증 항목                                                |
| ------ | ---------------------------------------------------- |
| 추가 예산  | **100원 단위** · 잔액 이하                                  |
| 일일 예산  | 필수 입력 · **100원 단위** · 3,000원 이상 · CPC 이상 · 최종 총예산 이하 |
| 최대 CPC | 필수 입력 · **100원 단위** · 일일 예산 이하                       |

* **최종 총예산 = 기존 총예산 + 추가 예산**

---

## 📸 스크린샷 / 데모 (옵션)

<!-- UI 변경사항이나 새로운 기능의 동작을 시각적으로 보여주세요. -->
- 캠페인 생성 시 validation
![화면 기록 2026-02-04 오후 6 06 41](https://github.com/user-attachments/assets/34470f04-cc76-4643-a417-ee2718655345)

- 캠페인 수정 시 validaiton
![화면 기록 2026-02-04 오후 6 07 34](https://github.com/user-attachments/assets/30367abe-85e7-4426-b903-be27bb0e9052)


---

## 🧪 테스트 방법 (옵션)

<!-- 리뷰어가 기능을 테스트할 수 있도록 구체적인 테스트 방법을 설명해주세요. -->

1. **캠페인 생성 화면**에서 예산 입력 시
   * 100원 단위가 아닌 금액(예: 105원)을 입력하면 validation 메시지가 노출되는지 확인합니다.
2. 캠페인 생성 시
   * `총 예산 < 일일 예산`, `일일 예산 < CPC`, `총 예산 > 잔액` 등의 케이스에서 각각 올바른 에러가 노출되는지 확인합니다.
3. **빠른 예산 수정 화면**에서
   * 추가 예산이 100원 단위가 아닐 경우 또는 잔액을 초과할 경우 에러가 노출되는지 확인합니다.
4. 모든 예산을 100원 단위로 정상 입력했을 때
   * 생성 및 수정이 정상적으로 완료되는지 확인합니다.


---

## 💬 To Reviewers

<!-- 리뷰어에게 전달하고 싶은 내용이나 특별히 확인이 필요한 부분을 작성해주세요. -->
UX 측면에서 안내 문구 위치나 표현이 더 좋을지에 대한 의견도 편하게 주시면 좋겠습니다 🙏