### PR TITLE
[Feat] 자정에 무료 크레딧 제공 종료 및 신규 광고주 UI 개선

### DIFF
--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -29,7 +29,7 @@ export class UserService {
 
       // ADVERTISER만 가입 축하 크레딧 지급
       if (user.role === UserRole.ADVERTISER) {
-        const WELCOME_CREDIT = 100000; // 100,000원
+        const WELCOME_CREDIT = 0; // TODO: 임시로 0원으로 변경 (원래 100,000원)
 
         await this.dataSource.transaction(async (manager) => {
           const userRepo = manager.getRepository(UserEntity);

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -29,7 +29,7 @@ export class UserService {
 
       // ADVERTISER만 가입 축하 크레딧 지급
       if (user.role === UserRole.ADVERTISER) {
-        const WELCOME_CREDIT = 1; // TODO: 임시로 0원으로 변경 (원래 100,000원)
+        const WELCOME_CREDIT = 0; // TODO: 임시로 0원으로 변경 (원래 100,000원)
 
         await this.dataSource.transaction(async (manager) => {
           const userRepo = manager.getRepository(UserEntity);

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -29,7 +29,7 @@ export class UserService {
 
       // ADVERTISER만 가입 축하 크레딧 지급
       if (user.role === UserRole.ADVERTISER) {
-        const WELCOME_CREDIT = 0; // TODO: 임시로 0원으로 변경 (원래 100,000원)
+        const WELCOME_CREDIT = 1; // TODO: 임시로 0원으로 변경 (원래 100,000원)
 
         await this.dataSource.transaction(async (manager) => {
           const userRepo = manager.getRepository(UserEntity);

--- a/frontend/src/3_features/campaignStats/ui/CampaignStatsTable.tsx
+++ b/frontend/src/3_features/campaignStats/ui/CampaignStatsTable.tsx
@@ -52,14 +52,20 @@ export function CampaignStatsTable() {
         </Link>
       </div>
 
-      <table>
-        <CampaignStatsTableHeader />
-        <tbody>
-          {campaigns.map((campaign) => (
-            <CampaignStatsTableRow key={campaign.id} campaign={campaign} />
-          ))}
-        </tbody>
-      </table>
+      {campaigns.length === 0 ? (
+        <div className="p-10 text-center text-gray-500">
+          등록된 캠페인이 없습니다.
+        </div>
+      ) : (
+        <table>
+          <CampaignStatsTableHeader />
+          <tbody>
+            {campaigns.map((campaign) => (
+              <CampaignStatsTableRow key={campaign.id} campaign={campaign} />
+            ))}
+          </tbody>
+        </table>
+      )}
     </div>
   );
 }

--- a/frontend/src/3_features/creditBalance/ui/CreditBalanceCard.tsx
+++ b/frontend/src/3_features/creditBalance/ui/CreditBalanceCard.tsx
@@ -41,7 +41,7 @@ export function CreditBalanceCard() {
       </div>
       <div className="flex flex-row items-baseline gap-4 pt-4">
         <div className="text-4xl font-bold text-gray-900">
-          {formatWithComma(balance ?? 0)}
+          {(balance ?? 0) === 0 ? '0' : formatWithComma(balance ?? 0)}
           <span className="text-2xl font-normal text-gray-600 ml-2">원</span>
         </div>
       </div>

--- a/frontend/src/3_features/creditHistory/ui/CreditHistoryTableRow.tsx
+++ b/frontend/src/3_features/creditHistory/ui/CreditHistoryTableRow.tsx
@@ -38,10 +38,10 @@ export function CreditHistoryTableRow({ history }: CreditHistoryTableRowProps) {
         className={`px-5 py-4 text-right font-semibold whitespace-nowrap ${amountColor}`}
       >
         {amountPrefix}
-        {formatWithComma(history.amount)}원
+        {history.amount === 0 ? '0' : formatWithComma(history.amount)}원
       </td>
       <td className="px-5 py-4 text-right text-gray-900 whitespace-nowrap">
-        {formatWithComma(history.balanceAfter)}원
+        {history.balanceAfter === 0 ? '0' : formatWithComma(history.balanceAfter)}원
       </td>
     </tr>
   );

--- a/frontend/src/3_features/keywordStats/ui/KeywordStatsCard.tsx
+++ b/frontend/src/3_features/keywordStats/ui/KeywordStatsCard.tsx
@@ -48,31 +48,37 @@ export function KeywordStatsCard() {
     <div className="text-gray-600 flex flex-col bg-white border border-gray-200 rounded-xl shadow">
       <KeywordStatsHeader sortBy={sortBy} onSortChange={handleSortChange} />
 
-      <div
-        ref={scrollRef}
-        onScroll={handleScroll}
-        className="p-4 flex flex-col gap-2 max-h-56.5 overflow-y-auto"
-      >
-        {keywords.map((keyword, index) => (
-          <KeywordStatsItem
-            key={keyword.id}
-            keyword={keyword}
-            rank={index + 1}
-          />
-        ))}
+      {keywords.length === 0 ? (
+        <div className="p-10 text-center text-gray-500">
+          키워드 성과 데이터가 없습니다.
+        </div>
+      ) : (
+        <div
+          ref={scrollRef}
+          onScroll={handleScroll}
+          className="p-4 flex flex-col gap-2 max-h-56.5 overflow-y-auto"
+        >
+          {keywords.map((keyword, index) => (
+            <KeywordStatsItem
+              key={keyword.id}
+              keyword={keyword}
+              rank={index + 1}
+            />
+          ))}
 
-        {isLoadingMore && (
-          <div className="py-2 text-center text-sm text-gray-500">
-            로딩 중...
-          </div>
-        )}
+          {isLoadingMore && (
+            <div className="py-2 text-center text-sm text-gray-500">
+              로딩 중...
+            </div>
+          )}
 
-        {!hasMore && keywords.length > 0 && (
-          <div className="py-2 text-center text-xs text-gray-400">
-            모든 키워드를 불러왔습니다
-          </div>
-        )}
-      </div>
+          {!hasMore && keywords.length > 0 && (
+            <div className="py-2 text-center text-xs text-gray-400">
+              모든 키워드를 불러왔습니다
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/3_features/realtimeBids/ui/RealtimeBidsTable.tsx
+++ b/frontend/src/3_features/realtimeBids/ui/RealtimeBidsTable.tsx
@@ -67,14 +67,20 @@ export function RealtimeBidsTable() {
         </Link>
       </div>
 
-      <table>
-        <RealtimeBidsTableHeader />
-        <tbody>
-          {bids.map((bid) => (
-            <RealtimeBidsTableRow key={bid.id} bid={bid} />
-          ))}
-        </tbody>
-      </table>
+      {bids.length === 0 ? (
+        <div className="p-10 text-center text-gray-500">
+          입찰 기록이 없습니다.
+        </div>
+      ) : (
+        <table>
+          <RealtimeBidsTableHeader />
+          <tbody>
+            {bids.map((bid) => (
+              <RealtimeBidsTableRow key={bid.id} bid={bid} />
+            ))}
+          </tbody>
+        </table>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
<!-- PR 제목 예시 : [Feat] 로그인 기능 구현 -->
<!-- PR 제목은 위 형식을 참고하여 작성해주세요. -->
<!-- 필요 없는 내용은 지우고 작성해주세요 -->

## 🔗 관련 이슈

- close: #

---

## ✅ 작업 내용


- 대시보드 페이지에서 각 카드마다 아무 데이터가 없을 경우 텍스트 div 표기 (입찰 히스토리나 캠페인 관리 페이지와 같은 형태로)
- 예산관리 페이지에서 0원일 경우 ' ' 으로 뜨는 format 변경
- 10만원 광고주 신규 크레딧 제공 삭제 

## 📸 스크린샷 / 데모 (옵션)

<img width="1450" height="877" alt="image" src="https://github.com/user-attachments/assets/ea419a2f-caa1-4367-b277-d95ca638d303" />

<img width="1453" height="876" alt="image" src="https://github.com/user-attachments/assets/d1f16b31-4704-4255-8090-0c2999ca3c32" />

---

## 💬 To Reviewers

<!-- 리뷰어에게 전달하고 싶은 내용이나 특별히 확인이 필요한 부분을 작성해주세요. -->
