### PR TITLE
[Hotfix] 예산 수정 error시 버튼 disabled 처리

### DIFF
--- a/frontend/src/3_features/campaignDetail/ui/BudgetStatusCard/BudgetEditMode.tsx
+++ b/frontend/src/3_features/campaignDetail/ui/BudgetStatusCard/BudgetEditMode.tsx
@@ -63,6 +63,17 @@ export function BudgetEditMode({
   };
 
   const handleSave = () => {
+    const addBudgetError = validateAddBudget();
+    const dailyBudgetError =
+      validateDailyBudget(dailyBudget, finalTotalBudget, maxCpc) || undefined;
+    const maxCpcError = validateMaxCpc(maxCpc, dailyBudget) || undefined;
+
+    setErrors({ addBudget: addBudgetError, dailyBudget: dailyBudgetError, maxCpc: maxCpcError });
+
+    if (addBudgetError || dailyBudgetError || maxCpcError) {
+      return;
+    }
+
     onSave({
       totalBudget: finalTotalBudget,
       dailyBudget,
@@ -91,7 +102,9 @@ export function BudgetEditMode({
           <CurrencyField
             value={addBudget}
             onChange={setAddBudget}
-            onBlur={() => setErrors((prev) => ({ ...prev, addBudget: validateAddBudget() }))}
+            onBlur={() =>
+              setErrors((prev) => ({ ...prev, addBudget: validateAddBudget() }))
+            }
             prefix="+"
             error={errors.addBudget}
             transparentMessage
@@ -133,7 +146,17 @@ export function BudgetEditMode({
             <CurrencyField
               value={dailyBudget}
               onChange={setDailyBudget}
-              onBlur={() => setErrors((prev) => ({ ...prev, dailyBudget: validateDailyBudget(dailyBudget, finalTotalBudget, maxCpc) || undefined }))}
+              onBlur={() =>
+                setErrors((prev) => ({
+                  ...prev,
+                  dailyBudget:
+                    validateDailyBudget(
+                      dailyBudget,
+                      finalTotalBudget,
+                      maxCpc
+                    ) || undefined,
+                }))
+              }
               error={errors.dailyBudget}
               transparentMessage
             />
@@ -151,7 +174,12 @@ export function BudgetEditMode({
             <CurrencyField
               value={maxCpc}
               onChange={setMaxCpc}
-              onBlur={() => setErrors((prev) => ({ ...prev, maxCpc: validateMaxCpc(maxCpc, dailyBudget) || undefined }))}
+              onBlur={() =>
+                setErrors((prev) => ({
+                  ...prev,
+                  maxCpc: validateMaxCpc(maxCpc, dailyBudget) || undefined,
+                }))
+              }
               error={errors.maxCpc}
               transparentMessage
             />
@@ -173,8 +201,8 @@ export function BudgetEditMode({
           <button
             type="button"
             onClick={handleSave}
-            disabled={isLoading}
-            className="flex-1 flex justify-center items-center py-2 bg-blue-500 rounded-lg text-xs font-bold text-white shadow-sm hover:bg-blue-600 transition-colors disabled:opacity-50"
+            disabled={isLoading || !!(errors.addBudget || errors.dailyBudget || errors.maxCpc)}
+            className="flex-1 flex justify-center items-center py-2 bg-blue-500 rounded-lg text-xs font-bold text-white shadow-sm hover:bg-blue-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             저장
           </button>


### PR DESCRIPTION
## 🔗 관련 이슈

- close: #

---

## ✅ 작업 내용

- 저장 클릭 시 3개 필드 validaiton 후 setErrors로 메시지 세팅 및 onSave 호출 차단
- 저장 버튼 disabled 처리
- disabled 상태에서 금지 아이콘 표시

## 📸 스크린샷 / 데모 (옵션)

<!-- UI 변경사항이나 새로운 기능의 동작을 시각적으로 보여주세요. -->
![화면 기록 2026-02-05 오후 4 12 11](https://github.com/user-attachments/assets/bece9252-bc7b-4b41-90fd-04ae6b75f996)


---

## 🧪 테스트 방법 (옵션)

<!-- 리뷰어가 기능을 테스트할 수 있도록 구체적인 테스트 방법을 설명해주세요. -->

1.
2.

---

## 💬 To Reviewers

<!-- 리뷰어에게 전달하고 싶은 내용이나 특별히 확인이 필요한 부분을 작성해주세요. -->
