### PR TITLE
[Refactor] 전체 캠페인 목록 불러오기 성능 개선

### DIFF
--- a/backend/src/campaign/repository/redis-campaign.cache.repository.ts
+++ b/backend/src/campaign/repository/redis-campaign.cache.repository.ts
@@ -16,7 +16,7 @@ export class RedisCampaignCacheRepository implements CampaignCacheRepository {
   private readonly logger = new Logger(RedisCampaignCacheRepository.name);
   private readonly KEY_PREFIX = 'campaign:';
   private readonly CAMPAIGN_CACHE_TTL = 60 * 60 * 24;
-  private readonly ALL_CAMPAIGNS_CACHE_TTL_MS = 1_000; // RTB decision hot path (짧은 TTL로 Redis SCAN/JSON.GET 비용 완화)
+  private readonly ALL_CAMPAIGNS_CACHE_TTL_MS = 10_000; // RTB decision hot path (짧은 TTL로 Redis SCAN/JSON.GET 비용 완화)
   private allCampaignsCache: {
     value: CachedCampaign[];
     expiresAtMs: number;


### PR DESCRIPTION
<!-- PR 제목 예시 : [Feat] 로그인 기능 구현 -->
<!-- PR 제목은 위 형식을 참고하여 작성해주세요. -->
<!-- 필요 없는 내용은 지우고 작성해주세요 -->

## 🔗 관련 이슈

- close: #

---

## ✅ 작업 내용

### 📌 주요 검토 파일

- `backend/src/campaign/repository/redis-campaign.cache.repository.ts` RTB decision hot path에서 캠페인 전체 조회를 짧은 TTL로 in-memory 캐시 + in-flight dedup + pipeline/batch 처리로 개선
- `backend/src/sdk/sdk.service.ts` (선행 변경) click dedup 적용 순서 변경 포함 (`docs/PR/32. hotfix-click-not-working.md` 내용) - PR base가 `develop`일 때 diff에 포함

### ✅ 수정된 파일 요약

- `backend/src/campaign/repository/redis-campaign.cache.repository.ts`
  - `getAllCampaigns()` 결과를 짧은 TTL(현재 10s)로 프로세스 메모리에 캐싱해 Redis `SCAN`/`JSON.GET` 호출 빈도 감소
  - 동시 요청 발생 시 동일한 Promise를 공유하도록 in-flight dedup 처리
  - `JSON.GET` 다건 호출을 pipeline + batch(200)로 변경해 round-trip/latency 감소
  - Redis 에러/JSON 파싱 실패를 분리 로깅하고 실패 항목만 skip
- `backend/src/sdk/sdk.service.ts`
  - `recordClick()`에서 유효성 검증(`existsByViewId`, `rollbackInfo/backup`)을 click dedup 키 세팅보다 먼저 수행하도록 순서 변경 (선행 변경 - base가 `develop`일 때 포함)

### 1) 배경: `getAllCampaigns()`가 RTB decision의 hot path

기존 구현은 `campaign:*` 키를 `SCAN`으로 수집한 뒤 key 개수만큼 `JSON.GET` + `JSON.parse`를 순차 호출했습니다.

- 캠페인 수가 늘거나 동시 요청이 많아질수록 Redis round-trip이 증가
- latency 증가로 `getAllCampaigns()` in-flight 요청이 쌓이면 heap spike로 이어질 수 있음

### 2) 개선: 짧은 TTL + in-flight + pipeline/batch

`getAllCampaigns()`에 아래 최적화를 적용했습니다.

1. **in-memory TTL 캐시**: 최근 조회 결과를 `ALL_CAMPAIGNS_CACHE_TTL_MS` 동안 메모리에 보관
2. **in-flight dedup**: 캐시 미스 상태에서 동시 호출이 들어오면 동일한 작업 Promise를 공유
3. **pipeline + batch**: `JSON.GET` 다건 호출을 pipeline으로 묶고, batch size(200)로 나눠 처리

### 3) 예외/안전성

- Redis 호출 중 에러가 발생해도 `allCampaignsInFlight`는 `finally`에서 정리되어 다음 요청에 영향이 없도록 처리
- 개별 캠페인 JSON 파싱 실패는 warn 로그 후 해당 항목만 skip

---

## 📸 스크린샷 / 데모 (옵션)

- N/A

---

## 🧪 테스트 방법 (옵션)



---

## 💬 To Reviewers

