### PR TITLE
[Refactor] 비동기 큐 개선

### DIFF
--- a/.github/workflows/back-deploy.yml
+++ b/.github/workflows/back-deploy.yml
@@ -110,5 +110,5 @@ jobs:
             fi
 
             $COMPOSE -f docker-compose.prod.yml pull
-            $COMPOSE -f docker-compose.prod.yml up -d --remove-orphans
+            $COMPOSE -f docker-compose.prod.yml up -d --remove-orphans --no-build
             $COMPOSE -f docker-compose.prod.yml ps

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,6 +9,7 @@
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
+    "start:worker": "node dist/worker.main.js",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -19,7 +19,6 @@ import { JwtCookieGuard } from './auth/guards/jwt-cookie.guard';
 import { BlogModule } from './blog/blog.module';
 import { ImageModule } from './image/image.module';
 import { RedisModule } from './redis/redis.module';
-import { QueueModule } from './queue/queue.module';
 import { PaymentModule } from './payment/payment.module';
 import { MetricsModule } from './metrics/metrics.module';
 
@@ -54,7 +53,6 @@ import { MetricsModule } from './metrics/metrics.module';
     BlogModule,
     ImageModule,
     RedisModule,
-    QueueModule,
     PaymentModule,
     MetricsModule,
     // QueueModule,

--- a/backend/src/blog/blog.module.ts
+++ b/backend/src/blog/blog.module.ts
@@ -2,7 +2,6 @@ import { Module } from '@nestjs/common';
 import { BlogService } from './blog.service';
 import { BlogController } from './blog.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { BullModule } from '@nestjs/bullmq';
 import { BlogEntity } from './entities/blog.entity';
 import { UserModule } from 'src/user/user.module';
 import { BlogRepository } from './repository/blog.repository.interface';
@@ -10,15 +9,14 @@ import { TypeOrmBlogRepository } from './repository/typeorm-blog.repository';
 import { RedisModule } from 'src/redis/redis.module';
 import { BlogRedisCacheRepository } from './repository/redis-blog.cache.repository';
 import { BlogCacheRepository } from './repository/blog.cache.repository.interface';
+import { QueueModule } from 'src/queue/queue.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([BlogEntity]),
     UserModule,
     RedisModule,
-    BullModule.registerQueue({
-      name: 'embedding-queue',
-    }),
+    QueueModule,
   ],
   controllers: [BlogController],
   providers: [

--- a/backend/src/campaign/campaign.module.ts
+++ b/backend/src/campaign/campaign.module.ts
@@ -1,6 +1,6 @@
 import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { BullModule } from '@nestjs/bullmq';
+// import { BullModule } from '@nestjs/bullmq';
 import { CampaignRepository } from './repository/campaign.repository.interface';
 import { TypeOrmCampaignRepository } from './repository/typeorm-campaign.repository';
 import { CampaignService } from './campaign.service';
@@ -18,6 +18,7 @@ import { UserModule } from 'src/user/user.module';
 import { AdvertiserModule } from 'src/advertiser/advertiser.module';
 import { CacheModule } from 'src/cache/cache.module';
 import { RedisModule } from 'src/redis/redis.module';
+import { QueueModule } from 'src/queue/queue.module';
 
 @Module({
   imports: [
@@ -33,9 +34,7 @@ import { RedisModule } from 'src/redis/redis.module';
     UserModule,
     forwardRef(() => AdvertiserModule),
     RedisModule,
-    BullModule.registerQueue({
-      name: 'embedding-queue',
-    }),
+    QueueModule,
   ],
   controllers: [CampaignController],
   providers: [

--- a/backend/src/campaign/dto/create-campaign.dto.ts
+++ b/backend/src/campaign/dto/create-campaign.dto.ts
@@ -9,6 +9,7 @@ import {
   MaxLength,
   Min,
   IsNotEmpty,
+  IsDivisibleBy,
 } from 'class-validator';
 
 export class CreateCampaignDto {
@@ -38,18 +39,21 @@ export class CreateCampaignDto {
   @IsNotEmpty()
   @IsInt({ message: '최대 CPC는 정수여야 합니다.' })
   @Min(100, { message: '최대 CPC는 100원 이상이어야 합니다.' })
+  @IsDivisibleBy(100, { message: '100원 단위로 입력해주세요.' })
   maxCpc: number;
 
   @Type(() => Number)
   @IsNotEmpty()
   @IsInt({ message: '일일 예산은 정수여야 합니다.' })
   @Min(3000, { message: '일일 예산은 3,000원 이상이어야 합니다.' })
+  @IsDivisibleBy(100, { message: '100원 단위로 입력해주세요.' })
   dailyBudget: number;
 
   @Type(() => Number)
   @IsNotEmpty()
   @IsInt({ message: '총 예산은 정수여야 합니다.' })
   @Min(0, { message: '총 예산은 0 이상이어야 합니다.' })
+  @IsDivisibleBy(100, { message: '100원 단위로 입력해주세요.' })
   totalBudget: number;
 
   @IsDateString({}, { message: '시작일은 ISO 8601 형식이어야 합니다.' })

--- a/backend/src/campaign/dto/update-campaign.dto.ts
+++ b/backend/src/campaign/dto/update-campaign.dto.ts
@@ -10,6 +10,7 @@ import {
   IsOptional,
   IsIn,
   IsBoolean,
+  IsDivisibleBy,
 } from 'class-validator';
 
 export class UpdateCampaignDto {
@@ -44,18 +45,21 @@ export class UpdateCampaignDto {
   @Type(() => Number)
   @IsInt({ message: '최대 CPC는 정수여야 합니다.' })
   @Min(0, { message: '최대 CPC는 0 이상이어야 합니다.' })
+  @IsDivisibleBy(100, { message: '100원 단위로 입력해주세요.' })
   maxCpc?: number;
 
   @IsOptional()
   @Type(() => Number)
   @IsInt({ message: '일일 예산은 정수여야 합니다.' })
   @Min(0, { message: '일일 예산은 0 이상이어야 합니다.' })
+  @IsDivisibleBy(100, { message: '100원 단위로 입력해주세요.' })
   dailyBudget?: number;
 
   @IsOptional()
   @Type(() => Number)
   @IsInt({ message: '총 예산은 정수여야 합니다.' })
   @Min(0, { message: '총 예산은 0 이상이어야 합니다.' })
+  @IsDivisibleBy(100, { message: '100원 단위로 입력해주세요.' })
   totalBudget?: number;
 
   @IsOptional()

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -23,6 +23,7 @@ async function bootstrap() {
       transform: true,
     })
   );
+  app.enableShutdownHooks();
 
   // CORS 설정
   const corsOrigin = process.env.CORS_ORIGIN;

--- a/backend/src/queue/queue.module.ts
+++ b/backend/src/queue/queue.module.ts
@@ -1,16 +1,10 @@
 import { Module } from '@nestjs/common';
 import { BullModule } from '@nestjs/bullmq';
 import { ConfigModule, ConfigService } from '@nestjs/config';
-import { RTBModule } from 'src/rtb/rtb.module';
-import { CampaignModule } from 'src/campaign/campaign.module';
-import { BlogModule } from 'src/blog/blog.module';
 
 @Module({
   imports: [
     ConfigModule,
-    RTBModule,
-    CampaignModule,
-    BlogModule,
     BullModule.forRootAsync({
       imports: [ConfigModule],
       useFactory: (configService: ConfigService) => ({

--- a/backend/src/queue/queue.module.ts
+++ b/backend/src/queue/queue.module.ts
@@ -1,7 +1,6 @@
 import { Module } from '@nestjs/common';
 import { BullModule } from '@nestjs/bullmq';
 import { ConfigModule, ConfigService } from '@nestjs/config';
-import { EmbeddingWorker } from './workers/embedding.worker';
 import { RTBModule } from 'src/rtb/rtb.module';
 import { CampaignModule } from 'src/campaign/campaign.module';
 import { BlogModule } from 'src/blog/blog.module';
@@ -26,7 +25,6 @@ import { BlogModule } from 'src/blog/blog.module';
       name: 'embedding-queue',
     }),
   ],
-  providers: [EmbeddingWorker],
   exports: [BullModule],
 })
 export class QueueModule {}

--- a/backend/src/worker.main.ts
+++ b/backend/src/worker.main.ts
@@ -1,0 +1,9 @@
+import { NestFactory } from '@nestjs/core';
+import { WorkerModule } from './worker/worker.module';
+
+async function bootstrap() {
+  const app = await NestFactory.createApplicationContext(WorkerModule);
+  app.enableShutdownHooks();
+}
+
+void bootstrap();

--- a/backend/src/worker.main.ts
+++ b/backend/src/worker.main.ts
@@ -2,8 +2,14 @@ import { NestFactory } from '@nestjs/core';
 import { WorkerModule } from './worker/worker.module';
 
 async function bootstrap() {
-  const app = await NestFactory.createApplicationContext(WorkerModule);
-  app.enableShutdownHooks();
+  try {
+    const app = await NestFactory.createApplicationContext(WorkerModule);
+    app.enableShutdownHooks();
+    console.log('Worker 부트스트랩 성공');
+  } catch (error) {
+    console.error('Worker 부트스트랩 실패:', error);
+    process.exit(1);
+  }
 }
 
 void bootstrap();

--- a/backend/src/worker/worker.module.ts
+++ b/backend/src/worker/worker.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { EventEmitterModule } from '@nestjs/event-emitter';
+import { QueueModule } from 'src/queue/queue.module';
+import { EmbeddingWorker } from 'src/queue/workers/embedding.worker';
+import { RedisModule } from 'src/redis/redis.module';
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
+    EventEmitterModule.forRoot(),
+    RedisModule,
+    QueueModule,
+  ],
+  providers: [EmbeddingWorker],
+})
+export class WorkerModule {}

--- a/backend/src/worker/worker.module.ts
+++ b/backend/src/worker/worker.module.ts
@@ -1,8 +1,8 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { EventEmitterModule } from '@nestjs/event-emitter';
-import { RedisCacheRepository } from 'src/cache/repository/redis-cache.repository';
 import { CampaignCacheRepository } from 'src/campaign/repository/campaign.cache.repository.interface';
+import { RedisCampaignCacheRepository } from 'src/campaign/repository/redis-campaign.cache.repository';
 import { QueueModule } from 'src/queue/queue.module';
 import { EmbeddingWorker } from 'src/queue/workers/embedding.worker';
 import { RedisModule } from 'src/redis/redis.module';
@@ -19,7 +19,10 @@ import { XenovaMLEngine } from 'src/rtb/ml/xenova-mlEngine';
   providers: [
     EmbeddingWorker,
     { provide: MLEngine, useClass: XenovaMLEngine },
-    { provide: CampaignCacheRepository, useClass: RedisCacheRepository },
+    {
+      provide: CampaignCacheRepository,
+      useClass: RedisCampaignCacheRepository,
+    },
   ],
 })
 export class WorkerModule {}

--- a/backend/src/worker/worker.module.ts
+++ b/backend/src/worker/worker.module.ts
@@ -1,9 +1,13 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { EventEmitterModule } from '@nestjs/event-emitter';
+import { RedisCacheRepository } from 'src/cache/repository/redis-cache.repository';
+import { CampaignCacheRepository } from 'src/campaign/repository/campaign.cache.repository.interface';
 import { QueueModule } from 'src/queue/queue.module';
 import { EmbeddingWorker } from 'src/queue/workers/embedding.worker';
 import { RedisModule } from 'src/redis/redis.module';
+import { MLEngine } from 'src/rtb/ml/mlEngine.interface';
+import { XenovaMLEngine } from 'src/rtb/ml/xenova-mlEngine';
 
 @Module({
   imports: [
@@ -12,6 +16,10 @@ import { RedisModule } from 'src/redis/redis.module';
     RedisModule,
     QueueModule,
   ],
-  providers: [EmbeddingWorker],
+  providers: [
+    EmbeddingWorker,
+    { provide: MLEngine, useClass: XenovaMLEngine },
+    { provide: CampaignCacheRepository, useClass: RedisCacheRepository },
+  ],
 })
 export class WorkerModule {}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,9 +1,6 @@
 services:
   nginx:
     image: ${NCR_ENDPOINT:-local}/boostad/nginx:${IMAGE_TAG:-deploy}
-    build:
-      context: .
-      dockerfile: nginx/Dockerfile.prod
     ports:
       - '80:80'
     expose:
@@ -14,10 +11,6 @@ services:
 
   backend:
     image: ${NCR_ENDPOINT:-local}/boostad/backend:${IMAGE_TAG:-deploy}
-    build:
-      context: .
-      dockerfile: backend/Dockerfile.prod
-      target: runner
     environment:
       PORT: '3000'
       # 배포 시 Object Storage(정적 호스팅) 도메인으로 교체
@@ -44,6 +37,17 @@ services:
       TOSS_SECRET_KEY: ${TOSS_SECRET_KEY}
     expose:
       - '3000'
+    restart: unless-stopped
+
+  backend-worker:
+    image: ${NCR_ENDPOINT:-local}/boostad/backend:${IMAGE_TAG:-deploy}
+    command: ['node', 'dist/worker.main.js']
+    environment:
+      # Worker는 HTTP 서버를 띄우지 않고 BullMQ Consumer만 실행합니다.
+      NODE_ENV: ${NODE_ENV:-development}
+      REDIS_HOST: ${REDIS_HOST:-localhost}
+      REDIS_PORT: ${REDIS_PORT:-6379}
+      # Xenova 모델 로딩(부트스트랩) 시 필요한 설정은 별도 없음.
     restart: unless-stopped
 
   node-exporter:

--- a/frontend/src/3_features/campaignDetail/ui/CampaignEditModal.tsx
+++ b/frontend/src/3_features/campaignDetail/ui/CampaignEditModal.tsx
@@ -5,6 +5,7 @@ import {
   Step2Content,
   Step3Content,
   useCampaignFormStore,
+  AVAILABLE_TAGS,
 } from '@shared/ui/CampaignForm';
 import type { CampaignFormData } from '@shared/ui/CampaignForm';
 import { useImageUpload } from '@shared/lib/hooks';
@@ -41,6 +42,10 @@ function formatDateForInput(dateString: string): string {
   return `${year}-${month}-${day}`;
 }
 
+const categoryByTagId = new Map(
+  AVAILABLE_TAGS.map((tag) => [tag.id, tag.category])
+);
+
 export function CampaignEditModal({
   isOpen,
   onClose,
@@ -76,7 +81,7 @@ export function CampaignEditModal({
           tags: initialData.tags.map((tag) => ({
             id: tag.id,
             name: tag.name,
-            category: '기타' as const,
+            category: categoryByTagId.get(tag.id) ?? '기타',
           })),
           isHighIntent: initialData.isHighIntent,
           image: initialData.image,


### PR DESCRIPTION
<!-- PR 제목 예시 : [Feat] 로그인 기능 구현 -->
<!-- PR 제목은 위 형식을 참고하여 작성해주세요. -->
<!-- 필요 없는 내용은 지우고 작성해주세요 -->

## 🔗 관련 이슈

- close: #296 

---

## ✅ 작업 내용

### 📌 주요 검토 파일

- `backend/src/worker.main.ts` Worker 전용 엔트리포인트(HTTP 서버 없이 DI 컨테이너만 실행)
- `backend/src/worker/worker.module.ts` Consumer 전용 모듈 구성(EmbeddingWorker + 의존성)
- `backend/src/queue/queue.module.ts` Queue 인프라 모듈 정리(순환 참조 제거, BullModule export)
- `docker-compose.prod.yml` backend-worker 서비스 추가 및 prod에서 build 제거
- `.github/workflows/back-deploy.yml` 배포 시 `--no-build`로 서버 빌드 방지

### ✅ 수정된 파일 요약

- `.github/workflows/back-deploy.yml`: 배포 서버에서 `docker compose up` 시 `--no-build` 옵션을 추가해 서버에서 이미지를 빌드하지 않도록 고정
- `docker-compose.prod.yml`: 같은 backend 이미지를 사용하되 엔트리포인트를 분리한 `backend-worker` 서비스 추가 + prod에서 `build` 블록 제거
- `backend/package.json`: 워커 프로세스 실행용 `start:worker` 스크립트 추가
- `backend/src/main.ts`: graceful shutdown을 위해 `enableShutdownHooks()` 추가
- `backend/src/app.module.ts`: `QueueModule` 직접 의존 제거(Producer 모듈을 통해서만 큐를 사용)
- `backend/src/queue/queue.module.ts`: 큐 인프라(연결 + registerQueue)만 남기고 Consumer/provider 및 불필요한 모듈 의존 제거
- `backend/src/campaign/campaign.module.ts`: `registerQueue` 제거 후 `QueueModule` import로 통합
- `backend/src/blog/blog.module.ts`: `registerQueue` 제거 후 `QueueModule` import로 통합
- `backend/src/worker.main.ts`: Worker 전용 부트스트랩(`createApplicationContext`) 추가
- `backend/src/worker/worker.module.ts`: Worker 컨테이너에서 필요한 DI 바인딩(EmbeddingWorker, XenovaMLEngine, RedisCampaignCacheRepository) 구성

## BullMQ 워커 프로세스/컨테이너 분리

### 1) 큐 등록/설정을 한 곳으로 통합
`embedding-queue` 등록이 `CampaignModule`, `BlogModule`, `QueueModule`에 중복되어 있어 유지보수와 의존성 관리가 어려웠습니다. 큐 등록을 `QueueModule`로 통합하고, Producer 쪽은 `QueueModule`만 import하면 `@InjectQueue('embedding-queue')`를 사용할 수 있도록 정리했습니다.

### 2) Worker 전용 모듈 + 엔트리포인트 추가
Consumer(EmbeddingWorker)를 API 서버 프로세스에서 분리하기 위해 `WorkerModule`과 `worker.main.ts`를 추가했습니다. `NestFactory.createApplicationContext(WorkerModule)`를 사용해 HTTP 서버 없이 Worker 전용 DI 컨테이너만 실행되도록 구성했습니다.

### 3) 배포에서 backend-worker 서비스로 실행
배포에서는 같은 backend 이미지를 사용하되, `backend-worker` 서비스가 `node dist/worker.main.js`로 실행되도록 `docker-compose.prod.yml`에 추가했습니다. 또한 서버에서 실수로 `build`가 수행되지 않도록 `docker-compose.prod.yml`의 `build` 블록을 제거하고, `back-deploy.yml`의 `docker compose up`에도 `--no-build` 옵션을 추가했습니다.

---

## 📸 스크린샷 / 데모 (옵션)

https://github.com/user-attachments/assets/3ae61a5b-6141-4775-8616-861e8214f9ea


- N/A

---

## 🧪 테스트 방법 (옵션)

1. (로컬) `npm --prefix backend run build`
2. (로컬) API 서버 실행: `npm --prefix backend run start:prod`
3. (로컬) 워커 실행: `npm --prefix backend run start:worker`
4. (워커 로그) `Processing job ...` 로그가 출력되는지 확인

---

## 💬 To Reviewers

- Base: `develop`, Head: `refactor/worker-container`
- 워커는 `WorkerModule` 기준으로만 실행되며, API 서버와 동일 Redis를 바라보도록 `REDIS_HOST`, `REDIS_PORT`가 필요합니다.
