### PR TITLE
[Hotfix] 상세페이지 prograss bar 수정

### DIFF
--- a/frontend/src/3_features/campaignDetail/ui/BudgetStatusCard/BudgetProgressSection.tsx
+++ b/frontend/src/3_features/campaignDetail/ui/BudgetStatusCard/BudgetProgressSection.tsx
@@ -43,6 +43,7 @@ export function BudgetProgressSection({
             colorScheme="blue"
             showLabel={false}
             size="md"
+            width="full"
           />
         </div>
       </div>
@@ -67,6 +68,7 @@ export function BudgetProgressSection({
             colorScheme="blue"
             showLabel={false}
             size="md"
+            width="full"
           />
         </div>
       </div>

--- a/frontend/src/4_shared/ui/ProgressBar/ProgressBar.tsx
+++ b/frontend/src/4_shared/ui/ProgressBar/ProgressBar.tsx
@@ -5,6 +5,7 @@ interface ProgressBarProps {
   colorScheme?: ColorScheme;
   showLabel?: boolean;
   size?: 'sm' | 'md';
+  width?: 'fixed' | 'full';
 }
 
 const COLOR_CLASSES = {
@@ -20,6 +21,11 @@ const SIZE_CLASSES = {
   md: 'h-3',
 } as const;
 
+const WIDTH_CLASSED = {
+  fixed: 'w-32',
+  full: 'w-full',
+} as const;
+
 function getAutoColor(percentage: number): keyof typeof COLOR_CLASSES {
   if (percentage >= 80) return 'red';
   if (percentage >= 50) return 'yellow';
@@ -31,14 +37,19 @@ export function ProgressBar({
   colorScheme = 'auto',
   showLabel = true,
   size = 'sm',
+  width = 'fixed',
 }: ProgressBarProps) {
-  const colorKey = colorScheme === 'auto' ? getAutoColor(percentage) : colorScheme;
+  const colorKey =
+    colorScheme === 'auto' ? getAutoColor(percentage) : colorScheme;
   const colors = COLOR_CLASSES[colorKey];
   const sizeClass = SIZE_CLASSES[size];
+  const widthSize = WIDTH_CLASSED[width];
 
   return (
     <div className="flex items-center gap-2 whitespace-nowrap">
-      <div className={`w-32 ${sizeClass} bg-gray-200 rounded-full overflow-hidden shrink-0`}>
+      <div
+        className={`${widthSize} ${sizeClass} bg-gray-200 rounded-full overflow-hidden shrink-0`}
+      >
         <div
           className={`h-full rounded-full ${colors.bar}`}
           style={{ width: `${Math.min(percentage, 100)}%` }}


### PR DESCRIPTION
## 🔗 관련 이슈

- close: #

---

## ✅ 작업 내용

- 상세페이지에서 prograss bar w-full로 조정을 위해
- 컴포넌트 props 수정

## 📸 스크린샷 / 데모 (옵션)

<!-- UI 변경사항이나 새로운 기능의 동작을 시각적으로 보여주세요. -->
<img width="591" height="211" alt="스크린샷 2026-02-05 오후 3 19 44" src="https://github.com/user-attachments/assets/9a468666-e97c-431a-9807-7e14208a091b" />

---

## 🧪 테스트 방법 (옵션)

<!-- 리뷰어가 기능을 테스트할 수 있도록 구체적인 테스트 방법을 설명해주세요. -->

1.
2.

---

## 💬 To Reviewers

<!-- 리뷰어에게 전달하고 싶은 내용이나 특별히 확인이 필요한 부분을 작성해주세요. -->
