### PR TITLE
[Fix] 네부캠 캠페인 수정 시 태그추가 선택 불가 문제 해결

### DIFF
--- a/frontend/src/3_features/campaignDetail/ui/CampaignEditModal.tsx
+++ b/frontend/src/3_features/campaignDetail/ui/CampaignEditModal.tsx
@@ -5,6 +5,7 @@ import {
   Step2Content,
   Step3Content,
   useCampaignFormStore,
+  AVAILABLE_TAGS,
 } from '@shared/ui/CampaignForm';
 import type { CampaignFormData } from '@shared/ui/CampaignForm';
 import { useImageUpload } from '@shared/lib/hooks';
@@ -41,6 +42,10 @@ function formatDateForInput(dateString: string): string {
   return `${year}-${month}-${day}`;
 }
 
+const categoryByTagId = new Map(
+  AVAILABLE_TAGS.map((tag) => [tag.id, tag.category])
+);
+
 export function CampaignEditModal({
   isOpen,
   onClose,
@@ -76,7 +81,7 @@ export function CampaignEditModal({
           tags: initialData.tags.map((tag) => ({
             id: tag.id,
             name: tag.name,
-            category: '기타' as const,
+            category: categoryByTagId.get(tag.id) ?? '기타',
           })),
           isHighIntent: initialData.isHighIntent,
           image: initialData.image,


### PR DESCRIPTION
<!-- PR 제목 예시 : [Feat] 로그인 기능 구현 -->
<!-- PR 제목은 위 형식을 참고하여 작성해주세요. -->
<!-- 필요 없는 내용은 지우고 작성해주세요 -->

## 🔗 관련 이슈

- close: #300

---

## ✅ 작업 내용

## <!-- 구현한 기능이나 수정한 내용을 상세히 기술해주세요. -->

- `frontend/src/3_features/campaignDetail/ui/CampaignEditModal.tsx`: AVAILABLE_TAGS 기준으로 tag.id -> category를 복원해서 저장하도록 변경.

## 📸 스크린샷 / 데모 (옵션)

<!-- UI 변경사항이나 새로운 기능의 동작을 시각적으로 보여주세요. -->

---

## 🧪 테스트 방법 (옵션)

<!-- 리뷰어가 기능을 테스트할 수 있도록 구체적인 테스트 방법을 설명해주세요. -->

1.
2.

---

## 💬 To Reviewers

<!-- 리뷰어에게 전달하고 싶은 내용이나 특별히 확인이 필요한 부분을 작성해주세요. -->
