### PR TITLE
[Refactor] dedup 적용 순서 변경

### DIFF
--- a/backend/src/campaign/repository/redis-campaign.cache.repository.ts
+++ b/backend/src/campaign/repository/redis-campaign.cache.repository.ts
@@ -16,7 +16,7 @@ export class RedisCampaignCacheRepository implements CampaignCacheRepository {
   private readonly logger = new Logger(RedisCampaignCacheRepository.name);
   private readonly KEY_PREFIX = 'campaign:';
   private readonly CAMPAIGN_CACHE_TTL = 60 * 60 * 24;
-  private readonly ALL_CAMPAIGNS_CACHE_TTL_MS = 1_000; // RTB decision hot path (짧은 TTL로 Redis SCAN/JSON.GET 비용 완화)
+  private readonly ALL_CAMPAIGNS_CACHE_TTL_MS = 10_000; // RTB decision hot path (짧은 TTL로 Redis SCAN/JSON.GET 비용 완화)
   private allCampaignsCache: {
     value: CachedCampaign[];
     expiresAtMs: number;


### PR DESCRIPTION
<!-- PR 제목 예시 : [Feat] 로그인 기능 구현 -->
<!-- PR 제목은 위 형식을 참고하여 작성해주세요. -->
<!-- 필요 없는 내용은 지우고 작성해주세요 -->

## 🔗 관련 이슈

- close: #

---

## ✅ 작업 내용

### 📌 주요 검토 파일

- `backend/src/sdk/sdk.service.ts`: `recordClick()`의 click dedup 적용 순서를 조정해 “무효 클릭이 dedup 키를 생성해 이후 클릭까지 막는 문제”를 방지

### ✅ 수정된 파일 요약

- `backend/src/sdk/sdk.service.ts`
  - `existsByViewId(viewId)` 및 `rollbackInfo/backup` 유효성 검증을 `setClickIdempotencyKey(viewId)`보다 먼저 수행하도록 순서 변경
  - Rollback TTL 관련 주석/로그 문구를 “기본 TTL + Backup” 표현으로 정리(실제 TTL은 `RedisCacheRepository` 기본값을 따름)

### 1) 문제 상황: Dismiss/TTL 이후 “무효 클릭”이 click dedup을 오염

기존 로직은 클릭 요청이 들어오면 `dedup:click:view:{viewId}`를 먼저 세팅한 뒤, 그 다음에 `rollbackInfo/backup` 존재 여부로 유효 클릭인지 판단했습니다.

이때 탭 전환 등으로 Dismiss가 먼저 처리되어 `rollbackInfo/backup`이 삭제된 상태에서 클릭이 들어오면,

- ClickLog는 저장되지 않지만(`return null`)
- click dedup 키는 이미 만들어져서(`dedup:click:view:{viewId}` = 존재)
- 이후 새로고침/재시도 시에도 “중복 클릭”으로 분기될 수 있는 문제가 있었습니다.

### 2) 해결: 유효성 검증 후에만 click dedup 키를 세팅

`recordClick()`에서 아래 순서로 처리하도록 변경했습니다.

1. `existsByViewId(viewId)` 확인
2. `rollbackInfo/backup` 확인 (둘 다 없으면 “이미 롤백된 view 클릭”으로 간주하고 즉시 종료)
3. 위 검증을 통과한 경우에만 `setClickIdempotencyKey(viewId)` 수행

---

## 📸 스크린샷 / 데모 (옵션)

- N/A

---

## 🧪 테스트 방법 (옵션)

1. 탭 전환으로 Dismiss가 발생하는 상황을 만든 뒤, 클릭이 무효 처리되더라도 click dedup이 “오염”되지 않는지 확인
2. 이후 새로고침/재시도에서 정상 클릭이 ClickLog로 기록되는지 확인

---

## 💬 To Reviewers


