### PR TITLE
[Refactor] RedisTTLWorker를 워커프로세스로 이동

### DIFF
--- a/backend/src/cache/cache.module.ts
+++ b/backend/src/cache/cache.module.ts
@@ -4,10 +4,10 @@ import { RedisModule } from 'src/redis/redis.module';
 import { CacheRepository } from './repository/cache.repository.interface';
 import { RedisCacheRepository } from './repository/redis-cache.repository';
 // import { RedisTTLWorker } from '../worker/redis-ttl.worker';
-import { CampaignModule } from 'src/campaign/campaign.module';
+// import { CampaignModule } from 'src/campaign/campaign.module';
 
 @Module({
-  imports: [LogModule, RedisModule, CampaignModule],
+  imports: [LogModule, RedisModule],
   providers: [
     { provide: CacheRepository, useClass: RedisCacheRepository },
     // RedisTTLWorker,

--- a/backend/src/cache/cache.module.ts
+++ b/backend/src/cache/cache.module.ts
@@ -3,7 +3,7 @@ import { LogModule } from 'src/log/log.module';
 import { RedisModule } from 'src/redis/redis.module';
 import { CacheRepository } from './repository/cache.repository.interface';
 import { RedisCacheRepository } from './repository/redis-cache.repository';
-import { RedisTTLWorker } from './redis-ttl.worker';
+import { RedisTTLWorker } from '../worker/redis-ttl.worker';
 import { CampaignModule } from 'src/campaign/campaign.module';
 
 @Module({

--- a/backend/src/cache/cache.module.ts
+++ b/backend/src/cache/cache.module.ts
@@ -3,14 +3,14 @@ import { LogModule } from 'src/log/log.module';
 import { RedisModule } from 'src/redis/redis.module';
 import { CacheRepository } from './repository/cache.repository.interface';
 import { RedisCacheRepository } from './repository/redis-cache.repository';
-import { RedisTTLWorker } from '../worker/redis-ttl.worker';
+// import { RedisTTLWorker } from '../worker/redis-ttl.worker';
 import { CampaignModule } from 'src/campaign/campaign.module';
 
 @Module({
   imports: [LogModule, RedisModule, CampaignModule],
   providers: [
     { provide: CacheRepository, useClass: RedisCacheRepository },
-    RedisTTLWorker,
+    // RedisTTLWorker,
   ],
   exports: [CacheRepository],
 })

--- a/backend/src/worker/redis-ttl.worker.ts
+++ b/backend/src/worker/redis-ttl.worker.ts
@@ -8,7 +8,7 @@ import { Inject } from '@nestjs/common';
 import Redis from 'ioredis';
 import { IOREDIS_CLIENT } from 'src/redis/redis.constant';
 import type { AppIORedisClient } from 'src/redis/redis.type';
-import { CacheRepository } from './repository/cache.repository.interface';
+import { CacheRepository } from '../cache/repository/cache.repository.interface';
 import { CampaignCacheRepository } from 'src/campaign/repository/campaign.cache.repository.interface';
 
 // TTL 만료 이벤트를 감지하여 롤백을 수행하는 Worker

--- a/backend/src/worker/worker.module.ts
+++ b/backend/src/worker/worker.module.ts
@@ -10,6 +10,7 @@ import { MLEngine } from 'src/rtb/ml/mlEngine.interface';
 import { XenovaMLEngine } from 'src/rtb/ml/xenova-mlEngine';
 import { CacheRepository } from 'src/cache/repository/cache.repository.interface';
 import { RedisCacheRepository } from 'src/cache/repository/redis-cache.repository';
+import { RedisTTLWorker } from './redis-ttl.worker';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { RedisCacheRepository } from 'src/cache/repository/redis-cache.repositor
   ],
   providers: [
     EmbeddingWorker,
+    RedisTTLWorker,
     { provide: MLEngine, useClass: XenovaMLEngine },
     {
       provide: CampaignCacheRepository,

--- a/backend/src/worker/worker.module.ts
+++ b/backend/src/worker/worker.module.ts
@@ -8,6 +8,8 @@ import { EmbeddingWorker } from 'src/worker/embedding.worker';
 import { RedisModule } from 'src/redis/redis.module';
 import { MLEngine } from 'src/rtb/ml/mlEngine.interface';
 import { XenovaMLEngine } from 'src/rtb/ml/xenova-mlEngine';
+import { CacheRepository } from 'src/cache/repository/cache.repository.interface';
+import { RedisCacheRepository } from 'src/cache/repository/redis-cache.repository';
 
 @Module({
   imports: [
@@ -22,6 +24,10 @@ import { XenovaMLEngine } from 'src/rtb/ml/xenova-mlEngine';
     {
       provide: CampaignCacheRepository,
       useClass: RedisCampaignCacheRepository,
+    },
+    {
+      provide: CacheRepository,
+      useClass: RedisCacheRepository,
     },
   ],
 })


### PR DESCRIPTION
<!-- PR 제목 예시 : [Feat] 로그인 기능 구현 -->
<!-- PR 제목은 위 형식을 참고하여 작성해주세요. -->
<!-- 필요 없는 내용은 지우고 작성해주세요 -->

## 🔗 관련 이슈

- close: #

---

## ✅ 작업 내용

### 📌 주요 검토 파일

- `backend/src/worker/redis-ttl.worker.ts` TTL 만료 이벤트 기반 롤백 워커를 worker 프로세스로 이동
- `backend/src/worker/worker.module.ts` Worker 컨테이너에 `RedisTTLWorker` + 의존성 Provider(`CacheRepository`, `CampaignCacheRepository`) 등록
- `backend/src/cache/cache.module.ts` CacheModule에서 TTL worker 및 `CampaignModule` 의존 제거(캐시 레포지토리만 제공)

### ✅ 수정된 파일 요약

- `backend/src/cache/cache.module.ts`: TTL worker provider 제거 + `CampaignModule` import 제거로 순환 의존/결합 완화
- `backend/src/cache/redis-ttl.worker.ts` → `backend/src/worker/redis-ttl.worker.ts`: TTL 만료 롤백 워커 이동
- `backend/src/worker/worker.module.ts`: `RedisTTLWorker` 등록 및 DI 바인딩(`CacheRepository`, `CampaignCacheRepository`) 추가

## Redis TTL 만료 롤백 워커를 worker 프로세스로 이동

### 1) CacheModule 책임 축소
기존에는 `CacheModule`이 TTL 만료 이벤트를 직접 구독하면서 `CampaignCacheRepository`까지 필요해 `CacheModule -> CampaignModule` 결합이 생겼습니다. TTL worker를 worker 컨테이너로 옮겨 `CacheModule`은 `CacheRepository`만 제공하도록 역할을 단순화했습니다.

### 2) WorkerModule에서 필요한 최소 DI 구성
`RedisTTLWorker`는 만료된 `rollback:view:{viewId}` 이벤트를 처리할 때,
- `CacheRepository`로 `backup:rollback:view:{viewId}` 백업 조회/삭제
- `CampaignCacheRepository`로 `dailySpent/totalSpent` 롤백
이 필요합니다. 따라서 Worker 컨테이너에서 두 토큰을 각각 `RedisCacheRepository`, `RedisCampaignCacheRepository`로 바인딩해 DI를 해결했습니다.

### 3) 동작 확인 포인트
- 워커 로그에 `TTL Worker 시작 - Keyspace Notification 구독 중`이 출력되는지 확인
- `rollback:view:{viewId}` TTL 만료 시 `[TTL Worker] 롤백 완료` 로그가 찍히는지 확인

- ***

## 📸 스크린샷 / 데모 (옵션)

<!-- UI 변경사항이나 새로운 기능의 동작을 시각적으로 보여주세요. -->
<img width="1012" height="408" alt="image" src="https://github.com/user-attachments/assets/c2ea9566-89ff-47de-83b4-026da9b5c1cd" />

---

## 🧪 테스트 방법 (옵션)

<!-- 리뷰어가 기능을 테스트할 수 있도록 구체적인 테스트 방법을 설명해주세요. -->

1.
2.

---

## 💬 To Reviewers

- 로컬에서 TTL 만료시 정상적으로 롤백되는것 확인했습니다! 
<!-- 리뷰어에게 전달하고 싶은 내용이나 특별히 확인이 필요한 부분을 작성해주세요. -->
